### PR TITLE
feat: Add different comment message for 1st time pulls

### DIFF
--- a/services/notification/notifiers/comment/__init__.py
+++ b/services/notification/notifiers/comment/__init__.py
@@ -8,6 +8,7 @@ from shared.torngit.exceptions import (
 )
 
 from database.enums import Notification
+from database.models import Pull
 from helpers.metrics import metrics
 from services.comparison.types import Comparison
 from services.license import requires_license
@@ -358,10 +359,21 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
             return self._create_empty_upload_message()
         if self.should_use_upload_limit_decoration():
             return self._create_reached_upload_limit_message(comparison)
+        if comparison.pull.is_first_pull:
+            return self._create_welcome_message()
         pull_dict = comparison.enriched_pull.provider_pull
         return await self.create_message(
             comparison, pull_dict, self.notifier_yaml_settings
         )
+
+    def _create_welcome_message(self):
+        return [
+            "## Welcome to [Codecov](https://codecov.io) :tada:",
+            "",
+            "Once merged to your default branch, Codecov will compare your coverage reports and display the results in this comment.",
+            "",
+            "Thanks for integrating Codecov - We've got you covered :open_umbrella:",
+        ]
 
     def _create_empty_upload_message(self):
         if self.is_passing_empty_upload():

--- a/services/notification/notifiers/tests/integration/test_comment.py
+++ b/services/notification/notifiers/tests/integration/test_comment.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from shared.reports.readonly import ReadOnlyReport
@@ -8,6 +8,15 @@ from services.comparison import ComparisonProxy
 from services.comparison.types import Comparison, EnrichedPull, FullCommit
 from services.decoration import Decoration
 from services.notification.notifiers.comment import CommentNotifier
+
+
+@pytest.fixture
+def is_not_first_pull(mocker):
+    mocker.patch(
+        "database.models.core.Pull.is_first_pull",
+        return_value=False,
+        new_callable=PropertyMock,
+    )
 
 
 @pytest.fixture
@@ -319,6 +328,7 @@ def sample_comparison_for_limited_upload(
     )
 
 
+@pytest.mark.usefixtures("is_not_first_pull")
 class TestCommentNotifierIntegration(object):
     @pytest.mark.asyncio
     async def test_notify(self, sample_comparison, codecov_vcr, mock_configuration):

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from database.models import Pull
-from database.tests.factories import CommitFactory, RepositoryFactory
+from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
 from services.archive import ArchiveService
 from services.notification.notifiers.base import NotificationResult
 from tasks.notify import NotifyTask
@@ -807,6 +807,8 @@ class TestNotifyTask(object):
             repository=repository,
             author=repository.owner,
         )
+        # create another pull so that we don't trigger the 1st time comment message
+        dbsession.add(PullFactory.create(repository=repository, pullid=8))
         commit = CommitFactory.create(
             message="",
             pullid=9,


### PR DESCRIPTION
https://github.com/codecov/engineering-team/issues/389

Companion PR to https://github.com/codecov/codecov-api/pull/108

If a pull is the 1st for a repo then we want to show different copy in the PR comment.
