### PR TITLE
add .coveragerc with relative_files=True so codecovcli can process reports from containers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+relative_files = True


### PR DESCRIPTION
consider this series of commands:
```
$ cd codecov-runner/worker
$ docker exec -it codecov-runner-worker-1 pytest --cov
$ codecovcli do-upload
```
`pytest --cov` is run inside the docker container and its `.coverage` database will include hardcoded filepaths from inside the container. `codecovcli` is run outside the container and won't have the same paths so it will silently fail to process the coverage reports.

this change tells `pytest --cov` [(well, `coverage.py`)](https://coverage.readthedocs.io/en/latest/config.html#run-relative-files) to use relative filepaths in the coverage database.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.