### PR TITLE
Adjust logic for trialing customers monthly upload limit

### DIFF
--- a/database/tests/factories/core.py
+++ b/database/tests/factories/core.py
@@ -44,6 +44,9 @@ class OwnerFactory(Factory):
     service = factory.Iterator(["gitlab", "github", "bitbucket"])
     free = 0
     unencrypted_oauth_token = factory.LazyFunction(lambda: uuid4().hex)
+    trial_start_date = datetime.now()
+    trial_end_date = datetime.now()
+    trial_status = enums.TrialStatus.NOT_STARTED.value
 
     oauth_token = factory.LazyAttribute(
         lambda o: encrypt_oauth_token(o.unencrypted_oauth_token)
@@ -222,6 +225,7 @@ class UploadFactory(Factory):
     upload_extras = {}
     upload_type = "uploaded"
     storage_path = "storage/path.txt"
+    created_at = datetime.now()
 
 
 class UploadLevelTotalsFactory(Factory):


### PR DESCRIPTION
Uploads while undergoing a trial shouldn't affect the monthly uploads post trial. This is a code change to adjust this in the worker level

- Adding logic to determine the monthly upload created date + tests
- Adding some properties + tests to the plan service

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.