### PR TITLE
fix: ezpz: downgrade checkpoint logger errors to warnings

### DIFF
--- a/helpers/checkpoint_logger.py
+++ b/helpers/checkpoint_logger.py
@@ -51,7 +51,7 @@ class CheckpointLogger:
         if self.strict:
             raise ValueError(msg)
         else:
-            logger.error(msg)
+            logger.warning(msg)
 
     def _validate_checkpoint(self, checkpoint):
         if checkpoint.__class__ != self.cls:


### PR DESCRIPTION
deployed with error severity to loudly flag whether the `UploadFlow` logs were hooked up right. downgrading to warning to lessen noise for support folks

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.