### PR TITLE
Fix cobertura XML parsing

### DIFF
--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -125,7 +125,7 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                     if type(coverage) is str and len(conditions) < int(
                         total_conditions
                     ):
-                        # <line number="23" hits="0" branch="true" condition-coverage="0% (covered/total)">
+                        # <line number="23" hits="0" branch="true" condition-coverage="0% (0/2)">
                         #     <conditions>
                         #         <condition number="0" type="jump" coverage="0%"/>
                         #     </conditions>

--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -121,19 +121,25 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                         for _ in line.iter("condition")
                         if _.attrib.get("coverage") != "100%"
                     ]
-                    if (
-                        type(coverage) is str
-                        and coverage[0] == "0"
-                        and len(conditions) < int(coverage.split("/")[1])
+                    if type(coverage) is str and len(conditions) < int(
+                        coverage.split("/")[1]
                     ):
                         # <line number="23" hits="0" branch="true" condition-coverage="0% (0/2)">
                         #     <conditions>
                         #         <condition number="0" type="jump" coverage="0%"/>
                         #     </conditions>
                         # </line>
+
+                        # <line number="3" hits="0" branch="true" condition-coverage="50% (1/2)"/>
+
                         conditions.extend(
                             map(
-                                str, range(len(conditions), int(coverage.split("/")[1]))
+                                str,
+                                range(
+                                    len(conditions),
+                                    int(coverage.split("/")[1])
+                                    - int(coverage.split("/")[0]),
+                                ),
                             )
                         )
                     if conditions:

--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -97,7 +97,7 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                 branch = _line.get("branch", "")
                 condition_coverage = _line.get("condition-coverage", "")
                 if (
-                    branch == "true"
+                    branch.lower() == "true"
                     and re.search("\(\d+\/\d+\)", condition_coverage) is not None
                 ):
                     coverage = condition_coverage.split(" ", 1)[1][1:-1]  # 1/2

--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -121,29 +121,31 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                         for _ in line.iter("condition")
                         if _.attrib.get("coverage") != "100%"
                     ]
-                    covered_conditions, total_conditions = coverage.split("/")
-                    if type(coverage) is str and len(conditions) < int(
-                        total_conditions
-                    ):
-                        # <line number="23" hits="0" branch="true" condition-coverage="0% (0/2)">
-                        #     <conditions>
-                        #         <condition number="0" type="jump" coverage="0%"/>
-                        #     </conditions>
-                        # </line>
+                    if type(coverage) is str:
+                        covered_conditions, total_conditions = coverage.split("/")
+                        if len(conditions) < int(total_conditions):
+                            # <line number="23" hits="0" branch="true" condition-coverage="0% (0/2)">
+                            #     <conditions>
+                            #         <condition number="0" type="jump" coverage="0%"/>
+                            #     </conditions>
+                            # </line>
 
-                        # <line number="3" hits="0" branch="true" condition-coverage="50% (1/2)"/>
+                            # <line number="3" hits="0" branch="true" condition-coverage="50% (1/2)"/>
 
