### PR TITLE
Move Commit.report to GCS

### DIFF
--- a/database/tests/factories/core.py
+++ b/database/tests/factories/core.py
@@ -112,7 +112,7 @@ class CommitFactory(Factory):
             "s": 1,
         }
     )
-    report_json = factory.LazyFunction(
+    _report_json = factory.LazyFunction(
         lambda: {
             "files": {
                 "awesome/__init__.py": [

--- a/database/tests/unit/test_model_utils.py
+++ b/database/tests/unit/test_model_utils.py
@@ -1,6 +1,7 @@
 import json
 
 from shared.storage.exceptions import FileNotInStorageError
+from shared.utils.ReportEncoder import ReportEncoder
 
 from database.models.core import Commit
 from database.tests.factories.core import CommitFactory
@@ -138,6 +139,7 @@ class TestArchiveField(object):
             field="archive_field",
             external_id=test_class.external_id,
             data=some_json,
+            encoder=ReportEncoder,
         )
         mock_archive_service.return_value.delete_file.assert_called_with(
             "path/to/old/data"

--- a/database/utils.py
+++ b/database/utils.py
@@ -4,8 +4,8 @@ from functools import lru_cache
 from typing import Any, Callable
 
 from shared.storage.exceptions import FileNotInStorageError
+from shared.utils.ReportEncoder import ReportEncoder
 
-from database.models.core import Repository
 from services.archive import ArchiveService
 
 log = logging.getLogger(__name__)
@@ -24,7 +24,7 @@ class ArchiveFieldInterfaceMeta(type):
 class ArchiveFieldInterface(metaclass=ArchiveFieldInterfaceMeta):
     """Any class that uses ArchiveField must implement this interface"""
 
-    def get_repository(self) -> Repository:
+    def get_repository(self):
         raise NotImplementedError()
 
     def get_commitid(self) -> str:
@@ -60,11 +60,13 @@ class ArchiveField:
         self,
         should_write_to_storage_fn: Callable[[object], bool],
         rehydrate_fn: Callable[[object, object], Any] = lambda self, x: x,
+        json_encoder=ReportEncoder,
         default_value=None,
     ):
         self.default_value = default_value
         self.rehydrate_fn = rehydrate_fn
         self.should_write_to_storage_fn = should_write_to_storage_fn
+        self.json_encoder = json_encoder
 
     def __set_name__(self, owner, name):
         # Validate that the owner class has the methods we need
@@ -80,19 +82,28 @@ class ArchiveField:
         repository = obj.get_repository()
         archive_service = ArchiveService(repository=repository)
         archive_field = getattr(obj, self.archive_field_name)
-        try:
-            file_str = archive_service.read_file(archive_field)
-            return self.rehydrate_fn(obj, json.loads(file_str))
-        except FileNotInStorageError:
-            log.error(
-                "Archive enabled field not in storage",
+        if archive_field:
+            try:
+                file_str = archive_service.read_file(archive_field)
+                return self.rehydrate_fn(obj, json.loads(file_str))
+            except FileNotInStorageError:
+                log.error(
+                    "Archive enabled field not in storage",
+                    extra=dict(
+                        storage_path=archive_field,
+                        object_id=obj.id,
+                        commit=obj.get_commitid(),
+                    ),
+                )
+        else:
+            log.info(
+                "Both db_field and archive_field are None",
                 extra=dict(
-                    storage_path=archive_field,
                     object_id=obj.id,
                     commit=obj.get_commitid(),
                 ),
             )
-            return self.default_value
+        return self.default_value
 
     def __get__(self, obj, objtype=None):
         db_field = getattr(obj, self.db_field_name)
@@ -113,6 +124,7 @@ class ArchiveField:
                 field=self.public_name,
                 external_id=obj.external_id,
                 data=value,
+                encoder=self.json_encoder,
             )
             if old_file_path is not None and path != old_file_path:
                 archive_service.delete_file(old_file_path)

--- a/helpers/config.py
+++ b/helpers/config.py
@@ -1,0 +1,25 @@
+from shared.config import get_config
+
+
+def should_write_data_to_storage_config_check(
+    master_switch_key: str, is_codecov_repo: bool, repoid: int
+) -> bool:
+    allowed_repo_ids = get_config(
+        "setup", "save_report_data_in_storage", "repo_ids", default=[]
+    )
+    is_in_allowed_repoids = repoid in allowed_repo_ids
+    master_write_switch = get_config(
+        "setup",
+        "save_report_data_in_storage",
+        master_switch_key,
+        default=False,
+    )
+    only_codecov = get_config(
+        "setup",
+        "save_report_data_in_storage",
+        "only_codecov",
+        default=True,
+    )
+    return master_write_switch and (
+        is_codecov_repo or is_in_allowed_repoids or not only_codecov
+    )

--- a/helpers/tests/unit/test_config.py
+++ b/helpers/tests/unit/test_config.py
@@ -1,0 +1,76 @@
+import pytest
+
+from helpers.config import should_write_data_to_storage_config_check
+
+
+@pytest.mark.parametrize(
+    "inner_config, func_args, result",
+    [
+        (
+            {
+                "repo_ids": [],
+                "only_codecov": True,
+                "report_details_files_array": True,
+                "commit_report": False,
+            },
+            ("report_details_files_array", False, 1),
+            False,
+        ),
+        (
+            {
+                "repo_ids": [],
+                "only_codecov": True,
+                "report_details_files_array": True,
+                "commit_report": False,
+            },
+            ("report_details_files_array", True, 1),
+            True,
+        ),
+        (
+            {
+                "repo_ids": [],
+                "only_codecov": True,
+                "report_details_files_array": True,
+                "commit_report": False,
+            },
+            ("commit_report", True, 1),
+            False,
+        ),
+        (
+            {
+                "repo_ids": [1],
+                "only_codecov": True,
+                "report_details_files_array": True,
+                "commit_report": False,
+            },
+            ("commit_report", False, 1),
+            False,
+        ),
+        (
+            {
+                "repo_ids": [1],
+                "only_codecov": True,
+                "report_details_files_array": True,
+                "commit_report": False,
+            },
+            ("report_details_files_array", False, 1),
+            True,
+        ),
+    ],
+)
+def test_should_write_data_to_storage_config_check(
+    inner_config, func_args, result, mocker
+):
+    config = {"setup": {"save_report_data_in_storage": inner_config}}
+
+    def fake_config(*path, default=None):
+        curr = config
+        for key in path:
+            if key in curr:
+                curr = curr.get(key)
+            else:
+                return default
+        return curr
+
+    mocker.patch("helpers.config.get_config", side_effect=fake_config)
+    assert should_write_data_to_storage_config_check(*func_args) == result

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -116,7 +116,10 @@ class ReportService(object):
         Returns:
             bool: Whether the commit already has initialized a report
         """
-        return commit.report_json is not None
+        return (
+            commit._report_json is not None
+            or commit._report_json_storage_path is not None
+        )
 
     async def initialize_and_save_report(
         self, commit: Commit, report_code: str = None
@@ -189,7 +192,6 @@ class ReportService(object):
             )
             db_session.add(report_details)
             db_session.flush()
-
         if not self.has_initialized_report(commit):
             report = await self.create_new_report_for_commit(commit)
             if not report.is_empty():
@@ -425,7 +427,7 @@ class ReportService(object):
         self, commit: Commit, report_class=None, *, report_code=None
     ) -> Optional[Report]:
         commitid = commit.commitid
-        if commit.report_json is None:
+        if commit._report_json is None and commit._report_json_storage_path is None:
             return None
         try:
             archive_service = self.get_archive_service(commit.repository)

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -231,7 +231,7 @@ def sample_commit_with_report_big(dbsession, mock_storage):
         ],
     }
     commit = CommitFactory.create(
-        report_json={"sessions": sessions_dict, "files": file_headers}
+        _report_json={"sessions": sessions_dict, "files": file_headers}
     )
     dbsession.add(commit)
     dbsession.flush()
@@ -396,7 +396,7 @@ def sample_commit_with_report_big_already_carriedforward(dbsession, mock_storage
         ],
     }
     commit = CommitFactory.create(
-        report_json={"sessions": sessions_dict, "files": file_headers}
+        _report_json={"sessions": sessions_dict, "files": file_headers}
     )
     dbsession.add(commit)
     dbsession.flush()
@@ -411,7 +411,7 @@ def sample_commit_with_report_big_already_carriedforward(dbsession, mock_storage
 class TestReportService(BaseTestCase):
     @pytest.mark.asyncio
     async def test_build_report_from_commit_no_report_saved(self, dbsession, mocker):
-        commit = CommitFactory(report_json=None)
+        commit = CommitFactory(_report_json=None)
         dbsession.add(commit)
         dbsession.commit()
         res = await ReportService({}).build_report_from_commit(commit)
@@ -421,7 +421,7 @@ class TestReportService(BaseTestCase):
 
     @pytest.mark.asyncio
     async def test_build_report_from_commit(self, dbsession, mock_storage):
-        commit = CommitFactory(report_json=None)
+        commit = CommitFactory(_report_json=None)
         dbsession.add(commit)
         report = ReportFactory(commit=commit)
         dbsession.add(report)
@@ -540,7 +540,7 @@ class TestReportService(BaseTestCase):
 
     @pytest.mark.asyncio
     async def test_build_report_from_commit_with_flags(self, dbsession, mock_storage):
-        commit = CommitFactory(report_json=None)
+        commit = CommitFactory(_report_json=None)
         dbsession.add(commit)
         report = ReportFactory(commit=commit)
         dbsession.add(report)
@@ -817,7 +817,7 @@ class TestReportService(BaseTestCase):
         commit = CommitFactory.create(
             repository=parent_commit.repository,
             parent_commit_id=parent_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -1879,7 +1879,7 @@ class TestReportService(BaseTestCase):
     async def test_create_new_report_for_commit_is_called_as_generate(
         self, dbsession, mocker
     ):
-        commit = CommitFactory.create(report_json=None)
+        commit = CommitFactory.create(_report_json=None)
         dbsession.add(commit)
         dbsession.flush()
         mocked_create_new_report_for_commit = mocker.patch.object(
@@ -1899,7 +1899,7 @@ class TestReportService(BaseTestCase):
         commit = CommitFactory.create(
             repository=parent_commit.repository,
             parent_commit_id=parent_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -2104,7 +2104,7 @@ class TestReportService(BaseTestCase):
         commit = CommitFactory.create(
             repository=parent_commit.repository,
             parent_commit_id=parent_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -2625,7 +2625,7 @@ class TestReportService(BaseTestCase):
         commit = CommitFactory.create(
             repository=parent_commit.repository,
             parent_commit_id=parent_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -2694,7 +2694,9 @@ class TestReportService(BaseTestCase):
     ):
         parent_commit = sample_commit_with_report_big
         commit = CommitFactory.create(
-            repository=parent_commit.repository, parent_commit_id=None, report_json=None
+            repository=parent_commit.repository,
+            parent_commit_id=None,
+            _report_json=None,
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -2760,13 +2762,13 @@ class TestReportService(BaseTestCase):
         parent_commit = CommitFactory.create(
             repository=grandparent_commit.repository,
             parent_commit_id=grandparent_commit.commitid,
-            report_json=None,
+            _report_json=None,
             state="pending",
         )
         commit = CommitFactory.create(
             repository=grandparent_commit.repository,
             parent_commit_id=parent_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(parent_commit)
         dbsession.add(commit)
@@ -2966,7 +2968,7 @@ class TestReportService(BaseTestCase):
         commit = CommitFactory.create(
             repository=parent_commit.repository,
             parent_commit_id=parent_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(parent_commit)
         dbsession.add(commit)
@@ -3073,14 +3075,14 @@ class TestReportService(BaseTestCase):
             current_commit = CommitFactory.create(
                 repository=grandparent_commit.repository,
                 parent_commit_id=current_commit.commitid,
-                report_json=None,
+                _report_json=None,
                 state="pending",
             )
             dbsession.add(current_commit)
         commit = CommitFactory.create(
             repository=grandparent_commit.repository,
             parent_commit_id=current_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -3106,14 +3108,14 @@ class TestReportService(BaseTestCase):
             current_commit = CommitFactory.create(
                 repository=current_commit.repository,
                 parent_commit_id=current_commit.commitid,
-                report_json=None,
+                _report_json=None,
                 state="pending",
             )
             dbsession.add(current_commit)
         commit = CommitFactory.create(
             repository=current_commit.repository,
             parent_commit_id=current_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -3132,7 +3134,7 @@ class TestReportService(BaseTestCase):
         commit = CommitFactory.create(
             repository=parent_commit.repository,
             parent_commit_id=parent_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(parent_commit)
         dbsession.add(commit)
@@ -3844,7 +3846,7 @@ class TestReportService(BaseTestCase):
     ):
         parent_commit = sample_commit_with_report_big
         commit = CommitFactory.create(
-            report_json=None,
+            _report_json=None,
             parent_commit_id=parent_commit.commitid,
             repository=parent_commit.repository,
         )
@@ -3923,7 +3925,7 @@ class TestReportService(BaseTestCase):
     ):
         parent_commit = sample_commit_with_report_big
         commit = CommitFactory.create(
-            report_json=None,
+            _report_json=None,
             parent_commit_id=parent_commit.commitid,
             repository=parent_commit.repository,
         )
@@ -4507,7 +4509,7 @@ class TestReportService(BaseTestCase):
         commit = CommitFactory.create(
             repository=parent_commit.repository,
             parent_commit_id=parent_commit.commitid,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(commit)
         dbsession.flush()

--- a/services/tests/test_repository_service.py
+++ b/services/tests/test_repository_service.py
@@ -593,7 +593,7 @@ class TestRepositoryServiceTestCase(object):
             author=None,
             pullid=1,
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=possible_parent_commit.repository,
         )
         dbsession.add(possible_parent_commit)
@@ -623,7 +623,7 @@ class TestRepositoryServiceTestCase(object):
         assert commit.message == "This message is brought to you by"
         assert commit.pullid == 1
         assert commit.totals is None
-        assert commit.report_json is None
+        assert commit.report_json == {}
         assert commit.branch == "newbranchyeah"
         assert commit.merged is False
         assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20)
@@ -646,7 +646,7 @@ class TestRepositoryServiceTestCase(object):
             pullid=None,
             totals=None,
             branch="papapa",
-            report_json=None,
+            _report_json=None,
             repository=repository,
         )
         dbsession.add(possible_parent_commit)
@@ -677,7 +677,7 @@ class TestRepositoryServiceTestCase(object):
         assert commit.message == "This message is brought to you by"
         assert commit.pullid is None
         assert commit.totals is None
-        assert commit.report_json is None
+        assert commit.report_json == {}
         assert commit.branch == "superbranch"
         assert commit.merged is True
         assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20)
@@ -700,7 +700,7 @@ class TestRepositoryServiceTestCase(object):
             pullid=None,
             branch="papapa",
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=repository,
         )
         dbsession.add(possible_parent_commit)
@@ -727,7 +727,7 @@ class TestRepositoryServiceTestCase(object):
         assert commit.message == "This message is brought to you by"
         assert commit.pullid is None
         assert commit.totals is None
-        assert commit.report_json is None
+        assert commit.report_json == {}
         assert commit.branch == "papapa"
         assert commit.merged is False
         assert commit.timestamp == datetime(2018, 7, 9, 23, 39, 20)
@@ -746,7 +746,7 @@ class TestRepositoryServiceTestCase(object):
             author=None,
             pullid=1,
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=possible_parent_commit.repository,
         )
         dbsession.add(possible_parent_commit)
@@ -775,7 +775,7 @@ class TestRepositoryServiceTestCase(object):
         assert commit.message == "This message is brought to you by"
         assert commit.pullid == 1
         assert commit.totals is None
-        assert commit.report_json is None
+        assert commit.report_json == {}
         assert commit.branch == "newbranchyeah"
         assert commit.parent_commit_id == possible_parent_commit.commitid
         assert commit.state == "complete"
@@ -797,7 +797,7 @@ class TestRepositoryServiceTestCase(object):
             author=None,
             pullid=1,
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=possible_parent_commit.repository,
         )
         dbsession.add(possible_parent_commit)
@@ -832,7 +832,7 @@ class TestRepositoryServiceTestCase(object):
         )
         assert commit.pullid == 1
         assert commit.totals is None
-        assert commit.report_json is None
+        assert commit.report_json == {}
         assert commit.branch == "thebasebranch"
         assert commit.parent_commit_id == possible_parent_commit.commitid
         assert commit.state == "complete"
@@ -891,7 +891,7 @@ class TestPullRequestFetcher(object):
     ):
         now = datetime.utcnow()
         commit = CommitFactory.create(
-            message="", pullid=1, totals=None, report_json=None
+            message="", pullid=1, totals=None, _report_json=None
         )
         base_commit = CommitFactory.create(repository=commit.repository)
         dbsession.add(commit)
@@ -954,7 +954,7 @@ class TestPullRequestFetcher(object):
             message="",
             pullid=pull.pullid,
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=repository,
         )
         base_commit = CommitFactory.create(repository=repository, branch="master")
@@ -1035,7 +1035,7 @@ class TestPullRequestFetcher(object):
             message="",
             pullid=pull.pullid,
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=repository,
         )
         base_commit = CommitFactory.create(repository=repository, branch="master")
@@ -1116,7 +1116,7 @@ class TestPullRequestFetcher(object):
             message="",
             pullid=pull.pullid,
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=repository,
         )
         second_comparedto_commit = CommitFactory.create(
@@ -1209,7 +1209,7 @@ class TestPullRequestFetcher(object):
             message="",
             pullid=pull.pullid,
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=repository,
         )
         dbsession.add(pull)
@@ -1275,7 +1275,7 @@ class TestPullRequestFetcher(object):
             message="",
             pullid=None,
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=repository,
         )
         compared_to_commit = CommitFactory.create(
@@ -1306,7 +1306,7 @@ class TestPullRequestFetcher(object):
             message="",
             pullid="123",
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=repository,
         )
         compared_to_commit = CommitFactory.create(
@@ -1357,7 +1357,7 @@ class TestPullRequestFetcher(object):
             message="",
             pullid=pull.pullid,
             totals=None,
-            report_json=None,
+            _report_json=None,
             repository=repository,
         )
         compared_to_commit = CommitFactory.create(

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -1263,7 +1263,7 @@ class TestNotifyTask(object):
             branch="test-branch-1",
             commitid="649eaaf2924e92dc7fd8d370ddb857033231e67a",
             repository=repository,
-            report_json=None,
+            _report_json=None,
         )
         dbsession.add(commit)
         dbsession.add(master_commit)

--- a/tasks/tests/integration/test_sync_pull.py
+++ b/tasks/tests/integration/test_sync_pull.py
@@ -69,7 +69,7 @@ class TestPullSyncTask(object):
             repository=repository,
             commitid="6dc3afd80a8deea5ea949d284d996d58811cd01d",
             branch="new_branch",
-            report_json=report_json,
+            _report_json=report_json,
         )
         archive_hash = ArchiveService.get_archive_hash(repository)
         with open(here.parent.parent / "samples" / "sample_chunks_1.txt") as f:


### PR DESCRIPTION
Moving Commit.report to GCS. The field name is actually 'report_json', but that's not super important.
Adjusting tests as well.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.