### PR TITLE
fix: unbreak user-plan-based task routing + upload task retries

### DIFF
--- a/tasks/base.py
+++ b/tasks/base.py
@@ -58,6 +58,10 @@ class BaseCodecovTask(celery_app.Task):
             "soft_time_limit": extra_config.get("soft_timelimit", None),
         }
         options = {**options, **celery_compatible_config}
+
+        opt_headers = options.pop("headers", {})
+        opt_headers = opt_headers if opt_headers is not None else {}
+
         # Pass current time in task headers so we can emit a metric of
         # how long the task was in the queue for
         current_time = datetime.now()

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -145,6 +145,12 @@ class UploadTask(BaseCodecovTask):
             UploadFlow.UPLOAD_TASK_BEGIN, kwargs=kwargs, ignore_repeat=True
         )
 
+        # `BaseCodecovTask` / `celery_task_router.py` try to route tasks based
+        # on the active user plan and require these to be in `kwargs` for that
+        # to work.
+        kwargs["repoid"] = repoid
+        kwargs["commitid"] = commitid
+
         log.info(
             "Received upload task",
             extra=dict(repoid=repoid, commit=commitid, report_code=report_code),


### PR DESCRIPTION
retrying `UploadTask` fails due to:
```
_get_user_plan_from_repoid() missing 1 required positional argument: 'repoid'
```
putting `repoid` (and `commitid`) into `kwargs` is a cheap fix.

then retries fail with:
```
TypeError: 'NoneType' object is not a mapping
```
the `headers` kwargs for `apply()` is `None` by default, but it's not specified for `apply_async()`'s `options` argument. i assume it's `None` by default there as well. when that happens, use an empty dict and it works

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.