-                        coverage_difference = int(total_conditions) - int(
-                            covered_conditions
-                        )
-                        missing_condition_elements = range(
-                            len(conditions), coverage_difference
-                        )
-                        conditions.extend(
-                            [str(condition) for condition in missing_condition_elements]
-                        )
-                    if conditions:
-                        missing_branches = conditions
+                            coverage_difference = int(total_conditions) - int(
+                                covered_conditions
+                            )
+                            missing_condition_elements = range(
+                                len(conditions), coverage_difference
+                            )
+                            conditions.extend(
+                                [
+                                    str(condition)
+                                    for condition in missing_condition_elements
+                                ]
+                            )
+                        if conditions:
+                            missing_branches = conditions
                 _file.append(
                     ln,
                     report_builder_session.create_coverage_line(

--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -121,10 +121,11 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                         for _ in line.iter("condition")
                         if _.attrib.get("coverage") != "100%"
                     ]
+                    covered_conditions, total_conditions = coverage.split("/")
                     if type(coverage) is str and len(conditions) < int(
-                        coverage.split("/")[1]
+                        total_conditions
                     ):
-                        # <line number="23" hits="0" branch="true" condition-coverage="0% (0/2)">
+                        # <line number="23" hits="0" branch="true" condition-coverage="0% (covered/total)">
                         #     <conditions>
                         #         <condition number="0" type="jump" coverage="0%"/>
                         #     </conditions>
@@ -132,15 +133,14 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
 
                         # <line number="3" hits="0" branch="true" condition-coverage="50% (1/2)"/>
 
+                        coverage_difference = int(total_conditions) - int(
+                            covered_conditions
+                        )
+                        missing_condition_elements = range(
+                            len(conditions), coverage_difference
+                        )
                         conditions.extend(
-                            map(
-                                str,
-                                range(
-                                    len(conditions),
-                                    int(coverage.split("/")[1])
-                                    - int(coverage.split("/")[0]),
-                                ),
-                            )
+                            [str(condition) for condition in missing_condition_elements]
                         )
                     if conditions:
                         missing_branches = conditions

--- a/services/report/languages/tests/unit/test_cobertura.py
+++ b/services/report/languages/tests/unit/test_cobertura.py
@@ -49,6 +49,7 @@ xml = """<?xml version="1.0" ?>
                         </line>
                         <line branch="true" condition-coverage="0%% (0/2)" hits="1" missing-branches="exit,exit,exit" number="7"/>
                         <line branch="true" condition-coverage="50%%" hits="1" number="8"/>
+                        <line number="9" hits="0" branch="true" condition-coverage="50%% (1/2)"/>
                     </lines>
                 </class>
                 <!-- Scala coverage -->
@@ -130,6 +131,7 @@ class TestCobertura(BaseTestCase):
                         None,
                     ),
                     (8, 1, None, [[0, 1, None, None, None]], None, None),
+                    (9, "1/2", "b", [[0, "1/2", ["0"], None, None]], None, None),
                 ],
             },
             "report": {
@@ -145,9 +147,9 @@ class TestCobertura(BaseTestCase):
                     ],
                     "source": [
                         0,
-                        [0, 8, 3, 2, 3, "37.50000", 6, 0, 0, 0, 0, 0, 0],
+                        [0, 9, 3, 2, 4, "33.33333", 7, 0, 0, 0, 0, 0, 0],
                         {
-                            "0": [0, 8, 3, 2, 3, "37.50000", 6],
+                            "0": [0, 9, 3, 2, 4, "33.33333", 7],
                             "meta": {"session_count": 1},
                         },
                         None,
@@ -159,15 +161,15 @@ class TestCobertura(BaseTestCase):
                 "C": 0,
                 "M": 0,
                 "N": 0,
-                "b": 7,
-                "c": "45.45455",
+                "b": 8,
+                "c": "41.66667",
                 "d": 1,
                 "diff": None,
                 "f": 2,
                 "h": 5,
                 "m": 3,
-                "n": 11,
-                "p": 3,
+                "n": 12,
+                "p": 4,
                 "s": 0,
             },
         }
@@ -193,7 +195,7 @@ class TestCobertura(BaseTestCase):
         )
         processed_report = self.convert_report_to_better_readable(report)
         assert len(processed_report["archive"]["file"]) == 3
-        assert processed_report["totals"]["c"] == "45.45455"
+        assert processed_report["totals"]["c"] == "41.66667"
 
     @pytest.mark.parametrize(
         "date",


### PR DESCRIPTION
This PR changes the Cobertura XML parsing to do case-insensitive handling of the branch attribute on a line, and to handle the case where both the condition elements and missing branches attributes don't exist on a partially covered line.

Fixes: https://github.com/codecov/feedback/issues/61
Fixes: https://github.com/codecov/feedback/issues/67