### PR TITLE
fix: always modify line to account for special labels

### DIFF
--- a/services/report/report_builder.py
+++ b/services/report/report_builder.py
@@ -81,9 +81,7 @@ class ReportBuilderSession(object):
         Returns:
             Report: The legacy report desired
         """
-        if self._present_labels and self._present_labels != {
-            SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER
-        }:
+        if self._present_labels:
             for file in self._report:
                 for line_number, line in file.lines:
                     self._possibly_modify_line_to_account_for_special_labels(
@@ -111,7 +109,7 @@ class ReportBuilderSession(object):
                 for datapoint in line.datapoints
             ]
             new_datapoints = [item for dp_list in new_datapoints for item in dp_list]
-            if new_datapoints != line.datapoints:
+            if new_datapoints and new_datapoints != line.datapoints:
                 # A check to avoid unnecessary replacement
                 file[line_number] = dataclasses.replace(
                     line,
@@ -121,7 +119,6 @@ class ReportBuilderSession(object):
                             x.sessionid,
                             x.coverage,
                             x.coverage_type,
-                            x.labels,
                         ),
                     ),
                 )

--- a/services/report/tests/unit/test_report_builder.py
+++ b/services/report/tests/unit/test_report_builder.py
@@ -150,6 +150,119 @@ def test_report_builder_session(mocker):
     ]
 
 
+def test_report_builder_session_only_all_labels(mocker):
+    current_yaml, sessionid, ignored_lines, path_fixer = (
+        {},
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+        mocker.MagicMock(),
+    )
+    filepath = "filepath"
+    builder = ReportBuilder(current_yaml, sessionid, ignored_lines, path_fixer)
+    builder_session = builder.create_report_builder_session(filepath)
+    first_file = ReportFile("filename.py")
+    first_file.append(2, ReportLine.create(coverage=0))
+    first_file.append(
+        3,
+        ReportLine.create(
+            coverage=0,
+            datapoints=[
+                CoverageDatapoint(
+                    sessionid=0,
+                    coverage=1,
+                    coverage_type=None,
+                    labels=[SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER],
+                )
+            ],
+        ),
+    )
+    first_file.append(
+        10,
+        ReportLine.create(
+            coverage=1,
+            type=None,
+            sessions=[
+                (
+                    LineSession(
+                        id=0,
+                        coverage=1,
+                    )
+                )
+            ],
+            datapoints=[
+                CoverageDatapoint(
+                    sessionid=0,
+                    coverage=1,
+                    coverage_type=None,
+                    labels=[SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER],
+                ),
+                CoverageDatapoint(
+                    sessionid=0,
+                    coverage=1,
+                    coverage_type=None,
+                    labels=None,
+                ),
+            ],
+            complexity=None,
+        ),
+    )
+    builder_session.append(first_file)
+    final_report = builder_session.output_report()
+    assert final_report.files == ["filename.py"]
+    assert sorted(final_report.get("filename.py").lines) == [
+        (
+            2,
+            ReportLine.create(
+                coverage=0, type=None, sessions=None, datapoints=None, complexity=None
+            ),
+        ),
+        (
+            3,
+            ReportLine.create(
+                coverage=0,
+                type=None,
+                sessions=None,
+                datapoints=[
+                    CoverageDatapoint(
+                        sessionid=0,
+                        coverage=1,
+                        coverage_type=None,
+                        labels=["Th2dMtk4M_codecov"],
+                    ),
+                ],
+                complexity=None,
+            ),
+        ),
+        (
+            10,
+            ReportLine.create(
+                coverage=1,
+                type=None,
+                sessions=[
+                    LineSession(
+                        id=0, coverage=1, branches=None, partials=None, complexity=None
+                    )
+                ],
+                datapoints=[
+                    CoverageDatapoint(
+                        sessionid=0,
+                        coverage=1,
+                        coverage_type=None,
+                        labels=["Th2dMtk4M_codecov"],
+                    ),
+                    CoverageDatapoint(
+                        sessionid=0,
+                        coverage=1,
+                        coverage_type=None,
+                        labels=None,
+                    ),
+                ],
+                complexity=None,
+            ),
+        ),
+    ]
+
+
 def test_report_builder_session_create_line(mocker):
     current_yaml, sessionid, ignored_lines, path_fixer = (
         {


### PR DESCRIPTION
fixes https://l.codecov.dev/fYqS4O

There was a situation where you only get `SpecialLabelsEnum` and so we were not calling
`_possibly_modify_line_to_account_for_special_labels` (which is the thing that transforms
the special label ENUM into a STR - so we can save it in the DB)

Now this is giving an error, so we need to fix it. These changes do fix it.
But why was that check there in the first place?

I can only theorize reasons... it might be to save processing time (since changing every line of
every file in the report is a lot of lines), and this condition simply slipped. OR it might indicate
some config error in the ATS process - e.g. we should never just receive the global label.

I suppose that we might have introduced this condition afterwards because when the code was written
it was impossible the case of uploading without running tests. I think now it's at least possible.

In any case I believe this fix should hold and we're not gonna have more problems because of it later on.

But wait... the actual error is `TypeError: Object of type SpecialLabelsEnum is not JSON serializable`,
why didn't you added that to `shared.utils.ReportEncoder.ReportEncoder`?

You are correct about that, little grasshopper. My reasoning was essencially that `SpecialLabelsEnum`
is defined in the worker level. We obviously have the logic to modify the labels in place there so
they never trickle down to `shared`.

I thought it more logical to handle `SpecialLabelsEnum` in the worker for all cases.
I was opposed to moving it to `shared`, and I think just adding `Enum` in general to the
`ReportEncoder` is too general.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.