### PR TITLE
Change names of path_fixes to report_fixes

### DIFF
--- a/services/report/fixes.py
+++ b/services/report/fixes.py
@@ -16,7 +16,6 @@ def get_fixes_from_raw(content, fix: Callable) -> Dict[str, Dict[str, Any]]:
                     files.setdefault(fix(filename), {})["eof"] = int(line)
 
                 else:
-                    # filename:5:<source>
                     # filename:5
                     # filename:5,10,20
                     filename, line = line.split(":", 1)

--- a/services/report/parser/legacy.py
+++ b/services/report/parser/legacy.py
@@ -9,7 +9,6 @@ from services.report.parser.types import LegacyParsedRawReport, ParsedUploadedRe
 
 
 class LegacyReportParser(object):
-
     network_separator = b"<<<<<< network"
     env_separator = b"<<<<<< ENV"
     eof_separator = b"<<<<<< EOF"
@@ -72,7 +71,7 @@ class LegacyReportParser(object):
             - toc: the 'network', list of files present on this report
             - env: the envvars the user set on the upload
             - uploaded_files: the actual report files
-            - path_fixes: the patfixes some languages need
+            - report_fixes: the report fixes some languages need
 
         and splits them, also taking care of 'strip()' them, removing whitespaces,
             as the original logic also does.
@@ -132,7 +131,7 @@ class LegacyReportParser(object):
         uploaded_files = []
         toc_section = None
         env_section = None
-        path_fixes_section = None
+        report_fixes_section = None
         for sect in sections:
             if sect["footer"] == self.network_separator:
                 toc_section = sect["contents"]
@@ -140,7 +139,7 @@ class LegacyReportParser(object):
                 env_section = sect["contents"]
             else:
                 if sect["filename"] == "fixes":
