### PR TITLE
carry forward flags in a seperate task 

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -16,6 +16,7 @@ from tasks.mutation_test_upload import mutation_test_upload_task
 from tasks.new_user_activated import new_user_activated_task
 from tasks.notify import notify_task
 from tasks.plan_manager_task import daily_plan_manager_task_name
+from tasks.preprocess_upload import preprocess_upload_task
 from tasks.profiling_find_uncollected import find_untotalized_profilings_task
 from tasks.profiling_normalizer import profiling_normalizer_task
 from tasks.save_report_results import save_report_results_task

--- a/tasks/preprocess_upload.py
+++ b/tasks/preprocess_upload.py
@@ -1,0 +1,152 @@
+import logging
+
+from redis.exceptions import LockError
+from shared.torngit.exceptions import TorngitClientError
+from shared.validation.exceptions import InvalidYamlException
+from shared.yaml import UserYaml
+
+from app import celery_app
+from database.enums import CommitErrorTypes
+from database.models import Commit
+from helpers.save_commit_error import save_commit_error
+from services.redis import get_redis_connection
+from services.report import ReportService
+from services.repository import get_repo_provider_service
+from services.yaml import save_repo_yaml_to_database_if_needed
+from services.yaml.fetcher import fetch_commit_yaml_from_provider
+from tasks.base import BaseCodecovTask
+
+log = logging.getLogger(__name__)
+
+
+class PreProcessUpload(BaseCodecovTask):
+
+    """
+    The main goal for this task is to carry forward flags from previous uploads
+    and save the new carried-forawrded upload in the db,as a pre-step for
+    uploading a report to codecov
+    """
+
+    name = "app.tasks.upload.PreProcessUpload"
+
+    async def run_async(
+        self,
+        db_session,
+        *,
+        repoid: int,
+        commitid: str,
+        report_code: str,
+        **kwargs,
+    ):
+        log.info(
+            "Received preprocess upload task",
+            extra=dict(repoid=repoid, commit=commitid, report_code=report_code),
+        )
+        lock_name = f"preprocess_upload_lock_{repoid}_{commitid}"
+        redis_connection = get_redis_connection()
+        try:
+            with redis_connection.lock(
+                lock_name,
+                timeout=60 * 5,
+                blocking_timeout=5,
+            ):
+                return await self.process_async_within_lock(
+                    db_session=db_session,
+                    repoid=repoid,
+                    commitid=commitid,
+                    report_code=report_code,
+                    **kwargs,
+                )
+        except LockError:
+            log.warning(
+                "Unable to acquire lock",
+                extra=dict(
+                    commit=commitid,
+                    repoid=repoid,
+                    number_retries=self.request.retries,
+                    lock_name=lock_name,
+                ),
+            )
+            return {"preprocessed_upload": False}
+
+    async def process_async_within_lock(
+        self,
+        *,
+        db_session,
+        repoid,
+        commitid,
+        report_code,
+        **kwargs,
+    ):
+        commits = db_session.query(Commit).filter(
+            Commit.repoid == repoid, Commit.commitid == commitid
+        )
+        commit = commits.first()
+        assert commit, "Commit not found in database."
+        repository = commit.repository
+        repository_service = get_repo_provider_service(repository, commit)
+        if repository_service:
+            commit_yaml = await self.fetch_commit_yaml_and_possibly_store(
+                commit, repository_service
+            )
+        else:
+            commit_yaml = UserYaml.get_final_yaml(
+                owner_yaml=repository.owner.yaml,
+                repo_yaml=repository.yaml,
+                commit_yaml=None,
+                ownerid=repository.owner.ownerid,
+            )
+        report_service = ReportService(commit_yaml)
+        commit_report = await report_service.initialize_and_save_report(
+            commit, report_code
+        )
+        return {"preprocessed_upload": True, "reportid": str(commit_report.external_id)}
+
+    async def fetch_commit_yaml_and_possibly_store(self, commit, repository_service):
+        repository = commit.repository
+        try:
+            log.info(
+                "Fetching commit yaml from provider for commit",
+                extra=dict(repoid=commit.repoid, commit=commit.commitid),
+            )
+            commit_yaml = await fetch_commit_yaml_from_provider(
+                commit, repository_service
+            )
+            save_repo_yaml_to_database_if_needed(commit, commit_yaml)
+        except InvalidYamlException as ex:
+            save_commit_error(
+                commit,
+                error_code=CommitErrorTypes.INVALID_YAML.value,
+                error_params=dict(
+                    repoid=repository.repoid,
+                    commit=commit.commitid,
+                    error_location=ex.error_location,
+                ),
+            )
+            log.warning(
+                "Unable to use yaml from commit because it is invalid",
+                extra=dict(
+                    repoid=repository.repoid,
+                    commit=commit.commitid,
+                    error_location=ex.error_location,
+                ),
+                exc_info=True,
+            )
+            commit_yaml = None
+        except TorngitClientError:
+            log.warning(
+                "Unable to use yaml from commit because it cannot be fetched",
+                extra=dict(repoid=repository.repoid, commit=commit.commitid),
+                exc_info=True,
+            )
+            commit_yaml = None
+        return UserYaml.get_final_yaml(
+            owner_yaml=repository.owner.yaml,
+            repo_yaml=repository.yaml,
+            commit_yaml=commit_yaml,
+            ownerid=repository.owner.ownerid,
+        )
+
+
+RegisteredUploadTask = celery_app.register_task(PreProcessUpload())
+preprocess_upload_task = celery_app.tasks[RegisteredUploadTask.name]

