### PR TITLE
fix: better handle missing static analysis info

### DIFF
--- a/services/static_analysis/__init__.py
+++ b/services/static_analysis/__init__.py
@@ -132,6 +132,17 @@ class StaticAnalysisComparisonService(object):
             )
             if not head_analysis_file_data and not base_analysis_file_data:
                 return None
+            if head_analysis_file_data is None or base_analysis_file_data is None:
+                log.warning(
+                    "Failed to load snapshot for file. Fallback to all lines in the file",
+                    extra=dict(
+                        file_path=change.after_filepath,
+                        is_missing_head=(head_analysis_file_data is None),
+                        is_missing_base=(base_analysis_file_data is None),
+                    ),
+                )
+                return {"all": True, "lines": None}
+
             for base_line in change.lines_only_on_base:
                 corresponding_exec_line = (
                     base_analysis_file_data.get_corresponding_executable_line(base_line)


### PR DESCRIPTION
Fix codecov/engineering-team#650

Recently we made changes to static analysis process of the CLI so it doesn't fails completely
if there are issues analysing a file or uploading it to GCS.

I think this inadvertedly broke the expectation of label analysis that all files in the static analysis
are uploaded and ready to be used. Or some other misterious bug is causing some snapshots to be missing

This is causing issues that the label analysis is not processing correctly. So we are now guarding
against missing snapshots in HEAD or BASE.

Sadly for ats, it only as good as the data it has. And being conservative (and safe) is important to us.
So if we can't make an educated guess about a change, the procedure so far is to just run everything.
That's the fallback, assume the entire file is compromised and needs to be tested again

closes codecov/engineering-team#650

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.