### PR TITLE
perf: update shared, use async generator for list_repos

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-git+ssh://git@github.com/codecov/shared.git@6a8a33248804a9c101d34f417efda7c11e4bbe63#egg=shared
+git+ssh://git@github.com/codecov/shared.git@ff739d64ace3a7d6be56cca1fe1f4c60669a641b#egg=shared
 git+ssh://git@github.com/codecov/opentelem-python.git@v0.0.4a1#egg=codecovopentelem
 boto3
 celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -251,7 +251,7 @@ s3transfer==0.3.4
     # via boto3
 sentry-sdk==1.19.1
     # via -r requirements.in
-shared @ git+ssh://git@github.com/codecov/shared.git@6a8a33248804a9c101d34f417efda7c11e4bbe63
+shared @ git+ssh://git@github.com/codecov/shared.git@ff739d64ace3a7d6be56cca1fe1f4c60669a641b
     # via -r requirements.in
 six==1.15.0
     # via

--- a/tasks/tests/unit/test_sync_repos_task.py
+++ b/tasks/tests/unit/test_sync_repos_task.py
@@ -522,8 +522,14 @@ class TestSyncReposTaskUnit(object):
             repo_obj("555555555", "soda", "python", False, "main", None),
         ]
 
+        async def mock_repos_using_installation(*args, **kwargs):
+            yield mock_repos[0:2]
+            yield mock_repos[2:4]
+
         # Mock GitHub response for repos that are visible to our app
-        mock_owner_provider.list_repos_using_installation.return_value = mock_repos
+        mock_owner_provider.list_repos_using_installation.side_effect = (
+            mock_repos_using_installation
+        )
 
         # Three of the four repositories we can see are already in the database.
         # Will we update `using_integration` correctly?


### PR DESCRIPTION
https://github.com/codecov/shared/pull/24
https://github.com/codecov/engineering-team/issues/6
https://github.com/codecov/engineering-team/issues/101

see `shared` PR for full explanation. tl;dr is `list_repos` frontloads all of its queries to git service provider APIs and then updates the db for each repo. if we alternate fetching and updating, we can make the UX more responsive.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.