### PR TITLE
ref: Make sure both base status notifiers cache notifications

### DIFF
--- a/services/notification/notifiers/checks/base.py
+++ b/services/notification/notifiers/checks/base.py
@@ -187,7 +187,7 @@ class ChecksNotifier(StatusNotifier):
                 payload["url"] = get_pull_url(comparison.pull)
             else:
                 payload["url"] = get_commit_url(comparison.head.commit)
-            return await self.send_notification(comparison, payload)
+            return await self.maybe_send_notification(comparison, payload)
         except TorngitClientError as e:
             if e.code == 403:
                 raise e


### PR DESCRIPTION
The `CheckNotifier` inherits from `StatusNotifier` which is where notification caching was happening.  `CheckNotifier` overrides the `notify` method but does not implement the caching.  This PR refactors where the caching happens such that it can easily be reused in both base notifier classes.