### PR TITLE
fix: define __le__ instead of just __lt__ for BaseFlow

### DIFF
--- a/helpers/checkpoint_logger/__init__.py
+++ b/helpers/checkpoint_logger/__init__.py
@@ -73,9 +73,19 @@ class BaseFlow(str, Enum):
             ) > self.__class__._member_names_.index(other.name)
         return NotImplemented
 
+    def __ge__(self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return self == other or self > other
+        return NotImplemented
+
     def __lt__(self, other: object) -> bool:
         if isinstance(other, self.__class__):
             return (not self == other) and (not self > other)
+        return NotImplemented
+
+    def __le__(self, other: object) -> bool:
+        if isinstance(other, self.__class__):
+            return self == other or self < other
         return NotImplemented
 
     def __hash__(self):

--- a/helpers/tests/unit/test_checkpoint_logger.py
+++ b/helpers/tests/unit/test_checkpoint_logger.py
@@ -377,3 +377,8 @@ class TestCheckpointLogger(unittest.TestCase):
         assert TestEnum1.C > TestEnum1.B
         assert SortOrderEnum.C < SortOrderEnum.B
         assert SortOrderEnum.A > SortOrderEnum.B
+
+        checkpoints = CheckpointLogger(SortOrderEnum)
+        checkpoints.log(SortOrderEnum.C)
+        checkpoints.log(SortOrderEnum.B)
+        checkpoints._subflow_duration(SortOrderEnum.C, SortOrderEnum.B)


### PR DESCRIPTION
tested by running real uploads through my local service instead of relying on unit tests and staging. i'll make sure to do that more in the future as these bugs were easily catchable before PR time if i were more diligent

i read somewhere that defining `__gt__` and `__eq__` should fill in for other comparison functions if they aren't defined. i saw that wasn't true for `__lt__` in the last bugfix and defined that one manually, but i thought surely `__lt__` and `__eq__` are enough to define `__le__` and did not verify

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.