### PR TITLE
chore: remove requirement of beta groups in ats

### DIFF
--- a/services/report/languages/tests/unit/test_pycoverage.py
+++ b/services/report/languages/tests/unit/test_pycoverage.py
@@ -179,7 +179,14 @@ class TestPyCoverageProcessor(BaseTestCase):
         content = SAMPLE
         p = PyCoverageProcessor()
         report_builder = ReportBuilder(
-            current_yaml={"beta_groups": ["labels"]},
+            current_yaml={
+                "flag_management": {
+                    "default_rules": {
+                        "carryforward": "true",
+                        "carryforward_mode": "labels",
+                    }
+                }
+            },
             sessionid=0,
             ignored_lines={},
             path_fixer=str,
@@ -445,7 +452,14 @@ class TestPyCoverageProcessor(BaseTestCase):
         content = COMPRESSED_SAMPLE
         p = PyCoverageProcessor()
         report_builder = ReportBuilder(
-            current_yaml={"beta_groups": ["labels"]},
+            current_yaml={
+                "flag_management": {
+                    "default_rules": {
+                        "carryforward": "true",
+                        "carryforward_mode": "labels",
+                    }
+                }
+            },
             sessionid=0,
             ignored_lines={},
             path_fixer=str,


### PR DESCRIPTION
Remove the requirement to configure `beta_groups: "labels"`
in the `codecov.yml` when using ATS.

Moving to open beta we think it's an extra step in config
that will confuse customers that forget to do it. And it's
very easy to miss. So we will remove it.

I change it instead to return True if the user has any flag
configured to use the labels carryforward. This is because
the labels thing changes the report (making it bigger), so
no reason to add that to customers that don't use labels.

codecov/platform-team#104

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.