### PR TITLE
feat: CheckpointLogger v2: cleaner usage, reliability counters, more UploadFlow metrics

### DIFF
--- a/helpers/checkpoint_logger.py
+++ b/helpers/checkpoint_logger.py
@@ -315,8 +315,18 @@ class CheckpointLogger:
         return self
 
 
-@failure_events("FAILED")
-@success_events("NOTIFIED")
+@failure_events(
+    "TOO_MANY_RETRIES",
+    "NOTIF_LOCK_ERROR",
+    "NOTIF_NO_VALID_INTEGRATION",
+    "NOTIF_GIT_CLIENT_ERROR",
+    "NOTIF_GIT_SERVICE_ERROR",
+    "NOTIF_TOO_MANY_RETRIES",
+    "NOTIF_ERROR_NO_REPORT",
+)
+@success_events(
+    "SKIPPING_NOTIFICATION", "NOTIFIED", "NO_PENDING_JOBS", "NOTIF_STALE_HEAD"
+)
 @subflows(
     ("time_before_processing", "UPLOAD_TASK_BEGIN", "PROCESSING_BEGIN"),
     ("initial_processing_duration", "PROCESSING_BEGIN", "INITIAL_PROCESSING_COMPLETE"),
@@ -331,9 +341,18 @@ class CheckpointLogger:
 @reliability_counters
 class UploadFlow(str, Enum):
     UPLOAD_TASK_BEGIN = auto()
+    NO_PENDING_JOBS = auto()
+    TOO_MANY_RETRIES = auto()
     PROCESSING_BEGIN = auto()
     INITIAL_PROCESSING_COMPLETE = auto()
     BATCH_PROCESSING_COMPLETE = auto()
     PROCESSING_COMPLETE = auto()
+    SKIPPING_NOTIFICATION = auto()
     NOTIFIED = auto()
-    FAILED = auto()
+    NOTIF_LOCK_ERROR = auto()
+    NOTIF_NO_VALID_INTEGRATION = auto()
+    NOTIF_GIT_CLIENT_ERROR = auto()
+    NOTIF_GIT_SERVICE_ERROR = auto()
+    NOTIF_TOO_MANY_RETRIES = auto()
+    NOTIF_STALE_HEAD = auto()
+    NOTIF_ERROR_NO_REPORT = auto()

--- a/helpers/checkpoint_logger.py
+++ b/helpers/checkpoint_logger.py
@@ -1,3 +1,5 @@
+import functools
+import itertools
 import logging
 import time
 from enum import Enum, auto
@@ -8,13 +10,146 @@ from shared.metrics import metrics
 logger = logging.getLogger(__name__)
 
 
-class UploadFlow(str, Enum):
-    UPLOAD_TASK_BEGIN = auto()
-    PROCESSING_BEGIN = auto()
-    INITIAL_PROCESSING_COMPLETE = auto()
-    BATCH_PROCESSING_COMPLETE = auto()
-    PROCESSING_COMPLETE = auto()
-    NOTIFIED = auto()
+def failure_events(*args):
+    """
+    Class decorator that designates some events as terminal failure conditions.
+
+    @failure_events('ERROR')
+    class MyEnum(str, Enum):
+        BEGIN: auto()
+        CHECKPOINT: auto()
+        ERROR: auto()
+        FINISHED: auto()
+    assert MyEnum.ERROR.is_failure()
+    """
+
+    def class_decorator(klass):
+        def _failure_events():
+            return {v for k, v in klass.__members__.items() if k in args}
+
+        def is_failure(obj):
+            return obj in klass._failure_events()
+
+        # `_failure_events` is a cached function rather than a data member so
+        # that it is not processed as if it's a value from the enum.
+        klass._failure_events = functools.lru_cache(maxsize=1)(_failure_events)
+        klass.is_failure = is_failure
+
+        return klass
+
+    return class_decorator
+
+
+def success_events(*args):
+    """
+    Class decorator that designates some events as terminal success conditions.
+
+    @success_events('FINISHED')
+    class MyEnum(str, Enum):
+        BEGIN: auto()
+        CHECKPOINT: auto()
+        ERROR: auto()
+        FINISHED: auto()
+    assert MyEnum.FINISHED.is_success()
+    """
+
+    def class_decorator(klass):
+        def _success_events():
+            return {v for k, v in klass.__members__.items() if k in args}
+
+        def is_success(obj):
+            return obj in klass._success_events()
+
+        # `_failure_events` is a cached function rather than a data member so
+        # that it is not processed as if it's a value from the enum.
+        klass._success_events = functools.lru_cache(maxsize=1)(_success_events)
+        klass.is_success = is_success
+
+        return klass
+
+    return class_decorator
+
+
+def subflows(*args):
+    """
+    Class decorator that defines a set of interesting subflows which should be
+    logged as well as the name each should be logged with.
+
+    @subflows(
+        ('first_subflow', 'BEGIN', 'CHECKPOINT_A'),
+        ('second_subflow', 'CHECKPOINT_A', 'FINISH')
+    )
+    class MyEnum(str, Enum):
+        BEGIN: auto()
+        CHECKPOINT: auto()
+        ERROR: auto()
+        FINISHED: auto()
+
+    A subflow from the first event to each terminal event (success and failure) is
+    created implicitly with names like 'MyEnum_BEGIN_to_FINISHED'. This name can be
+    overridden by defining the subflow explicitly.
+    """
+
+    def class_decorator(klass):
+        def _subflows():
+            # We get our subflows in the form: [(metric, begin, end)]
+            # We want them in the form: {end: [(metric, begin)]}
+            # The first step of munging is to group by end
+            key_on_end = lambda x: x[2]
+            sorted_by_end = sorted(args, key=key_on_end)
+            grouped_by_end = itertools.groupby(args, key=key_on_end)
+
+            enum_vals = klass.__members__
+
+            subflows = {}
+            for end, group in grouped_by_end:
+                # grouped_by_end is not a simple dict so we create our own.
+                # `begin` and `end` are still strings at this point so we also want to convert
+                # them to enum values.
+                subflows[enum_vals[end]] = list(
+                    ((metric, enum_vals[begin]) for metric, begin, _ in group)
+                )
+
+            # The first enum value is the beginning of the flow, no matter what
+            # branches it takes. We want to automatically define a subflow from
+            # this beginning to each terminal checkpoint (failures/successes)
+            # unless the user provided one already.
+            flow_begin = next(iter(enum_vals.values()))
+
+            # `klass._failure_events` comes from the `@failure_events` decorator
+            if hasattr(klass, "_failure_events"):
+                for end in klass._failure_events():
+                    flows_ending_here = subflows.setdefault(
+                        end, []
+                    )  # [(metric, begin)]
+                    if not any((x[1] == flow_begin for x in flows_ending_here)):
+                        flows_ending_here.append(
+                            (
+                                f"{klass.__name__}_{flow_begin.name}_to_{end.name}",
+                                flow_begin,
+                            )
+                        )
+
+            # `klass._success_events` comes from the `@success_events` decorator
+            if hasattr(klass, "_success_events"):
+                for end in klass._success_events():
+                    flows_ending_here = subflows.setdefault(
+                        end, []
+                    )  # [(metric, begin)]
+                    if not any((x[1] == flow_begin for x in flows_ending_here)):
+                        flows_ending_here.append(
+                            (
+                                f"{klass.__name__}_{flow_begin.name}_to_{end.name}",
+                                flow_begin,
+                            )
+                        )
+
+            return subflows
+
+        klass._subflows = functools.lru_cache(maxsize=1)(_subflows)
+        return klass
+
+    return class_decorator
 
 
 def _get_milli_timestamp():
@@ -37,6 +172,28 @@ def from_kwargs(cls, kwargs, strict=False):
 
 
 class CheckpointLogger:
+    """
+    CheckpointLogger is a class that tracks latencies/reliabilities for higher-level
+    "flows" that don't map well to auto-instrumented tracing. It can be
+    reconstructed from its serialized data allowing you to begin a flow on one host
+    and log its completion on another (as long as clock drift is marginal).
+
+      # Simple usage
+      checkpoints = CheckpointLogger(UploadFlow)
+      checkpoints.log(UploadFlow.BEGIN)
+      ...
+      checkpoints.log(UploadFlow.PROCESSING_BEGIN)
+      checkpoints.submit_subflow("time_before_processing", UploadFlow.BEGIN, UploadFlow.PROCESSING_BEGIN)
+
+      # Alternate usage (`kwargs=kwargs` will insert the log directly into `kwargs`)
+      from_kwargs(UploadFlow, kwargs).log(UploadFlow.BEGIN, kwargs=kwargs)
+      next_task(kwargs)
+      ...
+      from_kwargs(UploadFlow, kwargs)
+          .log(UploadFlow.NOTIFIED)
+          .submit_subflow('notification_latency', UploadFlow.BEGIN, UploadFlow.NOTIFIED)
+    """
+
     def __init__(self, cls, data=None, strict=False):
         self.cls = cls
         self.data = data if data else {}
@@ -96,3 +253,26 @@ class CheckpointLogger:
         sentry_sdk.set_measurement(metric, duration, "milliseconds")
 
         return self
+
+
+@failure_events("FAILED")
+@success_events("NOTIFIED")
+@subflows(
+    ("time_before_processing", "UPLOAD_TASK_BEGIN", "PROCESSING_BEGIN"),
+    ("initial_processing_duration", "PROCESSING_BEGIN", "INITIAL_PROCESSING_COMPLETE"),
+    (
+        "batch_processing_duration",
+        "INITIAL_PROCESSING_COMPLETE",
+        "BATCH_PROCESSING_COMPLETE",
+    ),
+    ("total_processing_duration", "PROCESSING_BEGIN", "PROCESSING_COMPLETE"),
+    ("notification_latency", "UPLOAD_TASK_BEGIN", "NOTIFIED"),
+)
+class UploadFlow(str, Enum):
+    UPLOAD_TASK_BEGIN = auto()
+    PROCESSING_BEGIN = auto()
+    INITIAL_PROCESSING_COMPLETE = auto()
+    BATCH_PROCESSING_COMPLETE = auto()
+    PROCESSING_COMPLETE = auto()
+    NOTIFIED = auto()
+    FAILED = auto()

--- a/helpers/tests/unit/test_checkpoint_logger.py
+++ b/helpers/tests/unit/test_checkpoint_logger.py
@@ -8,8 +8,29 @@ import sentry_sdk
 from helpers.checkpoint_logger import (
     CheckpointLogger,
     _get_milli_timestamp,
+    failure_events,
     from_kwargs,
+    subflows,
+    success_events,
 )
+
+
+@failure_events("BRANCH_1_FAIL")
+@success_events("BRANCH_1_SUCCESS", "BRANCH_2_SUCCESS")
+@subflows(
+    ("first_checkpoint", "BEGIN", "CHECKPOINT"),
+    ("branch_1_to_finish", "BRANCH_1", "BRANCH_1_SUCCESS"),
+    ("total_branch_1_time", "BEGIN", "BRANCH_1_SUCCESS"),
+    ("total_branch_1_fail_time", "BEGIN", "BRANCH_1_FAIL"),
+)
+class DecoratedEnum(Enum):
+    BEGIN = auto()
+    CHECKPOINT = auto()
+    BRANCH_1 = auto()
+    BRANCH_1_FAIL = auto()
+    BRANCH_1_SUCCESS = auto()
+    BRANCH_2 = auto()
+    BRANCH_2_SUCCESS = auto()
 
 
 class TestEnum1(Enum):
@@ -194,3 +215,66 @@ class TestCheckpointLogger(unittest.TestCase):
         mock_sentry.assert_called_with("x", expected_duration, "milliseconds")
         assert kwargs["checkpoints_TestEnum1"][TestEnum1.A] == 1337
         assert kwargs["checkpoints_TestEnum1"][TestEnum1.B] == 9001
+
+    def test_success_failure_decorators(self):
+        for val in DecoratedEnum.__members__.values():
+            if val in [DecoratedEnum.BRANCH_1_SUCCESS, DecoratedEnum.BRANCH_2_SUCCESS]:
+                assert val.is_success()
+            else:
+                assert not val.is_success()
+
+            if val in [DecoratedEnum.BRANCH_1_FAIL]:
+                assert val.is_failure()
+            else:
+                assert not val.is_failure()
+
+    def test_subflows_decorator(self):
+        subflows = DecoratedEnum._subflows()
+
+        # No subflows end at these checkpoints
+        assert DecoratedEnum.BEGIN not in subflows
+        assert DecoratedEnum.BRANCH_1 not in subflows
+        assert DecoratedEnum.BRANCH_2 not in subflows
+
+        # `DecoratedEnum.CHECKPOINT` is not a terminal event, but we explicitly
+        # defined a subflow ending there.
+        checkpoint_subflows = subflows.get(DecoratedEnum.CHECKPOINT)
+        assert checkpoint_subflows is not None
+        assert len(checkpoint_subflows) == 1
+        assert checkpoint_subflows[0] == ("first_checkpoint", DecoratedEnum.BEGIN)
+
+        # All terminal events should have a subflow defined for them which
+        # begins at the flow's first event. `BRANCH_1_FAIL` has had this
+        # subflow provided by the user, so we should use the user's name.
+        branch_1_fail_subflows = subflows.get(DecoratedEnum.BRANCH_1_FAIL)
+        assert branch_1_fail_subflows is not None
+        assert len(branch_1_fail_subflows) == 1
+        assert branch_1_fail_subflows[0] == (
+            "total_branch_1_fail_time",
+            DecoratedEnum.BEGIN,
+        )
+
+        # All terminal events should have a subflow defined for them which
+        # begins at the flow's first event. `BRANCH_1_SUCCESS` has had this
+        # subflow provided by the user, so we should use the user's name.
+        # Also, `BRANCH_1_SUCCESS` is the end of a second subflow. Ensure that
+        # both subflows are present.
+        branch_1_success_subflows = subflows.get(DecoratedEnum.BRANCH_1_SUCCESS)
+        assert branch_1_success_subflows is not None
+        assert len(branch_1_success_subflows) == 2
+        assert ("total_branch_1_time", DecoratedEnum.BEGIN) in branch_1_success_subflows
+        assert (
+            "branch_1_to_finish",
+            DecoratedEnum.BRANCH_1,
+        ) in branch_1_success_subflows
+
+        # All terminal events should have a subflow defined for them which
+        # begins at the flow's first event. `BRANCH_2_SUCCESS` has not had this
+        # subflow provided by the user, so we should use the default name.
+        branch_2_success_subflows = subflows.get(DecoratedEnum.BRANCH_2_SUCCESS)
+        assert branch_2_success_subflows is not None
+        assert len(branch_2_success_subflows) == 1
+        assert branch_2_success_subflows[0] == (
+            "DecoratedEnum_BEGIN_to_BRANCH_2_SUCCESS",
+            DecoratedEnum.BEGIN,
+        )

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -255,13 +255,7 @@ class NotifyTask(BaseCodecovTask):
                 enriched_pull,
                 empty_upload,
             )
