### PR TITLE
Revert "Move feedback link out of footer section and always include at the bottom of a comment

### DIFF
--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -156,8 +156,6 @@ class MessageMixin(object):
                         section_writer,
                     )
 
-        await self._write_feedback_link(comparison, settings, write)
-
         return [m for m in message if m is not None]
 
     async def _possibly_write_gh_app_login_announcement(
@@ -173,26 +171,6 @@ class MessageMixin(object):
             message_to_display = "Your organization needs to install the [Codecov GitHub app](https://github.com/apps/codecov/installations/select_target) to enable full functionality."
             write(f":exclamation: {message_to_display}")
             write("")
-
-    async def _write_feedback_link(
-        self, comparison: ComparisonProxy, settings: dict, write: Callable
-    ):
-        hide_project_coverage = settings.get("hide_project_coverage", False)
-        if hide_project_coverage:
-            write(
-                ":loudspeaker: Thoughts on this report? [Let us know!]({0}).".format(
-                    "https://about.codecov.io/pull-request-comment-report/"
-                )
-            )
-        else:
-            repo_service = comparison.repository_service.service
-            write(
-                ":loudspeaker: Have feedback on the report? [Share it here]({0}).".format(
-                    "https://gitlab.com/codecov-open-source/codecov-user-feedback/-/issues/4"
-                    if repo_service == "gitlab"
-                    else "https://about.codecov.io/codecov-pr-comment-feedback/"
-                )
-            )
 
     async def write_section_to_msg(
         self, comparison, changes, diff, links, write, section_writer, behind_by=None

--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -81,11 +81,26 @@ class NullSectionWriter(BaseSectionWriter):
 class NewFooterSectionWriter(BaseSectionWriter):
     async def do_write_section(self, comparison, diff, changes, links, behind_by=None):
         hide_project_coverage = self.settings.get("hide_project_coverage", False)
-        if not hide_project_coverage:
+        if hide_project_coverage:
+            yield ("")
+            yield (
+                ":loudspeaker: Thoughts on this report? [Let us know!]({0}).".format(
+                    "https://about.codecov.io/pull-request-comment-report/"
+                )
+            )
+        else:
+            repo_service = comparison.repository_service.service
             yield ("")
             yield (
                 "[:umbrella: View full report in Codecov by Sentry]({0}?src=pr&el=continue).   ".format(
                     links["pull"]
+                )
+            )
+            yield (
+                ":loudspeaker: Have feedback on the report? [Share it here]({0}).".format(
+                    "https://about.codecov.io/codecov-pr-comment-feedback/"
+                    if repo_service == "github"
+                    else "https://gitlab.com/codecov-open-source/codecov-user-feedback/-/issues/4"
                 )
             )
 

--- a/services/notification/notifiers/tests/integration/test_comment.py
+++ b/services/notification/notifiers/tests/integration/test_comment.py
@@ -390,7 +390,6 @@ class TestCommentNotifierIntegration(object):
             "> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`",
             "> Powered by [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/9?src=pr&el=footer). Last update [5b174c2...5601846](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/9?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             "",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         for exp, res in zip(result.data_sent["message"], message):
             assert exp == res
@@ -534,7 +533,6 @@ class TestCommentNotifierIntegration(object):
             "> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`",
             "> Powered by [Codecov](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1?src=pr&el=footer). Last update [0fc784a...0b6a213](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             "",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://gitlab.com/codecov-open-source/codecov-user-feedback/-/issues/4).",
         ]
         for exp, res in zip(result.data_sent["message"], message):
             assert exp == res
@@ -602,8 +600,8 @@ class TestCommentNotifierIntegration(object):
             "</details>",
             "",
             "[:umbrella: View full report in Codecov by Sentry](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/9?src=pr&el=continue).   ",
-            "",
             ":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
+            "",
         ]
         for exp, res in zip(result.data_sent["message"], message):
             assert exp == res
@@ -682,8 +680,8 @@ class TestCommentNotifierIntegration(object):
             "</details>",
             "",
             "[:umbrella: View full report in Codecov by Sentry](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/9?src=pr&el=continue).   ",
-            "",
             ":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
+            "",
         ]
         for exp, res in zip(result.data_sent["message"], message):
             assert exp == res

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -1516,7 +1516,6 @@ class TestProjectChecksNotifier(object):
                         f"",
                         f"... and [1 file with indirect coverage changes](test.example.br/gh/test_build_default_payload/{repo.name}/pull/{sample_comparison.pull.pullid}/indirect-changes?src=pr&el=tree-more)",
                         f"",
