### PR TITLE
fix: checkpointlogger: use enum declaration order instead of value order

### DIFF
--- a/helpers/tests/unit/test_checkpoint_logger.py
+++ b/helpers/tests/unit/test_checkpoint_logger.py
@@ -50,6 +50,12 @@ class TestEnum2(BaseFlow):
     C = auto()
 
 
+class SortOrderEnum(BaseFlow):
+    C = auto()
+    B = auto()
+    A = auto()
+
+
 class TestCheckpointLogger(unittest.TestCase):
     @pytest.fixture(scope="function", autouse=True)
     def inject_mocker(request, mocker):
@@ -352,9 +358,22 @@ class TestCheckpointLogger(unittest.TestCase):
         We encode the flow name and checkpoint name in the string value so that
         we can validate when we deserialize. Make sure that all works.
         """
-        deserialized = {
+        original = {
             TestEnum1.A: 1337,
             TestEnum1.B: 9001,
         }
-        assert json.dumps(deserialized) == '{"TestEnum1.A": 1337, "TestEnum1.B": 9001}'
-        assert json.loads(json.dumps(deserialized)) == deserialized
+        serialized = json.dumps(original)
+        deserialized = json.loads(serialized)
+
+        assert serialized == '{"TestEnum1.A": 1337, "TestEnum1.B": 9001}'
+        assert deserialized == {
+            "TestEnum1.A": 1337,
+            "TestEnum1.B": 9001,
+        }
+
+    def test_sort_order(self):
+        assert TestEnum1.A == TestEnum1.A
+        assert TestEnum1.A < TestEnum1.B
+        assert TestEnum1.C > TestEnum1.B
+        assert SortOrderEnum.C < SortOrderEnum.B
+        assert SortOrderEnum.A > SortOrderEnum.B


### PR DESCRIPTION
i made a sloppy mistake. i treated `BaseFlow` subclass values as if they were sorted by declaration order, but they're just strings and they're sorted lexicographically. example:

```
class Foo(BaseFlow):
    PROCESSING_BEGIN = auto()
    INITIAL_PROCESSING_COMPLETE = auto()

assert Foo.PROCESSING_BEGIN < Foo.INITIAL_PROCESSING_COMPLETE
```

`PROCESSING_BEGIN` is declared before `INITIAL_PROCESSING_COMPLETE`, so i want `PROCESSING_BEGIN < INITIAL_PROCESSING_COMPLETE` to be true. but with lexicographic order, "I" is before "P" so it's flipped.

`Foo._member_names_` remembers the declaration order and we can fix the bug by overriding `__eq__()` and friends to make them compare based on declaration order.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.