### PR TITLE
fix: update shared to include the logrecord error fix

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-git+ssh://git@github.com/codecov/shared.git@bc9933c6d61555ab36f310103feb6edd381d928f#egg=shared
+git+ssh://git@github.com/codecov/shared.git@02eae9af6c670f27cbd7ba56a3464c213b6a83a0#egg=shared
 git+ssh://git@github.com/codecov/opentelem-python.git@v0.0.4a1#egg=codecovopentelem
 boto3
 celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -246,7 +246,7 @@ s3transfer==0.3.4
     # via boto3
 sentry-sdk==1.19.1
     # via -r requirements.in
-shared @ git+ssh://git@github.com/codecov/shared.git@bc9933c6d61555ab36f310103feb6edd381d928f
+shared @ git+ssh://git@github.com/codecov/shared.git@02eae9af6c670f27cbd7ba56a3464c213b6a83a0
     # via -r requirements.in
 six==1.15.0
     # via


### PR DESCRIPTION
the other day worker pushed to production / enterprise instances. one instance had caching of certain github requests enabled and the cache decorator errored due to the issue fixed in https://github.com/codecov/shared/pull/7.

this PR updates the shared ref to include the fix.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.