### PR TITLE
Add back previous cobertura behaviour and put newer behaviour behind config option

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/36cea1a0ec45a333fbbd0b89ae1ca3860e17e6d1.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/c096c95a612ccc043843c2c773f6a3d83b5e4248.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 boto3
 celery

--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -121,31 +121,58 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                         for _ in line.iter("condition")
                         if _.attrib.get("coverage") != "100%"
                     ]
-                    if type(coverage) is str:
-                        covered_conditions, total_conditions = coverage.split("/")
-                        if len(conditions) < int(total_conditions):
+                    if read_yaml_field(
+                        repo_yaml,
+                        (
+                            "codecov",
+                            "parsers",
+                            "cobertura",
+                            "handle_missing_conditions",
+                        ),
+                        False,
+                    ):
+                        if type(coverage) is str:
+                            covered_conditions, total_conditions = coverage.split("/")
+                            if len(conditions) < int(total_conditions):
+                                # <line number="23" hits="0" branch="true" condition-coverage="0% (0/2)">
+                                #     <conditions>
+                                #         <condition number="0" type="jump" coverage="0%"/>
+                                #     </conditions>
+                                # </line>
+
+                                # <line number="3" hits="0" branch="true" condition-coverage="50% (1/2)"/>
+
+                                coverage_difference = int(total_conditions) - int(
+                                    covered_conditions
+                                )
+                                missing_condition_elements = range(
+                                    len(conditions), coverage_difference
+                                )
+                                conditions.extend(
+                                    [
+                                        str(condition)
+                                        for condition in missing_condition_elements
+                                    ]
+                                )
+                    else:  # previous behaviour
+                        if (
+                            type(coverage) is str
+                            and coverage[0] == "0"
+                            and len(conditions) < int(coverage.split("/")[1])
+                        ):
                             # <line number="23" hits="0" branch="true" condition-coverage="0% (0/2)">
                             #     <conditions>
                             #         <condition number="0" type="jump" coverage="0%"/>
                             #     </conditions>
                             # </line>
-
-                            # <line number="3" hits="0" branch="true" condition-coverage="50% (1/2)"/>
-
-                            coverage_difference = int(total_conditions) - int(
-                                covered_conditions
-                            )
-                            missing_condition_elements = range(
-                                len(conditions), coverage_difference
-                            )
                             conditions.extend(
-                                [
-                                    str(condition)
-                                    for condition in missing_condition_elements
-                                ]
+                                map(
+                                    str,
+                                    range(len(conditions), int(coverage.split("/")[1])),
+                                )
                             )
-                        if conditions:
-                            missing_branches = conditions
+                    if conditions:
+                        missing_branches = conditions
                 _file.append(
                     ln,
                     report_builder_session.create_coverage_line(

--- a/services/report/languages/tests/unit/test_cobertura.py
+++ b/services/report/languages/tests/unit/test_cobertura.py
@@ -131,6 +131,118 @@ class TestCobertura(BaseTestCase):
                         None,
                     ),
                     (8, 1, None, [[0, 1, None, None, None]], None, None),
+                    (9, "1/2", "b", [[0, "1/2", None, None, None]], None, None),
+                ],
+            },
+            "report": {
+                "files": {
+                    "file": [
+                        1,
+                        [0, 3, 2, 1, 0, "66.66667", 1, 1, 0, 0, 0, 0, 0],
+                        {
+                            "0": [0, 3, 2, 1, 0, "66.66667", 1, 1],
+                            "meta": {"session_count": 1},
+                        },
+                        None,
+                    ],
+                    "source": [
+                        0,
+                        [0, 9, 3, 2, 4, "33.33333", 7, 0, 0, 0, 0, 0, 0],
+                        {
+                            "0": [0, 9, 3, 2, 4, "33.33333", 7],
+                            "meta": {"session_count": 1},
+                        },
+                        None,
+                    ],
+                },
+                "sessions": {},
+            },
+            "totals": {
+                "C": 0,
+                "M": 0,
+                "N": 0,
+                "b": 8,
+                "c": "41.66667",
+                "d": 1,
+                "diff": None,
+                "f": 2,
+                "h": 5,
+                "m": 3,
+                "n": 12,
+                "p": 4,
+                "s": 0,
+            },
+        }
+        assert processed_report["archive"] == expected_result["archive"]
+        assert processed_report["report"] == expected_result["report"]
+        assert processed_report["totals"] == expected_result["totals"]
+        assert processed_report == expected_result
+
+    def test_report_missing_conditions(self):
+        def fixes(path, *, bases_to_try):
+            if path == "ignore":
+                return None
+            assert path in ("source", "empty", "file", "nolines")
+            return path
+
+        report_builder = ReportBuilder(
+            path_fixer=fixes,
+            ignored_lines={},
+            sessionid=0,
+            current_yaml={
+                "codecov": {
+                    "max_report_age": None,
+                    "parsers": {"cobertura": {"handle_missing_conditions": True}},
+                }
+            },
+        )
+        report_builder_session = report_builder.create_report_builder_session(
+            "filename"
+        )
+        report = cobertura.from_xml(
+            etree.fromstring(xml % ("", int(time()), "", "")), report_builder_session
+        )
+        processed_report = self.convert_report_to_better_readable(report)
+        import pprint
+
+        pprint.pprint(processed_report)
+        expected_result = {
+            "archive": {
+                "file": [
+                    (1, 0, "m", [[0, 0, None, None, None]], None, None),
+                    (2, 1, "b", [[0, 1, None, None, None]], None, None),
+                    (3, 1, None, [[0, 1, None, None, None]], None, None),
+                ],
+                "source": [
+                    (1, 1, None, [[0, 1, None, None, None]], None, None),
+                    (2, "0/2", "b", [[0, "0/2", ["exit"], None, None]], None, None),
+                    (3, "1/2", "b", [[0, "1/2", ["30"], None, None]], None, None),
+                    (4, "2/2", "b", [[0, "2/2", None, None, None]], None, None),
+                    (
+                        5,
+                        "2/4",
+                        "b",
+                        [[0, "2/4", ["0:jump", "1:jump"], None, None]],
+                        None,
+                        None,
+                    ),
+                    (
+                        6,
+                        "2/4",
+                        "b",
+                        [[0, "2/4", ["0:jump", "1:jump"], None, None]],
+                        None,
+                        None,
+                    ),
+                    (
+                        7,
+                        "0/2",
+                        "b",
+                        [[0, "0/2", ["loop", "exit"], None, None]],
+                        None,
+                        None,
+                    ),
+                    (8, 1, None, [[0, 1, None, None, None]], None, None),
                     (9, "1/2", "b", [[0, "1/2", ["0"], None, None]], None, None),
                 ],
             },


### PR DESCRIPTION
This PR is taking the changes in #118, and putting them behind a config option in the `codecov.yml` specifically
```yaml
parsers:
  cobertura:
    handle_missing_conditions: bool # default False
```

Depends on: https://github.com/codecov/shared/pull/67