### PR TITLE
chore: Standarize label-analysis error return

### DIFF
--- a/tasks/label_analysis.py
+++ b/tasks/label_analysis.py
@@ -52,10 +52,10 @@ class LabelAnalysisRequestProcessingTask(BaseCodecovTask):
             )
             return {
                 "success": False,
-                "present_report_labels": None,
-                "present_diff_labels": None,
-                "absent_labels": None,
-                "global_level_labels": None,
+                "present_report_labels": [],
+                "present_diff_labels": [],
+                "absent_labels": [],
+                "global_level_labels": [],
                 "errors": self.errors,
             }
         log.info(
@@ -112,10 +112,10 @@ class LabelAnalysisRequestProcessingTask(BaseCodecovTask):
             )
             return {
                 "success": False,
-                "present_report_labels": None,
-                "present_diff_labels": None,
-                "absent_labels": None,
-                "global_level_labels": None,
+                "present_report_labels": [],
+                "present_diff_labels": [],
+                "absent_labels": [],
+                "global_level_labels": [],
                 "errors": self.errors,
             }
         log.warning(
@@ -129,10 +129,10 @@ class LabelAnalysisRequestProcessingTask(BaseCodecovTask):
         label_analysis_request.state_id = LabelAnalysisRequestState.FINISHED.db_id
         result = {
             "success": True,
-            "present_report_labels": None,
-            "present_diff_labels": None,
+            "present_report_labels": [],
+            "present_diff_labels": [],
             "absent_labels": label_analysis_request.requested_labels,
-            "global_level_labels": None,
+            "global_level_labels": [],
             "errors": self.errors,
         }
         label_analysis_request.result = result

--- a/tasks/tests/unit/test_label_analysis.py
+++ b/tasks/tests/unit/test_label_analysis.py
@@ -572,10 +572,10 @@ async def test_call_label_analysis_no_request_object(dbsession):
     res = await task.run_async(db_session=dbsession, request_id=-1)
     assert res == {
         "success": False,
-        "present_report_labels": None,
-        "present_diff_labels": None,
-        "absent_labels": None,
-        "global_level_labels": None,
+        "present_report_labels": [],
+        "present_diff_labels": [],
+        "absent_labels": [],
+        "global_level_labels": [],
         "errors": [
             {
                 "error_code": "not found",
@@ -707,11 +707,11 @@ async def test_run_async_with_error(
     task = LabelAnalysisRequestProcessingTask()
     res = await task.run_async(dbsession, larf.id)
     expected_result = {
-        "absent_labels": None,
-        "present_diff_labels": None,
-        "present_report_labels": None,
+        "absent_labels": [],
+        "present_diff_labels": [],
+        "present_report_labels": [],
         "success": False,
-        "global_level_labels": None,
+        "global_level_labels": [],
         "errors": [
             {
                 "error_code": "failed",
@@ -752,9 +752,9 @@ async def test_calculate_result_no_report(
     assert res == {
         "success": True,
         "absent_labels": larf.requested_labels,
-        "present_diff_labels": None,
-        "present_report_labels": None,
-        "global_level_labels": None,
+        "present_diff_labels": [],
+        "present_report_labels": [],
+        "global_level_labels": [],
         "errors": [
             {
                 "error_code": "missing data",


### PR DESCRIPTION
Label analysis was returning `None` instead of empty list when some processing error happens.
The CLI always expects lists, so that is confusing for it and can lead to errors.
Instead of adding type checks in the CLI I think it's better to standarize the return values of
label analysis to always be lists. These changes do that.

Part of codecov/platform-team#104

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.