### PR TITLE
feat: Update announcements section of PR comment

### DIFF
--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -308,17 +308,56 @@ class HeaderSectionWriter(BaseSectionWriter):
 
 
 class AnnouncementSectionWriter(BaseSectionWriter):
-    current_active_messages = [
+    ats_message = (
         "We’re building smart automated test selection to slash your CI/CD build times. [Learn more](https://about.codecov.io/iterative-testing/)",
+    )
+    current_active_messages = [
+        "Codecov offers a browser extension for seamless coverage viewing on GitHub. Try it in [Chrome](https://chrome.google.com/webstore/detail/codecov/gedikamndpbemklijjkncpnolildpbgo) or [Firefox](https://addons.mozilla.org/en-US/firefox/addon/codecov/) today!"
         #   "Codecov can now indicate which changes are the most critical in Pull Requests. [Learn more](https://about.codecov.io/product/feature/runtime-insights/)"  # This is disabled as of CODE-1885. But we might bring it back later.
     ]
 
-    async def do_write_section(*args, **kwargs):
-        # This allows us to shift through active messages while respecting the annoucement limit.
-        message_to_display = random.choice(
-            AnnouncementSectionWriter.current_active_messages
-        )
+    async def do_write_section(self, comparison: ComparisonProxy, *args, **kwargs):
+        if self._potential_ats_user(comparison):
+            message_to_display = AnnouncementSectionWriter.ats_message
+        else:
+            # This allows us to shift through active messages while respecting the annoucement limit.
+            message_to_display = random.choice(
+                AnnouncementSectionWriter.current_active_messages
+            )
+
         yield f":mega: {message_to_display}"
+
+    def _has_ats_configured(self):
+        if not self.current_yaml:
+            return False
+        flags = self.current_yaml.read_yaml_field(
+            "flag_management", "individual_flags", _else=[]
+        )
+        for flag_info in flags:
+            if flag_info.get("carryforward_mode") == "labels":
+                return True
+        return False
+
+    def _potential_ats_user(self, comparison: ComparisonProxy) -> bool:
+        if self.repository and self.repository.language == "python":
+            if not self._has_ats_configured() and comparison.has_head_report():
+                report = comparison.head.report
+
+                # we're using the total chunks size as a proxy for potential CI
+                # runtime - assuming that if you have more files + uploads then
+                # perhaps your CI is running longer
+                approx_size = 0
+                for chunk in report._chunks:
+                    approx_size += len(chunk)
+
+                # this value was just chosen empirically by looking at some of our
+                # own repos and relating chunks size to CI time - ideally we'd like
+                # to target repos w/ CI time > 20 min but we don't really have that
+                # info available
+                if approx_size > 80_000_000:
+                    return True
+
+        return False
 
 
 class ImpactedEntrypointsSectionWriter(BaseSectionWriter):

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from types import SimpleNamespace
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -12,6 +13,7 @@ from shared.torngit.exceptions import (
     TorngitServerUnreachableError,
 )
 from shared.utils.sessions import Session
+from shared.yaml import UserYaml
 
 import services.notification.notifiers.mixins.message.sections as sections
 from database.tests.factories import RepositoryFactory
@@ -4010,12 +4012,35 @@ class TestAnnouncementsSectionWriter(object):
             mocker.MagicMock(),
             mocker.MagicMock(),
         )
-        res = list(await writer.write_section())
+        res = list(await writer.write_section(mocker.MagicMock()))
         assert len(res) == 1
         line = res[0]
         assert line.startswith(":mega: ")
         message = line[7:]
         assert message in AnnouncementSectionWriter.current_active_messages
+
+    @pytest.mark.asyncio
+    async def test_announcement_section_writer_ats(
+        self, mocker, create_sample_comparison
+    ):
+        comparison = create_sample_comparison()
+        current_yaml = UserYaml({})
+
+        writer = AnnouncementSectionWriter(
+            repository=comparison.head.commit.repository,
+            layout=mocker.MagicMock(),
+            show_complexity=mocker.MagicMock(),
+            settings=mocker.MagicMock(),
+            current_yaml=current_yaml,
+        )
+        writer.repository.language = "python"
+        comparison.head.report._chunks = ["xx"] * 80_000_000
+
+        res = list(await writer.write_section(comparison))
+        assert len(res) == 1
+        line = res[0]
+        assert line.startswith(":mega: ")
+        assert "smart automated test selection" in line
 
 
 class TestNewFooterSectionWriter(object):


### PR DESCRIPTION
Resolves https://github.com/codecov/engineering-team/issues/475

Show the ATS message to applicable repos only and otherwise show info about the browser extension.


* announcements section will still show up to 25% of PR comments that do not have the comment layout overridden in their YAML
* if the ATS announcement applies to the comment then favor that:
  - must not be using ATS already
  - must be a Python repo
  - must have sufficiently large chunks size
* otherwise fallback to one of the other general announcements (currently just the browser comment announcement)