### PR TITLE
chore: debug files array missing meta

### DIFF
--- a/services/archive.py
+++ b/services/archive.py
@@ -209,6 +209,11 @@ class ArchiveService(object):
             external_id=external_id,
         )
         stringified_data = json.dumps(data, cls=encoder)
+        if table == "reports_reportdetails" and not ("meta" in stringified_data):
+            log.warning(
+                "Saving files_array data without meta",
+                extra=dict(commit=commit_id, data=stringified_data, path=path),
+            )
         self.write_file(path, stringified_data)
         return path
 


### PR DESCRIPTION
We've been having files_array data missing the 'meta' key.
This started happening after moving data to GCS, so naturally we assume something is wrong.
To help us identify the issue (because most the time you can see the 'meta' key in the data)
we're adding a temporary debug log when saving it.

Part of codecov.platform-team#119

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.