### PR TITLE
Handle key error for now

### DIFF
--- a/services/comparison/__init__.py
+++ b/services/comparison/__init__.py
@@ -182,7 +182,14 @@ class ComparisonProxy(object):
                             ),
                         )
                         return None
-
+                    except KeyError:
+                        log.warning(
+                            "Error fetching base branch from Git provider",
+                            extra=dict(
+                                branch=branch_to_get,
+                            ),
+                        )
+                        return None
                     self._branch = branch_response
 
                 distance = await self.repository_service.get_distance_in_commits(


### PR DESCRIPTION
Handle key error with BB branches in the short term


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.