-                        ":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
                     ]
                 ),
             },
@@ -1559,7 +1558,6 @@ class TestProjectChecksNotifier(object):
                         f"",
                         f"... and [1 file with indirect coverage changes](test.example.br/gh/test_build_default_payload_with_flags/{repo.name}/pull/{sample_comparison.pull.pullid}/indirect-changes?src=pr&el=tree-more)",
                         f"",
-                        ":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
                     ]
                 ),
             },
@@ -1610,7 +1608,6 @@ class TestProjectChecksNotifier(object):
                         f"> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`",
                         f"> Powered by [Codecov](test.example.br/gh/{test_name}/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=footer). Last update [{base_commit.commitid[:7]}...{head_commit.commitid[:7]}](test.example.br/gh/{test_name}/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
                         f"",
-                        ":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
                     ]
                 ),
             },

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -713,7 +713,6 @@ class TestCommentNotifier(object):
             f"| [file\\_1.go](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree#diff-ZmlsZV8xLmdv) | `62.50% <ø> (+12.50%)` | `10.00 <0.00> (-1.00)` | :arrow_up: |",
             f"| [file\\_2.py](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree#diff-ZmlsZV8yLnB5) | `50.00% <ø> (ø)` | `0.00 <0.00> (ø)` | |",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         res = await notifier.create_message(comparison, pull_dict, {"layout": "files"})
         print(res)
@@ -874,7 +873,6 @@ class TestCommentNotifier(object):
             f"| [file\\_2.py](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree#diff-ZmlsZV8yLnB5) **Critical** | `50.00% <ø> (ø)` | `0.00 <0.00> (ø)` | |",
             f"",
             "",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         res = await notifier.build_message(comparison)
         assert expected_result == res
@@ -948,7 +946,6 @@ class TestCommentNotifier(object):
             f"[{sample_comparison.base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -992,7 +989,6 @@ class TestCommentNotifier(object):
             "",
             "Flags with carried forward coverage won't be shown. [Click here](https://docs.codecov.io/docs/carryforward-flags#carryforward-flags-in-the-pull-request-comment) to find out more.",
             "",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         li = 0
         print("\n".join(result))
@@ -1083,7 +1079,6 @@ class TestCommentNotifier(object):
             f"",
             f"",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -1343,7 +1338,6 @@ class TestCommentNotifier(object):
             f"[{sample_comparison.base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -1415,7 +1409,6 @@ class TestCommentNotifier(object):
             f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -1484,7 +1477,6 @@ class TestCommentNotifier(object):
             f"[cdf9aa4...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -1558,7 +1550,6 @@ class TestCommentNotifier(object):
             f"[{sample_comparison_no_change.base.commit.commitid[:7]}...{sample_comparison_no_change.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         print(result)
         li = 0
@@ -1637,7 +1628,6 @@ class TestCommentNotifier(object):
             f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         print(result)
         for exp, res in zip(expected_result, result):
@@ -1702,7 +1692,6 @@ class TestCommentNotifier(object):
             f"- Misses        871      874       +3     ",
             f"```",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         print(result)
         li = 0
@@ -1757,7 +1746,6 @@ class TestCommentNotifier(object):
             f"Patch coverage has no change and project coverage change: **`-0.04%`** :warning:",
             f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 88.58% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 88.54%.",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         print(result)
         li = 0
@@ -1833,7 +1821,6 @@ class TestCommentNotifier(object):
             f"[{sample_comparison.base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -1898,7 +1885,6 @@ class TestCommentNotifier(object):
             f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         print(result)
         li = 0
@@ -1968,7 +1954,6 @@ class TestCommentNotifier(object):
             f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         print(result)
         li = 0
@@ -2045,7 +2030,6 @@ class TestCommentNotifier(object):
             f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         print(result)
         li = 0
@@ -2120,7 +2104,6 @@ class TestCommentNotifier(object):
             f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         print(result)
         li = 0
@@ -2228,7 +2211,6 @@ class TestCommentNotifier(object):
             f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -3246,7 +3228,6 @@ class TestCommentNotifier(object):
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
             f"</details>",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         li = 0
         for exp, res in zip(expected_result, result):
@@ -3279,7 +3260,6 @@ class TestCommentNotifier(object):
             "",
             ":mega: message",
             "",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         for exp, res in zip(expected_result, result):
             if exp == ":mega: message":
@@ -3317,7 +3297,6 @@ class TestCommentNotifier(object):
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         li = 0
         for exp, res in zip(expected_result, result):
