### PR TITLE
Add templates using jinja2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -7,6 +7,7 @@ coverage
 factory-boy
 google-cloud-storage>=2.10.0
 httpx
+jinja2
 analytics-python==1.3.0b1
 lxml>=4.9.1
 mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -145,6 +145,8 @@ idna==2.10
     #   yarl
 iniconfig==1.1.1
     # via pytest
+jinja2==3.1.2
+    # via -r requirements.in
 jmespath==0.10.0
     # via
     #   boto3
@@ -153,6 +155,8 @@ kombu==5.2.4
     # via celery
 lxml==4.9.1
     # via -r requirements.in
+markupsafe==2.1.3
+    # via jinja2
 minio==7.1.13
     # via shared
 mmh3==4.0.1

--- a/services/template.py
+++ b/services/template.py
@@ -1,10 +1,6 @@
 from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
 
 
-def get_template_service():
-    return TemplateService()
-
-
 class TemplateService:
     def __init__(self):
         # this loads the templates from the templates directory in this repository since it's looking for a dir named `templates` next to app.py
@@ -14,6 +10,6 @@ class TemplateService:
             undefined=StrictUndefined,
         )
 
-    def get_template(self, name, **kwargs):
+    def get_template(self, name):
         template = self.env.get_template(f"{name}")
-        return template.render(**kwargs)
+        return template

--- a/services/template.py
+++ b/services/template.py
@@ -9,12 +9,13 @@ class TemplateService:
         return cls.env is not None
 
     def __init__(self):
-        # this loads the templates from the templates directory in this repository since it's looking for a dir named `templates` next to app.py
-        TemplateService.env = Environment(
-            loader=PackageLoader("app"),
-            autoescape=select_autoescape(),
-            undefined=StrictUndefined,
-        )
+        if TemplateService.env is None:
+            # this loads the templates from the templates directory in this repository since it's looking for a dir named `templates` next to app.py
+            TemplateService.env = Environment(
+                loader=PackageLoader("app"),
+                autoescape=select_autoescape(),
+                undefined=StrictUndefined,
+            )
 
     def get_template(self, name):
         template = TemplateService.env.get_template(f"{name}")

--- a/services/template.py
+++ b/services/template.py
@@ -1,0 +1,28 @@
+from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
+
+_template_service = None
+
+
+def get_template_service():
+    return _get_cached_template_service()
+
+
+def _get_cached_template_service():
+    global _template_service
+    if _template_service is None:
+        _template_service = TemplateService()
+    return _template_service
+
+
+class TemplateService:
+    def __init__(self):
+        # this loads the templates from the templates directory in this repository since it's looking for a dir named `templates` next to app.py
+        self.env = Environment(
+            loader=PackageLoader("app"),
+            autoescape=select_autoescape(),
+            undefined=StrictUndefined,
+        )
+
+    def get_template(self, name, **kwargs):
+        template = self.env.get_template(f"{name}")
+        return template.render(**kwargs)

--- a/services/template.py
+++ b/services/template.py
@@ -2,14 +2,20 @@ from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescap
 
 
 class TemplateService:
+    env = None
+
+    @classmethod
+    def loaded(cls):
+        return cls.env is not None
+
     def __init__(self):
         # this loads the templates from the templates directory in this repository since it's looking for a dir named `templates` next to app.py
