### PR TITLE
feat: Only send status checks when payload has changed

### DIFF
--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -6,6 +6,7 @@ from shared.analytics_tracking import track_event
 from shared.torngit.exceptions import TorngitClientError, TorngitError
 from shared.utils.sessions import SessionType
 
+from helpers.cache import DEFAULT_TTL, NO_VALUE, cache, make_hash_sha256
 from helpers.environment import is_enterprise
 from helpers.match import match
 from helpers.metrics import metrics
@@ -209,7 +210,32 @@ class StatusNotifier(AbstractBaseNotifier):
                 payload["url"] = get_pull_url(comparison.pull)
             else:
                 payload["url"] = get_commit_url(comparison.head.commit)
-            return await self.send_notification(comparison, payload)
+
+            base_commit = comparison.base.commit if comparison.base else None
+            head_commit = comparison.head.commit if comparison.head else None
+
+            cache_key = make_hash_sha256(
+                dict(
+                    type="status_check_notification",
+                    repoid=head_commit.repoid,
+                    base_commitid=base_commit.commitid if base_commit else None,
+                    head_commitid=head_commit.commitid if head_commit else None,
+                    notifier_name=self.name,
+                    notifier_title=self.title,
+                )
+            )
+
+            last_payload = cache.get_backend().get(cache_key)
+            if last_payload is NO_VALUE or last_payload != payload:
+                cache.get_backend().set(cache_key, 300, payload)  # 5 min expiration
+                return await self.send_notification(comparison, payload)
+            else:
+                return NotificationResult(
+                    notification_attempted=False,
+                    notification_successful=None,
+                    explanation="payload_unchanged",
+                    data_sent=None,
+                )
         except TorngitClientError:
             log.warning(
                 "Unable to send status notification to user due to a client-side error",

--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -236,6 +236,16 @@ class StatusNotifier(AbstractBaseNotifier):
                 cache.get_backend().set(cache_key, ttl, payload)
                 return await self.send_notification(comparison, payload)
             else:
+                log.info(
+                    "Notification payload unchanged.  Skipping notification.",
+                    extra=dict(
+                        repoid=head_commit.repoid,
+                        base_commitid=base_commit.commitid if base_commit else None,
+                        head_commitid=head_commit.commitid if head_commit else None,
+                        notifier_name=self.name,
+                        notifier_title=self.title,
+                    ),
+                )
                 return NotificationResult(
                     notification_attempted=False,
                     notification_successful=None,

--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -3,6 +3,7 @@ from contextlib import nullcontext
 from typing import Dict
 
 from shared.analytics_tracking import track_event
+from shared.config import get_config
 from shared.torngit.exceptions import TorngitClientError, TorngitError
 from shared.utils.sessions import SessionType
 
@@ -227,7 +228,12 @@ class StatusNotifier(AbstractBaseNotifier):
 
             last_payload = cache.get_backend().get(cache_key)
             if last_payload is NO_VALUE or last_payload != payload:
-                cache.get_backend().set(cache_key, 300, payload)  # 5 min expiration
+                ttl = int(
+                    get_config(
+                        "setup", "cache", "send_status_notification", default=600
+                    )
+                )  # 10 min default
+                cache.get_backend().set(cache_key, ttl, payload)
                 return await self.send_notification(comparison, payload)
             else:
                 return NotificationResult(


### PR DESCRIPTION
Resolves https://github.com/codecov/engineering-team/issues/350

Only send status notifications when the payload has changed from the last time we sent the same notification.