-                    path_fixes_section = sect["contents"]
+                    report_fixes_section = sect["contents"]
                 else:
                     uploaded_files.append(
                         ParsedUploadedReportFile(
@@ -152,5 +151,5 @@ class LegacyReportParser(object):
             toc=toc_section,
             env=env_section,
             uploaded_files=uploaded_files,
-            path_fixes=path_fixes_section,
+            report_fixes=report_fixes_section,
         )

--- a/services/report/parser/tests/unit/test_version_one_parser.py
+++ b/services/report/parser/tests/unit/test_version_one_parser.py
@@ -8,7 +8,7 @@ from services.report.parser.version_one import (
 )
 
 input_data = b"""{
-    "path_fixes": {
+    "report_fixes": {
         "format": "legacy",
         "value": {
             "SwiftExample/AppDelegate.swift": {
@@ -49,7 +49,7 @@ def test_version_one_parser():
     subject = VersionOneReportParser()
     res = subject.parse_raw_report_from_bytes(input_data)
     assert res.get_env() is None
-    assert res.get_path_fixes(None) == {
+    assert res.get_report_fixes(None) == {
         "SwiftExample/AppDelegate.swift": {
             "eof": 15,
             "lines": [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 13],

--- a/services/report/parser/version_one.py
+++ b/services/report/parser/version_one.py
@@ -24,10 +24,15 @@ class VersionOneReportParser(object):
             uploaded_files=[
                 self._parse_single_coverage_file(x) for x in data["coverage_files"]
             ],
-            path_fixes=self._parse_path_fixes(data["path_fixes"]),
+            report_fixes=self._parse_report_fixes(
+                # want backwards compatibility with older versions of the CLI that still name this section path_fixes
+                data["report_fixes"]
+                if "report_fixes" in data
+                else data["path_fixes"]
+            ),
         )
 
-    def _parse_path_fixes(self, value):
+    def _parse_report_fixes(self, value):
         return value["value"]
 
     def _parse_single_coverage_file(self, coverage_file):

--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -73,8 +73,8 @@ def process_raw_upload(
     # ------------------
     # Extract bash fixes
     # ------------------
-    if reports.has_path_fixes():
-        ignored_file_lines = reports.get_path_fixes(path_fixer)
+    if reports.has_report_fixes():
+        ignored_file_lines = reports.get_report_fixes(path_fixer)
     else:
         ignored_file_lines = None
 

--- a/services/report/tests/unit/test_parser.py
+++ b/services/report/tests/unit/test_parser.py
@@ -321,21 +321,21 @@ class TestParser(object):
         res = LegacyReportParser().parse_raw_report_from_bytes(simple_content)
         assert res.has_toc()
         assert not res.has_env()
-        assert not res.has_path_fixes()
+        assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 1
 
     def test_parser_no_toc(self):
         res = LegacyReportParser().parse_raw_report_from_bytes(simple_no_toc)
         assert not res.has_toc()
         assert not res.has_env()
-        assert not res.has_path_fixes()
+        assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 1
 
     def test_parser_more_complete(self):
         res = LegacyReportParser().parse_raw_report_from_bytes(more_complex)
         assert res.has_toc()
         assert res.has_env()
-        assert not res.has_path_fixes()
+        assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
         assert res.uploaded_files[0].contents.startswith(b'<?xml version="1.0" ?>')
@@ -350,7 +350,7 @@ class TestParser(object):
         )
         assert res.has_toc()
         assert res.has_env()
-        assert not res.has_path_fixes()
+        assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
         assert (
@@ -375,7 +375,7 @@ class TestParser(object):
         res = LegacyReportParser().parse_raw_report_from_bytes(line_end_no_line_break)
         assert res.has_toc()
         assert res.has_env()
-        assert not res.has_path_fixes()
+        assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
         assert (
@@ -415,7 +415,7 @@ class TestParser(object):
             ]
         )
         assert res.has_env()
-        assert not res.has_path_fixes()
+        assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
         assert (
@@ -453,7 +453,7 @@ class TestParser(object):
             ]
         )
         assert res.has_env()
-        assert not res.has_path_fixes()
+        assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
         assert (
@@ -482,7 +482,7 @@ class TestParser(object):
             ]
         )
         assert not res.has_env()
-        assert not res.has_path_fixes()
+        assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 1
         assert res.uploaded_files[0].filename == "coverage.txt"
         assert (
@@ -510,8 +510,8 @@ github.com/mypath/bugsbunny.go:20.36,22.17 2 1"""
         assert res.toc.getvalue() == would_be_simple_content_res.toc.getvalue()
         assert not res.has_env()
         assert not would_be_simple_content_res.has_env()
-        assert not res.has_path_fixes()
-        assert not would_be_simple_content_res.has_path_fixes()
+        assert not res.has_report_fixes()
+        assert not would_be_simple_content_res.has_report_fixes()
         assert len(res.uploaded_files) == len(
             would_be_simple_content_res.uploaded_files
         )
@@ -538,8 +538,8 @@ github.com/mypath/bugsbunny.go:20.36,22.17 2 1"""
         assert res.toc.getvalue() == would_be_simple_content_res.toc.getvalue()
         assert not res.has_env()
         assert not would_be_simple_content_res.has_env()
-        assert not res.has_path_fixes()
-        assert not would_be_simple_content_res.has_path_fixes()
+        assert not res.has_report_fixes()
+        assert not would_be_simple_content_res.has_report_fixes()
         assert len(res.uploaded_files) == len(
             would_be_simple_content_res.uploaded_files
         )

--- a/services/report/tests/unit/test_process.py
+++ b/services/report/tests/unit/test_process.py
@@ -455,7 +455,7 @@ class TestProcessReport(BaseTestCase):
 
         assert res.get("file") is not None
 
-    def test_path_fixes_same_final_result(self):
+    def test_report_fixes_same_final_result(self):
         commit_yaml = {"fixes": ["arroba::prefix", "bingo::prefix"]}
         result = process.process_raw_upload(
             commit_yaml=UserYaml(commit_yaml),
@@ -915,7 +915,7 @@ class TestProcessReport(BaseTestCase):
         uploaded_reports = LegacyParsedRawReport(
             toc=None,
             env=None,
-            path_fixes=None,
+            report_fixes=None,
             uploaded_files=[
                 ParsedUploadedReportFile(
                     filename="/Users/path/to/app.coverage.txt",
@@ -1074,7 +1074,7 @@ class TestProcessRawUploadCarryforwardFlags(BaseTestCase):
         uploaded_reports = LegacyParsedRawReport(
             toc=None,
             env=None,
-            path_fixes=None,
+            report_fixes=None,
             uploaded_files=[
                 ParsedUploadedReportFile(
                     filename="/Users/path/to/app.coverage.json",


### PR DESCRIPTION
This PR changes the name of the path_fixes
section in the ParsedRawReport classes to report_fixes.

For more information on report fixes:
https://docs.codecov.com/docs/fixing-reports

For more information on path fixes:
https://docs.codecov.com/docs/fixing-paths

Fixes: https://github.com/codecov/codecov-cli/issues/207