### PR TITLE
fix: Archive task name

### DIFF
--- a/tasks/backfill_commit_data_to_storage.py
+++ b/tasks/backfill_commit_data_to_storage.py
@@ -26,7 +26,7 @@ class BackfillResult(TypedDict):
 
 
 class BackfillCommitDataToStorageTask(BaseCodecovTask):
-    name = f"app.tasks.{TaskConfigGroup.archive}.BackfillCommitDataToStorage"
+    name = f"app.tasks.{TaskConfigGroup.archive.value}.BackfillCommitDataToStorage"
 
     async def run_async(
         self,


### PR DESCRIPTION
This was previously resulting in the task name of `app.tasks.TaskGroupConfig.archive.BackfillCommitDataToStorage`