-        self.env = Environment(
+        TemplateService.env = Environment(
             loader=PackageLoader("app"),
             autoescape=select_autoescape(),
             undefined=StrictUndefined,
         )
 
     def get_template(self, name):
-        template = self.env.get_template(f"{name}")
+        template = TemplateService.env.get_template(f"{name}")
         return template

--- a/services/template.py
+++ b/services/template.py
@@ -1,17 +1,8 @@
 from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescape
 
-_template_service = None
-
 
 def get_template_service():
-    return _get_cached_template_service()
-
-
-def _get_cached_template_service():
-    global _template_service
-    if _template_service is None:
-        _template_service = TemplateService()
-    return _template_service
+    return TemplateService()
 
 
 class TemplateService:

--- a/services/template.py
+++ b/services/template.py
@@ -4,10 +4,6 @@ from jinja2 import Environment, PackageLoader, StrictUndefined, select_autoescap
 class TemplateService:
     env = None
 
-    @classmethod
-    def loaded(cls):
-        return cls.env is not None
-
     def __init__(self):
         if TemplateService.env is None:
             # this loads the templates from the templates directory in this repository since it's looking for a dir named `templates` next to app.py

--- a/services/tests/test_template.py
+++ b/services/tests/test_template.py
@@ -1,5 +1,5 @@
 import pytest
-from jinja2.exceptions import UndefinedError, TemplateNotFound
+from jinja2.exceptions import TemplateNotFound, UndefinedError
 
 from services.template import TemplateService
 
@@ -7,16 +7,14 @@ from services.template import TemplateService
 class TestTemplate(object):
     def test_get_template(self):
         ts = TemplateService()
-        populated_template = ts.get_template(
-            "test.txt", **dict(username="test_username")
-        )
+        template = ts.get_template("test.txt")
+        populated_template = template.render(**dict(username="test_username"))
         assert populated_template == "Test template test_username"
 
     def test_get_template_html(self):
         ts = TemplateService()
-        populated_template = ts.get_template(
-            "test.html", **dict(username="test_username")
-        )
+        template = ts.get_template("test.html")
+        populated_template = template.render(**dict(username="test_username"))
         expected_result = """<!DOCTYPE html>
 <html lang="en">
 
@@ -40,8 +38,9 @@ class TestTemplate(object):
 
     def test_get_template_no_kwargs(self):
         ts = TemplateService()
+        template = ts.get_template("test.txt")
         with pytest.raises(UndefinedError):
-            ts.get_template("test.txt")
+            template.render(not_username="")
 
     def test_get_template_non_existing(self):
         ts = TemplateService()

--- a/services/tests/test_template.py
+++ b/services/tests/test_template.py
@@ -1,0 +1,49 @@
+import pytest
+from jinja2.exceptions import UndefinedError
+
+from services.template import get_template_service
+
+
+class TestTemplate(object):
+    def test_idempotent_service(self):
+        first = get_template_service()
+        second = get_template_service()
+        assert id(first) == id(second)
+
+    def test_get_template(self):
+        ts = get_template_service()
+        populated_template = ts.get_template(
+            "test.txt", **dict(username="test_username")
+        )
+        assert populated_template == "Test template test_username"
+
+    def test_get_template_html(self):
+        ts = get_template_service()
+        populated_template = ts.get_template(
+            "test.html", **dict(username="test_username")
+        )
+        expected_result = """<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+    <p>
+        test template test_username
+    </p>
+</body>
+
+</html>"""
+        for expected_line, actual_line in zip(
+            expected_result.splitlines(), populated_template.splitlines()
+        ):
+            assert expected_line == actual_line
+
+    def test_get_template_no_kwargs(self):
+        ts = get_template_service()
+        with pytest.raises(UndefinedError):
+            ts.get_template("test.txt")

--- a/services/tests/test_template.py
+++ b/services/tests/test_template.py
@@ -5,11 +5,6 @@ from services.template import get_template_service
 
 
 class TestTemplate(object):
-    def test_idempotent_service(self):
-        first = get_template_service()
-        second = get_template_service()
-        assert id(first) == id(second)
-
     def test_get_template(self):
         ts = get_template_service()
         populated_template = ts.get_template(

--- a/services/tests/test_template.py
+++ b/services/tests/test_template.py
@@ -1,19 +1,19 @@
 import pytest
-from jinja2.exceptions import UndefinedError
+from jinja2.exceptions import UndefinedError, TemplateNotFound
 
-from services.template import get_template_service
+from services.template import TemplateService
 
 
 class TestTemplate(object):
     def test_get_template(self):
-        ts = get_template_service()
+        ts = TemplateService()
         populated_template = ts.get_template(
             "test.txt", **dict(username="test_username")
         )
         assert populated_template == "Test template test_username"
 
     def test_get_template_html(self):
-        ts = get_template_service()
+        ts = TemplateService()
         populated_template = ts.get_template(
             "test.html", **dict(username="test_username")
         )
@@ -39,6 +39,11 @@ class TestTemplate(object):
             assert expected_line == actual_line
 
     def test_get_template_no_kwargs(self):
-        ts = get_template_service()
+        ts = TemplateService()
         with pytest.raises(UndefinedError):
             ts.get_template("test.txt")
+
+    def test_get_template_non_existing(self):
+        ts = TemplateService()
+        with pytest.raises(TemplateNotFound):
+            ts.get_template("nonexistent")

--- a/templates/test.html
+++ b/templates/test.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body>
+    <p>
+        test template {{ username }}
+    </p>
+</body>
+
+</html>

--- a/templates/test.txt
+++ b/templates/test.txt
@@ -1,0 +1,1 @@
+Test template {{ username }}


### PR DESCRIPTION
This commit creates the TemplateService that uses
jinja to get and render templates.

This TemplateService provides the get_template method to get a rendered template. It takes the file name of the template as an arg and the template variables as the kwargs.

Templates should be added into the templates directory at the top level of the repository. This commit creates two example templates.