### PR TITLE
turning off updated comments when pushing a new commit to PRs when ma…

### DIFF
--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -191,14 +191,6 @@ class NotifyTask(BaseCodecovTask):
         if self.should_send_notifications(
             current_yaml, commit, ci_results, head_report
         ):
-            log.info(
-                "We are going to be sending notifications",
-                extra=dict(
-                    commit=commit.commitid,
-                    repoid=commit.repoid,
-                    current_yaml=current_yaml.to_dict(),
-                ),
-            )
             enriched_pull = await fetch_and_update_pull_request_information_from_commit(
                 repository_service, commit, current_yaml
             )
@@ -208,6 +200,27 @@ class NotifyTask(BaseCodecovTask):
             else:
                 pull = None
                 base_commit = self.fetch_parent(commit)
+
+            if (
+                enriched_pull
+                and not self.send_notifications_if_commit_differs_from_pulls_head(
+                    commit, enriched_pull, current_yaml
+                )
+            ):
+                log.info(
+                    "Not sending notifications for commit when it differs from pull's most recent head",
+                    extra=dict(
+                        commit=commit.commitid,
+                        repoid=commit.repoid,
+                        current_yaml=current_yaml.to_dict(),
+                        pull_head=enriched_pull.provider_pull["head"]["commitid"],
+                    ),
+                )
+                return {
+                    "notified": False,
+                    "notifications": None,
+                    "reason": "User doesnt want notifications warning them that current head differs from pull request most recent head.",
+                }
 
             if base_commit is not None:
                 base_report = report_service.get_existing_report_for_commit(
@@ -224,7 +237,14 @@ class NotifyTask(BaseCodecovTask):
                     "notifications": None,
                     "reason": "no_head_report",
                 }
-
+            log.info(
+                "We are going to be sending notifications",
+                extra=dict(
+                    commit=commit.commitid,
+                    repoid=commit.repoid,
+                    current_yaml=current_yaml.to_dict(),
+                ),
+            )
             notifications = await self.submit_third_party_notifications(
                 current_yaml,
                 base_commit,
@@ -303,6 +323,26 @@ class NotifyTask(BaseCodecovTask):
             commit.repository, current_yaml, decoration_type
         )
         return await notifications_service.notify(comparison)
+
+    def send_notifications_if_commit_differs_from_pulls_head(
+        self, commit, enriched_pull, current_yaml
+    ):
+        if (
+            enriched_pull.provider_pull is not None
+            and commit.commitid != enriched_pull.provider_pull["head"]["commitid"]
+        ):
+            wait_for_ci = read_yaml_field(
+                current_yaml, ("codecov", "notify", "wait_for_ci")
+            )
+            manual_trigger = read_yaml_field(
+                current_yaml, ("codecov", "notify", "manual_trigger")
+            )
+            after_n_builds = read_yaml_field(
+                current_yaml, ("codecov", "notify", "after_n_builds")
+            )
+            if wait_for_ci or manual_trigger or after_n_builds:
+                return False
+        return True
 
     def fetch_pull_request_base(self, pull: Pull) -> Commit:
         return pull.get_comparedto_commit()


### PR DESCRIPTION
turning off updated comments when pushing a new commit to PRs when `manual_trigger`, `wait_for_ci` or `after_n_builds` are configured in the yaml

Users are complaining about getting partial updated comments when a new commit is pushed to their PR, when the latest commit's CI hasn't finished yet, even when setting wait_for_ci in their codecov.yml which contradicts the idea of `wait_for_ci`

This PR doesn't send these kind of notifications when we know that the commit that triggered the notifications is different from the provider's pull head, thus not sending incorrect notifications 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.