### PR TITLE
fix: include fix for missing language normalization in sync_repos

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-git+ssh://git@github.com/codecov/shared.git@v0.11.2#egg=shared
+git+ssh://git@github.com/codecov/shared.git@707a3d9b540d3b42d9fc33282b65705fdc2e4544#egg=shared
 git+ssh://git@github.com/codecov/opentelem-python.git@v0.0.4a1#egg=codecovopentelem
 boto3
 celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -77,8 +77,6 @@ deprecated==1.2.12
     # via opentelemetry-api
 ecdsa==0.16.1
     # via tlslite-ng
-exceptiongroup==1.1.2
-    # via pytest
 factory-boy==3.2.0
     # via -r requirements.in
 faker==8.8.2
@@ -248,7 +246,7 @@ s3transfer==0.3.4
     # via boto3
 sentry-sdk==1.19.1
     # via -r requirements.in
-shared @ git+ssh://git@github.com/codecov/shared.git@v0.11.2
+shared @ git+ssh://git@github.com/codecov/shared.git@707a3d9b540d3b42d9fc33282b65705fdc2e4544
     # via -r requirements.in
 six==1.15.0
     # via
@@ -285,8 +283,6 @@ timestring==1.6.4
     # via -r requirements.in
 tlslite-ng==0.8.0-alpha39
     # via shared
-tomli==2.0.1
-    # via pytest
 typing==3.7.4.3
     # via shared
 typing-extensions==4.6.3


### PR DESCRIPTION
https://github.com/codecov/shared/pull/15 fixes an issue causing a lot of `sync_repos` failures. the PR was merged on main, but the hash used here is a hash that was rebased atop the currently-deployed `shared` hash. so if we deploy worker with this, it will only include the fix from `shared` and not other changes.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.