### PR TITLE
fix: unbreak upload retries (two bugs)

### DIFF
--- a/tasks/base.py
+++ b/tasks/base.py
@@ -58,11 +58,15 @@ class BaseCodecovTask(celery_app.Task):
             "soft_time_limit": extra_config.get("soft_timelimit", None),
         }
         options = {**options, **celery_compatible_config}
+
+        opt_headers = options.pop("headers", {})
+        opt_headers = opt_headers if opt_headers is not None else {}
+
         # Pass current time in task headers so we can emit a metric of
         # how long the task was in the queue for
         current_time = datetime.now()
         headers = {
-            **options.pop("headers", {}),
+            **opt_headers,
             "created_timestamp": current_time.isoformat(),
         }
         return super().apply_async(args=args, kwargs=kwargs, headers=headers, **options)


### PR DESCRIPTION
`UploadTask` retries seem to be broken and i'm not sure how long ago they broke

### first problem

the first problem is in `tasks/base.py`: celery's `apply_async()` function takes an `options` dict which may have a `"headers"` key. i believe it's `None` by default (docs aren't explicit) and as a result we attempt `**None` which errors with:
```
'NoneType' object is not a mapping
```

the fix for this problem is straightforward

### second problem

second problem was recently introduced (by me). by changing `self.retry()` to `self.retry(args=args, kwargs=kwargs)`, i excluded the `repoid` and `commitid` arguments which led to an exception in `celery_task_router.py`:
```
_get_user_plan_from_repoid() missing 1 required positional argument: 'repoid'
```

strangely, the clearest fix for a missing positional argument is... to add it to `kwargs`. regular `args` are not plumbed through to `celery_task_router.py`, and i tried to plumb them through but i just don't have the tools (read: static type system) to be confident i caught all the task operations that need to be updated.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.