### PR TITLE
Make sure toc exists in content before calling get_toc

### DIFF
--- a/services/report/parser/types.py
+++ b/services/report/parser/types.py
@@ -53,9 +53,10 @@ class ParsedRawReport(object):
 
     def content(self) -> BytesIO:
         buffer = BytesIO()
-        for file in self.get_toc():
-            buffer.write(f"{file}\n".encode("utf-8"))
-        buffer.write("<<<<<< network\n\n".encode("utf-8"))
+        if self.has_toc():
+            for file in self.get_toc():
+                buffer.write(f"{file}\n".encode("utf-8"))
+            buffer.write("<<<<<< network\n\n".encode("utf-8"))
         for file in self.uploaded_files:
             buffer.write(f"# path={file.filename}\n".encode("utf-8"))
             buffer.write(file.contents)


### PR DESCRIPTION
Fix bug introduced by adding network section back to readable parsed raw reports by ensuring `toc` exists before calling `get_toc()`

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.