-            checkpoints_from_kwargs(UploadFlow, kwargs).log(
-                UploadFlow.NOTIFIED
-            ).submit_subflow(
-                "notification_latency",
-                UploadFlow.UPLOAD_TASK_BEGIN,
-                UploadFlow.NOTIFIED,
-            )
+            checkpoints_from_kwargs(UploadFlow, kwargs).log(UploadFlow.NOTIFIED)
             log.info(
                 "Notifications done",
                 extra=dict(

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -151,7 +151,7 @@ class UploadTask(BaseCodecovTask):
     ):
         # If we're a retry, kwargs will already have our first checkpoint.
         # If not, log it directly into kwargs so we can pass it onto other tasks
-        checkpoints_from_kwargs(UploadFlow, kwargs).log(
+        checkpoints = checkpoints_from_kwargs(UploadFlow, kwargs).log(
             UploadFlow.UPLOAD_TASK_BEGIN, kwargs=kwargs, ignore_repeat=True
         )
 
@@ -204,6 +204,7 @@ class UploadTask(BaseCodecovTask):
                     "Not retrying since there are likely no jobs that need scheduling",
                     extra=dict(commit=commitid, repoid=repoid),
                 )
+                checkpoints.log(UploadFlow.NO_PENDING_JOBS)
                 return {
                     "was_setup": False,
                     "was_updated": False,
@@ -214,6 +215,7 @@ class UploadTask(BaseCodecovTask):
                     "Not retrying since we already had too many retries",
                     extra=dict(commit=commitid, repoid=repoid),
                 )
+                checkpoints.log(UploadFlow.TOO_MANY_RETRIES)
                 return {
                     "was_setup": False,
                     "was_updated": False,

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -280,11 +280,7 @@ class UploadTask(BaseCodecovTask):
 
         try:
             checkpoints = checkpoints_from_kwargs(UploadFlow, kwargs)
-            checkpoints.log(UploadFlow.PROCESSING_BEGIN).submit_subflow(
-                "time_before_processing",
-                UploadFlow.UPLOAD_TASK_BEGIN,
-                UploadFlow.PROCESSING_BEGIN,
-            )
+            checkpoints.log(UploadFlow.PROCESSING_BEGIN)
         except ValueError as e:
             log.warning(f"CheckpointLogger failed to log/submit", extra=dict(error=e))
 
@@ -378,11 +374,6 @@ class UploadTask(BaseCodecovTask):
             )
         else:
             checkpoints.log(UploadFlow.INITIAL_PROCESSING_COMPLETE)
-            checkpoints.submit_subflow(
-                "initial_processing_duration",
-                UploadFlow.PROCESSING_BEGIN,
-                UploadFlow.INITIAL_PROCESSING_COMPLETE,
-            )
             log.info(
                 "Not scheduling task because there were no arguments were found on redis",
                 extra=dict(
@@ -461,11 +452,6 @@ class UploadTask(BaseCodecovTask):
             checkpoint_data = None
             if checkpoints:
                 checkpoints.log(UploadFlow.INITIAL_PROCESSING_COMPLETE)
-                checkpoints.submit_subflow(
-                    "initial_processing_duration",
-                    UploadFlow.PROCESSING_BEGIN,
-                    UploadFlow.INITIAL_PROCESSING_COMPLETE,
-                )
                 checkpoint_data = checkpoints.data
 
             finish_sig = upload_finisher_task.signature(

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -180,6 +180,9 @@ class UploadFinisherTask(BaseCodecovTask):
 
         if checkpoints:
             checkpoints.log(UploadFlow.PROCESSING_COMPLETE)
+            if not notifications_called:
+                checkpoints.log(UploadFlow.SKIPPING_NOTIFICATION)
+
         return {"notifications_called": notifications_called}
 
     def should_call_notifications(

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -57,11 +57,7 @@ class UploadFinisherTask(BaseCodecovTask):
     ):
         try:
             checkpoints = checkpoints_from_kwargs(UploadFlow, kwargs)
-            checkpoints.log(UploadFlow.BATCH_PROCESSING_COMPLETE).submit_subflow(
-                "batch_processing_duration",
-                UploadFlow.INITIAL_PROCESSING_COMPLETE,
-                UploadFlow.BATCH_PROCESSING_COMPLETE,
-            )
+            checkpoints.log(UploadFlow.BATCH_PROCESSING_COMPLETE)
         except ValueError as e:
             log.warning(f"CheckpointLogger failed to log/submit", extra=dict(error=e))
 
@@ -183,11 +179,7 @@ class UploadFinisherTask(BaseCodecovTask):
             commit.state = "skipped"
 
         if checkpoints:
-            checkpoints.log(UploadFlow.PROCESSING_COMPLETE).submit_subflow(
-                "total_processing_duration",
-                UploadFlow.PROCESSING_BEGIN,
-                UploadFlow.PROCESSING_COMPLETE,
-            )
+            checkpoints.log(UploadFlow.PROCESSING_COMPLETE)
         return {"notifications_called": notifications_called}
 
     def should_call_notifications(


### PR DESCRIPTION
this PR adds some features to `CheckpointLogger`:
- `@subflows()` decorator
  - define subflow metrics alongside the checkpoints themselves instead of peppered around the code
  - auto-submit a pre-defined subflow when you log its end checkpoint
- `@success_events()` and `@failure_events()` decorators
  - designate "completed successfully" and "completed with error" terminal checkpoints for your flow
  - automatically create a subflow from the first checkpoint in a flow to each of these terminal checkpoints (if one wasn't manually created)
- `@reliability_counters` decorator
  - increment a counter for each checkpoint logged (`{flow}.events.{checkpoint}`)
  - increment special counters for reliability metrics
    - `{flow}.total.begun` when the first checkpoint is logged
    - `{flow}.total.failed` when any `@failure_events()` checkpoint is logged
    - `{flow}.total.succeeded` when any `@success_events()` checkpoint is logged
    - `{flow}.total.ended` when any terminal checkpoint (success of failure) is logged

some reliability metrics this enables:
- `{flow}.total.ended / {flow}.total.begun`: should be 1, but if it isn't that suggests there are exit conditions that you haven't instrumented
- `{flow}.total.succeeded / {flow}.total.begun`: success rate. denominator maybe could be `ended` instead
- `{flow}.total.failed / {flow}.total.begun`: failure rate. denominator maybe could be `ended` instead
- `{flow}.events.SPECIFIC_ERROR / {flow}.total.failed`: % of failures caused by `SPECIFIC_ERROR`

this PR also instruments more of the exit conditions of the upload flow. there are more non-error exit conditions (no pending jobs, not sending notifs, stale PR head) as well as error exit conditions (no valid bot, git service errors, too many retries...)

sentry is still the backend for subflow durations and statsd is still the backend for the reliability counters, but i'm looking to change both in future iterations. 

### before
```
class Foo(Enum):
    BEGIN = auto()
    CHECKPOINT = auto
    SUCCESS = auto()

checkpoints = checkpoints_from_kwargs(Foo, kwargs).log(Foo.BEGIN)
...
# explicitly adds `first_checkpoint` metric to sentry transaction
# that's all
checkpoints.log(Foo.CHECKPOINT).submit_subflow("first_checkpoints", Foo.BEGIN, Foo.CHECKPOINT)
...
```
the checkpoints are defined in one place, but the relationships between them (the subflows) are peppered throughout the code. 

### now
```
@success_events('SUCCESS')
@failure_events('FAILURE')
@subflows(
    ('time_to_checkpoint', 'BEGIN', 'SUCCESS')
    ('time_to_success', 'BEGIN', 'SUCCESS'),
    # implicitly creates a subflow for all terminal metrics
    # ('Foo_BEGIN_to_FAILURE', 'BEGIN', 'FAILURE')
)
@reliability_counters
class Foo(Enum):
    BEGIN = auto()
    CHECKPOINT = auto()
    FAILURE = auto()
    SUCCESS = auto()

# implicitly increments `Foo.events.BEGIN`
# implicitly increments `Foo.total.begun`
checkpoints = checkpoints_from_kwargs(Foo, kwargs).log(Foo.BEGIN)
...
# implicitly increments `Foo.events.CHECKPOINT`
# implicitly adds the pre-defined `time_to_checkpoint` metric to sentry transaction
checkpoints.log(Foo.CHECKPOINT)
...
# implicitly increments `Foo.events.FAILURE`
# implicitly increments `Foo.total.failed`
# implicitly increments `Foo.total.ended`
# implicitly adds the implicitly-defined `Foo_BEGIN_to_FAILURE` metric to sentry transaction
checkpoints.log(Foo.FAILURE)
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.