### PR TITLE
fix 'NoneType' object is not subscriptable

### DIFF
--- a/tasks/tests/unit/test_label_analysis.py
+++ b/tasks/tests/unit/test_label_analysis.py
@@ -400,8 +400,21 @@ def sample_report_with_labels():
             complexity=None,
         ),
     )
+    random_rf = ReportFile("path/from/randomfile_no_static_analysis.html")
+    random_rf.append(
+        1,
+        ReportLine.create(
+            coverage=1,
+            type=None,
+            sessions=[(LineSession(id=1, coverage=1))],
+            datapoints=None,
+            complexity=None,
+        ),
+    )
     r.append(first_rf)
     r.append(second_rf)
+    r.append(random_rf)
+
     return r
 
 
@@ -662,6 +675,55 @@ def test_get_executable_lines_labels_all_labels_in_one_file(sample_report_with_l
             "pineapple",
         },
         {"orangejuice", "justjuice", "applejuice"},
+    )
+
+
+def test_get_executable_lines_labels_some_labels_in_one_file(sample_report_with_labels):
+    executable_lines = {
+        "all": False,
+        "files": {"source.py": {"all": False, "lines": set([5, 6])}},
+    }
+    task = LabelAnalysisRequestProcessingTask()
+    assert task.get_executable_lines_labels(
+        sample_report_with_labels, executable_lines
+    ) == (
+        {"apple", "label_one", "pineapple", "banana"},
+        set(),
+    )
+
+
+def test_get_executable_lines_labels_some_labels_in_one_file_with_globals(
+    sample_report_with_labels,
+):
+    executable_lines = {
+        "all": False,
+        "files": {"source.py": {"all": False, "lines": set([6, 8])}},
+    }
+    task = LabelAnalysisRequestProcessingTask()
+    assert task.get_executable_lines_labels(
+        sample_report_with_labels, executable_lines
+    ) == (
+        {"label_one", "pineapple", "banana", "orangejuice", "applejuice"},
+        {"applejuice", "justjuice", "orangejuice"},
+    )
+
+
+def test_get_executable_lines_labels_some_labels_in_one_file_other_null(
+    sample_report_with_labels,
+):
+    executable_lines = {
+        "all": False,
+        "files": {
+            "source.py": {"all": False, "lines": set([5, 6])},
+            "path/from/randomfile_no_static_analysis.html": None,
+        },
+    }
+    task = LabelAnalysisRequestProcessingTask()
+    assert task.get_executable_lines_labels(
+        sample_report_with_labels, executable_lines
+    ) == (
+        {"apple", "label_one", "pineapple", "banana"},
+        set(),
     )
 
 


### PR DESCRIPTION
Fix for https://l.codecov.dev/hqZ1Ci (Sentry issue)

The error itself is `TypeError: 'NoneType' object is not subscriptable`.
This was happening because if we don't have static analysis for a file
the lines relevant for that file might be `None`, and we we're not checking
this condition prior to starting to access the dict items.

The fix itself is very simple, but I wanted to add type hints and better
tests too, so they're in the change as well.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.