### PR TITLE
add pretrial_user_count to expiration task

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -49,6 +49,7 @@ class Owner(CodecovBaseModel):
     trial_status = Column(types.Text, server_default=FetchedValue())
     plan = Column(types.Text, server_default=FetchedValue())
     plan_user_count = Column(types.SmallInteger, server_default=FetchedValue())
+    pretrial_users_count = Column(types.SmallInteger, server_default=FetchedValue())
     plan_auto_activate = Column(types.Boolean, server_default=FetchedValue())
     stripe_customer_id = Column(types.Text, server_default=FetchedValue())
     stripe_subscription_id = Column(types.Text, server_default=FetchedValue())

--- a/tasks/tests/unit/test_trial_expiration.py
+++ b/tasks/tests/unit/test_trial_expiration.py
@@ -8,7 +8,26 @@ from tasks.trial_expiration import TrialExpirationTask
 
 class TestTrialExpiration(object):
     @pytest.mark.asyncio
-    async def test_trial_expiration_task(self, dbsession, mocker):
+    async def test_trial_expiration_task_with_pretrial_users_count(
+        self, dbsession, mocker
+    ):
+        owner = OwnerFactory.create(pretrial_users_count=5)
+        dbsession.add(owner)
+        dbsession.flush()
+
+        task = TrialExpirationTask()
+        assert await task.run_async(dbsession, owner.ownerid) == {"successful": True}
+
+        assert owner.plan == BillingPlan.users_basic.value
+        assert owner.plan_activated_users == None
+        assert owner.plan_user_count == 5
+        assert owner.stripe_subscription_id == None
+        assert owner.trial_status == TrialStatus.EXPIRED.value
+
+    @pytest.mark.asyncio
+    async def test_trial_expiration_task_without_pretrial_users_count(
+        self, dbsession, mocker
+    ):
         owner = OwnerFactory.create()
         dbsession.add(owner)
         dbsession.flush()

--- a/tasks/trial_expiration.py
+++ b/tasks/trial_expiration.py
@@ -24,10 +24,9 @@ class TrialExpirationTask(BaseCodecovTask):
         )
         owner.plan = BillingPlan.users_basic.value
         owner.plan_activated_users = None
-        owner.plan_user_count = 1
+        owner.plan_user_count = owner.pretrial_users_count or 1
         owner.stripe_subscription_id = None
         owner.trial_status = TrialStatus.EXPIRED.value
-        db_session.add(owner)
         db_session.flush()
         return {"successful": True}
 


### PR DESCRIPTION
Added the `pretrial_users_count` field to the owner's model and the trial expiration task. The user count will be that value if it exists, otherwise 1