### PR TITLE
fix: don't share default values in ArchiveField

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -238,7 +238,7 @@ class Commit(CodecovBaseModel):
     _report_json_storage_path = Column("report_storage_path", types.Text, nullable=True)
     report_json = ArchiveField(
         should_write_to_storage_fn=should_write_to_storage,
-        default_value={},
+        default_value_class=dict,
     )
 
 
@@ -358,7 +358,7 @@ class Pull(CodecovBaseModel):
     _flare = Column("flare", postgresql.JSON)
     _flare_storage_path = Column("flare_storage_path", types.Text, nullable=True)
     flare = ArchiveField(
-        should_write_to_storage_fn=should_write_to_storage, default_value={}
+        should_write_to_storage_fn=should_write_to_storage, default_value_class=dict
     )
 
 

--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -170,7 +170,7 @@ class ReportDetails(CodecovBaseModel, MixinBaseClass):
     files_array = ArchiveField(
         should_write_to_storage_fn=_should_write_to_storage,
         rehydrate_fn=rehydrate_encoded_data,
-        default_value=[],
+        default_value_class=list,
     )
 
 

--- a/database/tests/unit/test_model_utils.py
+++ b/database/tests/unit/test_model_utils.py
@@ -36,9 +36,7 @@ class TestArchiveField(object):
             self._archive_field_storage_path = archive_value
             self.should_write_to_gcs = should_write_to_gcs
 
-        archive_field = ArchiveField(
-            should_write_to_storage_fn=should_write_to_storage, default_value=None
-        )
+        archive_field = ArchiveField(should_write_to_storage_fn=should_write_to_storage)
 
     class ClassWithArchiveFieldMissingMethods:
         commit: Commit

--- a/database/utils.py
+++ b/database/utils.py
@@ -68,9 +68,9 @@ class ArchiveField:
         should_write_to_storage_fn: Callable[[object], bool],
         rehydrate_fn: Callable[[object, object], Any] = lambda self, x: x,
         json_encoder=ReportEncoder,
-        default_value=None,
+        default_value_class=lambda: None,
     ):
-        self.default_value = default_value
+        self.default_value_class = default_value_class
         self.rehydrate_fn = rehydrate_fn
         self.should_write_to_storage_fn = should_write_to_storage_fn
         self.json_encoder = json_encoder
@@ -103,14 +103,14 @@ class ArchiveField:
                     ),
                 )
         else:
-            log.info(
+            log.debug(
                 "Both db_field and archive_field are None",
                 extra=dict(
                     object_id=obj.id,
                     commit=obj.get_commitid(),
                 ),
             )
-        return self.default_value
+        return self.default_value_class()
 
     def __get__(self, obj, objtype=None):
         cached_value = getattr(obj, self.cached_value_property_name, None)


### PR DESCRIPTION
Passing an object as the default value to `ArchiveField` (such as `{}`)
means that we always return the same reference to multiple objects. So they're shared.
(thanks @scott-codecov for pointing that out)

So instead we will pass a class and call the class, creating a new object if we have to use it.
Noticed I hacked it a little for the default of the defaults to return `None`.
We can do the same if we ever need more complex values, or just create a new class.

I also moved the log of dbfield and archive_field None to be DEBUG and not INFO.
We are getting that quite a lot and it's making support's work hard.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.