### PR TITLE
fix: handle reports with line 0 executed

### DIFF
--- a/services/report/languages/pycoverage.py
+++ b/services/report/languages/pycoverage.py
@@ -53,14 +53,15 @@ class PyCoverageProcessor(BaseLanguageProcessor):
                             str(ln), []
                         )
                     ]
-                    report_file.append(
-                        ln,
-                        report_builder_session.create_coverage_line(
-                            fixed_filename,
-                            cov,
-                            coverage_type=CoverageType.line,
-                            labels_list_of_lists=label_list_of_lists,
-                        ),
-                    )
+                    if ln > 0:
+                        report_file.append(
+                            ln,
+                            report_builder_session.create_coverage_line(
+                                fixed_filename,
+                                cov,
+                                coverage_type=CoverageType.line,
+                                labels_list_of_lists=label_list_of_lists,
+                            ),
+                        )
                 report_builder_session.append(report_file)
         return report_builder_session.output_report()

--- a/services/report/languages/tests/unit/test_pycoverage.py
+++ b/services/report/languages/tests/unit/test_pycoverage.py
@@ -157,6 +157,20 @@ COMPRESSED_SAMPLE = {
             "excluded_lines": [],
             "contexts": {},
         },
+        "services/__init__.py": {
+            "executed_lines": [0],
+            "summary": {
+                "covered_lines": 0,
+                "num_statements": 0,
+                "percent_covered": "100.0",
+                "percent_covered_display": "100",
+                "missing_lines": 0,
+                "excluded_lines": 0,
+            },
+            "missing_lines": [],
+            "excluded_lines": [],
+            "contexts": {"0": [0]},
+        },
     },
     "labels_table": {
         "0": "",


### PR DESCRIPTION
Recently when testing the docs for integrating ATS I did [this commit](https://app.codecov.io/gh/giovanni-guidini/ats-data/commit/c24c1db8aa27fcda2d311fdcd293c20697030389)
for which processing failed. Checking the logs it failed because of

```
  [... removed stack trace...]
  File "/worker/services/report/languages/pycoverage.py", line 56, in process
    report_file.append(
  File "/usr/local/lib/python3.10/site-packages/shared/reports/resources.py", line 341, in append
    raise ValueError("Line number must be greater then 0. Got %s" % ln)
ValueError: Line number must be greater then 0. Got 0
```

Indeed when I donwloaded and checked the uploaded files there were 3 of them with `executed_lines: [0]`.
They were all `__init__.py` files. Idk why that happened, to be honest. It looks strange because the 3 files are empty.

In any case it's an easy fix that will not hurt us.
I think line 0 should not exist. It might indicate that when importing the code or something like that the file was
executed somehow, but for `__init__.py` files with some content in them the list of lines executed is as expected.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.