### PR TITLE
Fix plan_activated_users count for an installation

### DIFF
--- a/services/license.py
+++ b/services/license.py
@@ -55,7 +55,7 @@ def get_installation_plan_activated_users(db_session) -> list:
     query_string = text(
         """
                         WITH all_plan_activated_users AS (
-                            SELECT 
+                            SELECT DISTINCT
                                 UNNEST(o.plan_activated_users) AS activated_owner_id
                             FROM owners o
                         ) SELECT count(*) as count

--- a/services/tests/test_activation.py
+++ b/services/tests/test_activation.py
@@ -92,8 +92,9 @@ class TestActivationServiceTestCase(object):
     def test_activate_user_failure_for_enterprise_pr_billing_no_seats(
         self, request, dbsession, mock_configuration, mocker, with_sql_functions
     ):
+        mocker.patch("services.license.is_enterprise", return_value=True)
+        mocker.patch("services.license._get_now", return_value=datetime(2020, 4, 2))
 
-        mocker.patch("helpers.environment.is_enterprise", return_value=True)
         # Create two orgs to ensure our seat availability checking works across
         # multiple organizations.
         org = OwnerFactory.create(

--- a/services/tests/test_activation.py
+++ b/services/tests/test_activation.py
@@ -62,7 +62,6 @@ class TestActivationServiceTestCase(object):
     def test_activate_user_success_for_enterprise_pr_billing(
         self, request, dbsession, mocker, mock_configuration, with_sql_functions
     ):
-
         mocker.patch("services.license.is_enterprise", return_value=True)
         mocker.patch("services.license._get_now", return_value=datetime(2020, 4, 2))
 
@@ -88,6 +87,51 @@ class TestActivationServiceTestCase(object):
         assert was_activated is True
         dbsession.commit()
         assert user.ownerid in org.plan_activated_users
+
+    def test_activate_user_success_user_org_overlap(
+        self, request, dbsession, mock_configuration, mocker, with_sql_functions
+    ):
+        mocker.patch("services.license.is_enterprise", return_value=True)
+        mocker.patch("services.license._get_now", return_value=datetime(2020, 4, 2))
+
+        # Create two orgs to ensure our seat availability checking works across
+        # multiple organizations.
+        org = OwnerFactory.create(
+            service="github",
+            oauth_token=None,
+            plan_activated_users=list(range(15, 20)),
+            plan_auto_activate=True,
+        )
+        dbsession.add(org)
+        dbsession.flush()
+
+        org_second = OwnerFactory.create(
+            service="github",
+            oauth_token=None,
+            plan_activated_users=list(
+                range(
+                    20,
+                    24,
+                )
+            ),
+            plan_auto_activate=True,
+        )
+        dbsession.add(org_second)
+        dbsession.flush()
+
+        encrypted_license = "wxWEJyYgIcFpi6nBSyKQZQeaQ9Eqpo3SXyUomAqQOzOFjdYB3A8fFM1rm+kOt2ehy9w95AzrQqrqfxi9HJIb2zLOMOB9tSy52OykVCzFtKPBNsXU/y5pQKOfV7iI3w9CHFh3tDwSwgjg8UsMXwQPOhrpvl2GdHpwEhFdaM2O3vY7iElFgZfk5D9E7qEnp+WysQwHKxDeKLI7jWCnBCBJLDjBJRSz0H7AfU55RQDqtTrnR+rsLDHOzJ80/VxwVYhb"
+        mock_configuration.params["setup"]["enterprise_license"] = encrypted_license
+        mock_configuration.params["setup"]["codecov_url"] = "https://codecov.mysite.com"
+
+        user = OwnerFactory.create_from_test_request(request)
+        dbsession.add(org_second)
+        dbsession.add(user)
+        dbsession.flush()
+
+        was_activated = activate_user(dbsession, org_second.ownerid, user.ownerid)
+        assert was_activated is True
+        dbsession.commit()
+        assert user.ownerid in org_second.plan_activated_users
 
     def test_activate_user_failure_for_enterprise_pr_billing_no_seats(
         self, request, dbsession, mock_configuration, mocker, with_sql_functions

--- a/services/tests/test_activation.py
+++ b/services/tests/test_activation.py
@@ -108,13 +108,13 @@ class TestActivationServiceTestCase(object):
         org_second = OwnerFactory.create(
             service="github",
             oauth_token=None,
-            plan_activated_users=list(range(2, 7)),
+            plan_activated_users=list(range(2, 8)),
             plan_auto_activate=True,
         )
         dbsession.add(org_second)
         dbsession.flush()
 
-        assert get_installation_plan_activated_users(dbsession)[0][0] == 6
+        assert get_installation_plan_activated_users(dbsession)[0][0] == 7
 
         # {'company': 'Test Company', 'expires': '2021-01-01 00:00:00', 'url': 'https://codecov.mysite.com', 'trial': False, 'users': 10, 'repos': None, 'pr_billing': True}
         encrypted_license = "wxWEJyYgIcFpi6nBSyKQZQeaQ9Eqpo3SXyUomAqQOzOFjdYB3A8fFM1rm+kOt2ehy9w95AzrQqrqfxi9HJIb2zLOMOB9tSy52OykVCzFtKPBNsXU/y5pQKOfV7iI3w9CHFh3tDwSwgjg8UsMXwQPOhrpvl2GdHpwEhFdaM2O3vY7iElFgZfk5D9E7qEnp+WysQwHKxDeKLI7jWCnBCBJLDjBJRSz0H7AfU55RQDqtTrnR+rsLDHOzJ80/VxwVYhb"
@@ -134,7 +134,7 @@ class TestActivationServiceTestCase(object):
         assert was_activated is True
         dbsession.commit()
 
-        assert get_installation_plan_activated_users(dbsession)[0][0] == 7
+        assert get_installation_plan_activated_users(dbsession)[0][0] == 8
 
     def test_activate_user_failure_for_enterprise_pr_billing_no_seats(
         self, request, dbsession, mock_configuration, mocker, with_sql_functions


### PR DESCRIPTION
this PR changes the behaviour of `get_installation_plan_activated_users` to no longer count one user in multiple orgs as multiple users to match the behaviour in the API

Fixes: https://github.com/codecov/worker/issues/121