### PR TITLE
feat: add prometheus instrumentation to checkpointlogger

### DIFF
--- a/helpers/checkpoint_logger/__init__.py
+++ b/helpers/checkpoint_logger/__init__.py
@@ -443,6 +443,9 @@ class CheckpointLogger(Generic[T]):
             self.data[checkpoint] = _get_milli_timestamp()
         elif not ignore_repeat:
             self._error(f"Already recorded checkpoint {checkpoint}")
+            return self
+        else:
+            return self
 
         if kwargs is not None:
             kwargs[self.kwargs_key] = self.data

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -927,3 +927,55 @@ class TestNotifyTask(object):
             empty_upload=None,
             **kwargs,
         )
+
+    @pytest.mark.asyncio
+    async def test_checkpoints_not_logged_outside_upload_flow(
+        self, dbsession, mock_redis, mocker, mock_checkpoint_submit, mock_configuration
+    ):
+        fake_notifier = mocker.MagicMock(
+            AbstractBaseNotifier,
+            is_enabled=mocker.MagicMock(return_value=True),
+            title="the_title",
+            notification_type=Notification.comment,
+            decoration_type=Decoration.standard,
+        )
+        fake_notifier.name = "fake_hahaha"
+        fake_notifier.notify.return_value = NotificationResult(
+            notification_attempted=True,
+            notification_successful=True,
+            explanation="",
+            data_sent={"all": ["The", 1, "data"]},
+        )
+        mocker.patch.object(
+            NotificationService, "get_notifiers_instances", return_value=[fake_notifier]
+        )
+        mock_configuration.params["setup"][
+            "codecov_dashboard_url"
+        ] = "https://codecov.io"
+        mocker.patch.object(NotifyTask, "app")
+        mocker.patch.object(NotifyTask, "should_send_notifications", return_value=True)
+        fetch_and_update_whether_ci_passed_result = {}
+        mocker.patch.object(
+            NotifyTask,
+            "fetch_and_update_whether_ci_passed",
+            return_value=fetch_and_update_whether_ci_passed_result,
+        )
+        mocked_fetch_pull = mocker.patch(
+            "tasks.notify.fetch_and_update_pull_request_information_from_commit"
+        )
+        mocker.patch.object(
+            ReportService, "get_existing_report_for_commit", return_value=Report()
+        )
+        mocked_fetch_pull.return_value = None
+        commit = CommitFactory.create(message="", pullid=None)
+        dbsession.add(commit)
+        dbsession.flush()
+
+        task = NotifyTask()
+        result = await task.run_async_within_lock(
+            dbsession,
+            repoid=commit.repoid,
+            commitid=commit.commitid,
+            current_yaml={"coverage": {"status": {"patch": True}}},
+        )
+        assert not mock_checkpoint_submit.called


### PR DESCRIPTION
mirror `CheckpointLogger` data in prometheus, once this is flowing we can delete the statsd/sentry stuff

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.