### PR TITLE
Update repo updatestamp in upload task

### DIFF
--- a/database/tests/factories/core.py
+++ b/database/tests/factories/core.py
@@ -71,6 +71,7 @@ class RepositoryFactory(Factory):
 
     owner = factory.SubFactory(OwnerFactory)
     bot = None
+    updatestamp = factory.LazyAttribute(lambda o: datetime.now())
 
 
 class BranchFactory(Factory):

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -122,6 +122,8 @@ class TestUploadTaskIntegration(object):
         )
         dbsession.add(commit)
         dbsession.flush()
+        dbsession.refresh(commit)
+        repo_updatestamp = commit.repository.updatestamp
         mock_redis.lists[
             f"uploads/{commit.repoid}/{commit.commitid}"
         ] = jsonified_redis_queue
@@ -139,6 +141,7 @@ class TestUploadTaskIntegration(object):
         assert commit.parent_commit_id is None
         assert commit.report is not None
         assert commit.report.details is not None
+        assert commit.repository.updatestamp > repo_updatestamp
         sessions = commit.report.uploads
         assert len(sessions) == 1
         first_session = (

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -294,6 +294,7 @@ class UploadTask(BaseCodecovTask):
         commit = commits.first()
         assert commit, "Commit not found in database."
         repository = commit.repository
+        repository.updatestamp = datetime.now()
         repository_service = None
         was_updated, was_setup = False, False
         try:


### PR DESCRIPTION
This is currently happening in the API's upload endpoint (https://github.com/codecov/codecov-api/pull/200) and can actually be quite slow sometimes.  Let's do it in the worker instead.

More context here: https://sentry.slack.com/archives/C0557QXEW4V/p1697657512609759