### PR TITLE
chore: don't save errors in `LabelAnalysisRequest` object

### DIFF
--- a/tasks/label_analysis.py
+++ b/tasks/label_analysis.py
@@ -137,16 +137,16 @@ class LabelAnalysisRequestProcessingTask(BaseCodecovTask):
             ),
         )
         label_analysis_request.state_id = LabelAnalysisRequestState.FINISHED.db_id
-        result = {
+        result_to_save = {
             "success": True,
             "present_report_labels": [],
             "present_diff_labels": [],
             "absent_labels": label_analysis_request.requested_labels,
             "global_level_labels": [],
-            "errors": self.errors,
         }
-        label_analysis_request.result = result
-        return result
+        label_analysis_request.result = result_to_save
+        result_to_return = {**result_to_save, "errors": self.errors}
+        return result_to_return
 
     def add_processing_error(
         self,


### PR DESCRIPTION
In the case where we have some missing information we were saving the errors as part of the result dict (in the database).
There's a dedicated table for the larq errors, they should not be saved in the database.
THese changes fix that adding the errors to the dict to return only after savign the real results.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.