### PR TITLE
Different handling label analysis if result already calculated

### DIFF
--- a/tasks/tests/unit/test_label_analysis.py
+++ b/tasks/tests/unit/test_label_analysis.py
@@ -517,6 +517,7 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
         "present_report_labels": expected_present_report_labels,
         "success": True,
         "global_level_labels": [],
+        "errors": [],
     }
     assert larf.result == {
         "absent_labels": expected_absent_labels,
@@ -524,7 +525,6 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
         "present_report_labels": expected_present_report_labels,
         "global_level_labels": [],
     }
-
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This change is intended to work with the PATCHing of labels by the CLI after collecting them.
Currently doing that doesn't trigger another task in the worker. SO if the labels arraive after we finished calculating we are left with incomplete results on the database. That is fine as the CLI will calculate again.

I think this change might have been a bit premature, but the idea is to have a different way of handling the calculation if we already have results. Then we simply calculate the final result using the saved labels and add in the requested labels that we might not have had the first time around. This would be much much faster than calculating everything again.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.