--- a/tasks/tests/unit/test_preprocess_upload.py
+++ b/tasks/tests/unit/test_preprocess_upload.py
@@ -1,0 +1,174 @@
+import pytest
+from shared.reports.types import ReportTotals, SessionTotalsArray
+
+from database.models.reports import Upload
+from database.tests.factories.core import (
+    CommitFactory,
+    ReportFactory,
+    RepositoryFactory,
+)
+from services.report import ReportService
+from tasks.preprocess_upload import PreProcessUpload
+
+
+class TestPreProcessUpload(object):
+    @pytest.mark.asyncio
+    async def test_preprocess_task(
+        self,
+        mocker,
+        mock_configuration,
+        dbsession,
+        mock_storage,
+        mock_redis,
+        celery_app,
+        sample_report,
+    ):
+        # get_existing_report_for_commit gets called for the parent commit
+        mocker.patch.object(
+            ReportService,
+            "get_existing_report_for_commit",
+            return_value=sample_report,
+        )
+        mocked_fetch_yaml = mocker.patch.object(
+            PreProcessUpload,
+            "fetch_commit_yaml_and_possibly_store",
+            return_value={
+                "flag_management": {
+                    "individual_flags": [
+                        {
+                            "name": "unit",
+                            "carryforward": True,
+                        }
+                    ]
+                }
+            },
+        )
+
+        def fake_possibly_shift(report, base, head):
+            return report
+
+        mock_possibly_shift = mocker.patch.object(
+            ReportService,
+            "_possibly_shift_carryforward_report",
+            side_effect=fake_possibly_shift,
+        )
+        commit, report = self.create_commit_and_report(dbsession)
+
+        result = await PreProcessUpload().run_async(
+            dbsession,
+            repoid=commit.repository.repoid,
+            commitid=commit.commitid,
+            report_code=None,
+        )
+        # assert that commit.report has carried forwarded flags sessions from its parent
+        assert commit.report.details.files_array == [
+            {
+                "filename": "file_1.go",
+                "file_index": 0,
+                "file_totals": ReportTotals(
+                    files=0,
+                    lines=8,
+                    hits=5,
+                    misses=3,
+                    partials=0,
+                    coverage="62.50000",
+                    branches=0,
+                    methods=0,
+                    messages=0,
+                    sessions=0,
+                    complexity=10,
+                    complexity_total=2,
+                    diff=0,
+                ),
+                "session_totals": SessionTotalsArray.build_from_encoded_data(
+                    [
+                        ReportTotals(
+                            files=0,
+                            lines=8,
+                            hits=5,
+                            misses=3,
+                            partials=0,
+                            coverage="62.50000",
+                            branches=0,
+                            methods=0,
+                            messages=0,
+                            sessions=0,
+                            complexity=10,
+                            complexity_total=2,
+                            diff=0,
+                        )
+                    ]
+                ),
+                "diff_totals": None,
+            },
+            {
+                "filename": "file_2.py",
+                "file_index": 1,
+                "file_totals": ReportTotals(
+                    files=0,
+                    lines=2,
+                    hits=1,
+                    misses=0,
+                    partials=1,
+                    coverage="50.00000",
+                    branches=1,
+                    methods=0,
+                    messages=0,
+                    sessions=0,
+                    complexity=0,
+                    complexity_total=0,
+                    diff=0,
+                ),
+                "session_totals": SessionTotalsArray.build_from_encoded_data(
+                    [
+                        ReportTotals(
+                            files=0,
+                            lines=2,
+                            hits=1,
+                            misses=0,
+                            partials=1,
+                            coverage="50.00000",
+                            branches=1,
+                            methods=0,
+                            messages=0,
+                            sessions=0,
+                            complexity=0,
+                            complexity_total=0,
+                            diff=0,
+                        )
+                    ]
+                ),
+                "diff_totals": None,
+            },
+        ]
+        for sess_id, session in sample_report.sessions.items():
+            upload = (
+                dbsession.query(Upload)
+                .filter_by(report_id=commit.report.id_, order_number=sess_id)
+                .first()
+            )
+            assert upload
+            assert upload.flag_names == ["unit"]
+        assert result == {
+            "preprocessed_upload": True,
+            "reportid": str(report.external_id),
+        }
+        mocked_fetch_yaml.assert_called()
+        mock_possibly_shift.assert_called()
+
+    def create_commit_and_report(self, dbsession):
+        repository = RepositoryFactory()
+        parent_commit = CommitFactory(repository=repository)
+        parent_commit_report = ReportFactory(commit=parent_commit)
+        commit = CommitFactory(
+            _report_json=None,
+            parent_commit_id=parent_commit.commitid,
+            repository=repository,
+        )
+        report = ReportFactory(commit=commit)
+        dbsession.add(parent_commit)
+        dbsession.add(parent_commit_report)
+        dbsession.add(commit)
+        dbsession.add(report)
+        dbsession.flush()
+        return commit, report


### PR DESCRIPTION
move carry forwarding to a new seperate task that will get called when creating a new db report instance

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.