### PR TITLE
feat: Add cron monitoring for celery tasks (#362)

### DIFF
--- a/helpers/sentry.py
+++ b/helpers/sentry.py
@@ -34,7 +34,7 @@ def initialize_sentry() -> None:
         environment=os.getenv("DD_ENV", "production"),
         traces_sample_rate=float(os.environ.get("SERVICES__SENTRY__SAMPLE_RATE", 1)),
         integrations=[
-            CeleryIntegration(),
+            CeleryIntegration(monitor_beat_tasks=True),
             SqlalchemyIntegration(),
             RedisIntegration(),
             HttpxIntegration(),


### PR DESCRIPTION

Add Sentry Cron Monitoring feature for Codecov org. This should add monitoring for every celery type tasks in the repo and data should auto-populate on the Sentry dashboard after the first time each task is ran. This change does not add alerting for the tasks.



### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.