### PR TITLE
fix bug when there's changed files, but none have missing cov lines

### DIFF
--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -3569,6 +3569,85 @@ class TestFileSectionWriter(object):
         ]
 
     @pytest.mark.asyncio
+    async def test_filesection_hide_project_cov_with_changed_files_but_no_missing_lines(
+        self, sample_comparison, mocker
+    ):
+        section_writer = FileSectionWriter(
+            sample_comparison.head.commit.repository,
+            "layout",
+            show_complexity=False,
+            settings={"hide_project_coverage": True},
+            current_yaml={},
+        )
+        changes = [
+            Change(
+                path="unrelated.py",
+                in_diff=False,
+                totals=ReportTotals(
+                    files=0,
+                    lines=0,
+                    hits=-3,
+                    misses=2,
+                    partials=0,
+                    coverage=-43.333330000000004,
+                    branches=0,
+                    methods=0,
+                    messages=0,
+                    sessions=0,
+                    complexity=0,
+                    complexity_total=0,
+                    diff=0,
+                ),
+            ),
+            Change(path="added.py", new=True, in_diff=None, old_path=None, totals=None),
+        ]
+        lines = list(
+            await section_writer.write_section(
+                sample_comparison,
+                {
+                    "files": {
+                        "file_1.go": {
+                            "type": "added",
+                            "totals": ReportTotals(
+                                lines=3,
+                                hits=3,
+                                misses=0,
+                                coverage=100.00,
+                                branches=0,
+                                methods=0,
+                                messages=0,
+                                sessions=0,
+                                complexity=0,
+                                complexity_total=0,
+                                diff=0,
+                            ),
+                        },
+                        "file_2.py": {
+                            "type": "added",
+                            "totals": ReportTotals(
+                                lines=3,
+                                hits=3,
+                                misses=0,
+                                partials=0,
+                                coverage=-100.00,
+                                branches=0,
+                                methods=0,
+                                messages=0,
+                                sessions=0,
+                                complexity=0,
+                                complexity_total=0,
+                                diff=0,
+                            ),
+                        },
+                    }
+                },
+                changes,
+                links={"pull": "pull.link"},
+            )
+        )
+        assert lines == []
+
+    @pytest.mark.asyncio
     async def test_filesection_hide_project_cov_no_files_changed(
         self, sample_comparison, mocker
     ):


### PR DESCRIPTION
<!-- Describe your PR here. -->
sometimes a PR has changed files, but all changed files has patch coverage 100%. Currently, we have a bug that prints out the header without the printing anything in the table. In this case, we don't want anything to be printed out, as we only care about files with patch coverage < 100% 


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.