### PR TITLE
fix: make sure to update commit info

### DIFF
--- a/tasks/commit_update.py
+++ b/tasks/commit_update.py
@@ -12,6 +12,7 @@ from database.models import Commit
 from helpers.exceptions import RepositoryWithoutValidBotError
 from services.repository import (
     get_repo_provider_service,
+    possibly_update_commit_from_provider_info,
     update_commit_from_provider_info,
 )
 from tasks.base import BaseCodecovTask
@@ -38,7 +39,7 @@ class CommitUpdateTask(BaseCodecovTask, name=commit_update_task_name):
         was_updated = False
         try:
             repository_service = get_repo_provider_service(repository, commit)
-            was_updated = await self.possibly_update_commit_from_provider_info(
+            was_updated = await possibly_update_commit_from_provider_info(
                 commit, repository_service
             )
         except RepositoryWithoutValidBotError:
@@ -63,32 +64,6 @@ class CommitUpdateTask(BaseCodecovTask, name=commit_update_task_name):
                 extra=dict(commitid=commitid, repoid=repoid),
             )
         return {"was_updated": was_updated}
-
-    # TODO move this into services as it is used in upload task also
-    async def possibly_update_commit_from_provider_info(
-        self, commit, repository_service
-    ):
-        repoid = commit.repoid
-        commitid = commit.commitid
-        try:
-            if not commit.message:
-                log.info(
-                    "Commit does not have all needed info. Reaching provider to fetch info",
-                    extra=dict(repoid=repoid, commit=commitid),
-                )
-                await update_commit_from_provider_info(repository_service, commit)
-                return True
-        except TorngitObjectNotFoundError:
-            log.warning(
-                "Could not update commit with info because it was not found at the provider",
-                extra=dict(repoid=repoid, commit=commitid),
-            )
-            return False
-        log.debug(
-            "Not updating commit because it already seems to be populated",
-            extra=dict(repoid=repoid, commit=commitid),
-        )
-        return False
 
 
 RegisteredCommitUpdateTask = celery_app.register_task(CommitUpdateTask())

--- a/tasks/tests/unit/test_commit_update.py
+++ b/tasks/tests/unit/test_commit_update.py
@@ -159,7 +159,7 @@ class TestCommitUpdate(object):
     ):
 
         mock_update_commit_from_provider = mocker.patch(
-            "tasks.commit_update.update_commit_from_provider_info"
+            "tasks.commit_update.possibly_update_commit_from_provider_info"
         )
         mock_update_commit_from_provider.side_effect = TorngitObjectNotFoundError(
             "fake_response", "message"

--- a/tasks/tests/unit/test_preprocess_upload.py
+++ b/tasks/tests/unit/test_preprocess_upload.py
@@ -155,6 +155,7 @@ class TestPreProcessUpload(object):
         assert result == {
             "preprocessed_upload": True,
             "reportid": str(report.external_id),
+            "updated_commit": False,
         }
         mocked_fetch_yaml.assert_called()
         mock_possibly_shift.assert_called()

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -234,8 +234,8 @@ class TestUploadTaskIntegration(object):
         mock_redis,
         celery_app,
     ):
-        mock_possibly_update_commit_from_provider_info = mocker.patch.object(
-            UploadTask, "possibly_update_commit_from_provider_info", return_value=True
+        mock_possibly_update_commit_from_provider_info = mocker.patch(
+            "tasks.upload.possibly_update_commit_from_provider_info", return_value=True
         )
         mocker.patch.object(UploadTask, "possibly_setup_webhooks", return_value=True)
         mocker.patch.object(UploadTask, "fetch_commit_yaml_and_possibly_store")
@@ -281,8 +281,8 @@ class TestUploadTaskIntegration(object):
         mock_redis,
         celery_app,
     ):
-        mocker.patch.object(
-            UploadTask, "possibly_update_commit_from_provider_info", return_value=True
+        mocker.patch(
+            "tasks.upload.possibly_update_commit_from_provider_info", return_value=True
         )
         mocker.patch.object(UploadTask, "possibly_setup_webhooks", return_value=True)
         mocker.patch.object(UploadTask, "fetch_commit_yaml_and_possibly_store")
@@ -300,9 +300,6 @@ class TestUploadTaskIntegration(object):
         ).timestamp()
         mock_configuration.set_params({"setup": {"upload_processing_delay": 1000}})
         mocker.patch.object(UploadTask, "app", celery_app)
-        mocker.patch.object(
-            UploadTask, "possibly_update_commit_from_provider_info", return_value=True
-        )
         mocker.patch.object(UploadTask, "possibly_setup_webhooks", return_value=True)
         mocker.patch.object(UploadTask, "fetch_commit_yaml_and_possibly_store")
         mocked_chain = mocker.patch("tasks.upload.chain")
@@ -334,8 +331,8 @@ class TestUploadTaskIntegration(object):
     ):
         mock_configuration.set_params({"setup": {"upload_processing_delay": 1000}})
         mocker.patch.object(UploadTask, "app", celery_app)
-        mocker.patch.object(
-            UploadTask, "possibly_update_commit_from_provider_info", return_value=True
+        mocker.patch(
+            "tasks.upload.possibly_update_commit_from_provider_info", return_value=True
         )
         mocker.patch.object(UploadTask, "possibly_setup_webhooks", return_value=True)
         mocker.patch.object(UploadTask, "fetch_commit_yaml_and_possibly_store")
@@ -713,8 +710,8 @@ class TestUploadTaskIntegration(object):
         mock_storage,
     ):
         mocked_schedule_task = mocker.patch.object(UploadTask, "schedule_task")
-        mock_possibly_update_commit_from_provider_info = mocker.patch.object(
-            UploadTask, "possibly_update_commit_from_provider_info", return_value=True
+        mock_possibly_update_commit_from_provider_info = mocker.patch(
+            "tasks.upload.possibly_update_commit_from_provider_info", return_value=True
         )
         mock_create_upload = mocker.patch.object(ReportService, "create_report_upload")
 


### PR DESCRIPTION
The pre-process commit task doesn't check if the commit data has
been already pulled from the provider. This can cause an error where
the parent commit is not found to carryforward the reports.

These changes make sure that we try to update the commit info if necessary.
It also moves the function - that was repeated in a few places - to
RepositoryService.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.