@@ -3823,6 +3802,51 @@ class TestNewFooterSectionWriter(object):
         assert res == [
             "",
             "[:umbrella: View full report in Codecov by Sentry](pull.link?src=pr&el=continue).   ",
+            ":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_footer_section_writer_in_gitlab(self, mocker):
+        writer = NewFooterSectionWriter(
+            mocker.MagicMock(),
+            mocker.MagicMock(),
+            mocker.MagicMock(),
+            settings={},
+            current_yaml=mocker.MagicMock(),
+        )
+        mock_comparison = mocker.MagicMock()
+        mock_comparison.repository_service.service = "gitlab"
+        res = list(
+            await writer.write_section(
+                mock_comparison, {}, [], links={"pull": "pull.link"}
+            )
+        )
+        assert res == [
+            "",
+            "[:umbrella: View full report in Codecov by Sentry](pull.link?src=pr&el=continue).   ",
+            ":loudspeaker: Have feedback on the report? [Share it here](https://gitlab.com/codecov-open-source/codecov-user-feedback/-/issues/4).",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_footer_section_writer_in_bitbucket(self, mocker):
+        writer = NewFooterSectionWriter(
+            mocker.MagicMock(),
+            mocker.MagicMock(),
+            mocker.MagicMock(),
+            settings={},
+            current_yaml=mocker.MagicMock(),
+        )
+        mock_comparison = mocker.MagicMock()
+        mock_comparison.repository_service.service = "bitbucket"
+        res = list(
+            await writer.write_section(
+                mock_comparison, {}, [], links={"pull": "pull.link"}
+            )
+        )
+        assert res == [
+            "",
+            "[:umbrella: View full report in Codecov by Sentry](pull.link?src=pr&el=continue).   ",
+            ":loudspeaker: Have feedback on the report? [Share it here](https://gitlab.com/codecov-open-source/codecov-user-feedback/-/issues/4).",
         ]
 
     @pytest.mark.asyncio
@@ -3844,7 +3868,10 @@ class TestNewFooterSectionWriter(object):
                 mock_comparison, {}, [], links={"pull": "pull.link"}
             )
         )
-        assert res == []
+        assert res == [
+            "",
+            ":loudspeaker: Thoughts on this report? [Let us know!](https://about.codecov.io/pull-request-comment-report/).",
+        ]
 
 
 @pytest.mark.usefixtures("is_not_first_pull")
@@ -4004,7 +4031,6 @@ class TestCommentNotifierInNewLayout(object):
             f"| [file\\_2.py](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree#diff-ZmlsZV8yLnB5) **Critical** | `50.00% <ø> (ø)` | `0.00 <0.00> (ø)` | |",
             f"",
             "",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
         res = await notifier.build_message(comparison)
         assert expected_result == res
@@ -4068,8 +4094,8 @@ class TestCommentNotifierInNewLayout(object):
             f"",
             f"",
             f"[:umbrella: View full report in Codecov by Sentry](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=continue).   ",
-            f"",
             f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
+            f"",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -4138,8 +4164,8 @@ class TestCommentNotifierInNewLayout(object):
             f"</details>",
             f"",
             f"[:umbrella: View full report in Codecov by Sentry](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=continue).   ",
-            f"",
             f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
+            f"",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -4179,6 +4205,7 @@ class TestCommentNotifierInNewLayout(object):
             f"",
             f"",
             f":loudspeaker: Thoughts on this report? [Let us know!](https://about.codecov.io/pull-request-comment-report/).",
+            f"",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -4245,8 +4272,8 @@ class TestCommentNotifierInNewLayout(object):
             f"</details>",
             f"",
             f"[:umbrella: View full report in Codecov by Sentry](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=continue).   ",
-            f"",
             f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
+            f"",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -4325,8 +4352,8 @@ class TestCommentNotifierInNewLayout(object):
             f"</details>",
             f"",
             f"[:umbrella: View full report in Codecov by Sentry](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=continue).   ",
-            f"",
             f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
+            f"",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -4396,7 +4423,6 @@ class TestCommentNotifierInNewLayout(object):
             f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
-            f":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
         ]
 
         for exp, res in zip(expected_result, result):

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -1193,7 +1193,6 @@ class TestNotifyTask(object):
                                 "> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`",
                                 "> Powered by [Codecov](https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/pull/9?src=pr&el=footer). Last update [5b174c2...5601846](https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/pull/9?src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
                                 "",
-                                ":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
                             ],
                             "commentid": None,
                             "pullid": 9,


### PR DESCRIPTION
Reverts #91 

https://github.com/codecov/engineering-team/issues/296