### PR TITLE
feat: add team plan to billing and upload limits

### DIFF
--- a/services/billing.py
+++ b/services/billing.py
@@ -18,6 +18,8 @@ class BillingPlan(Enum):
     pr_yearly = "users-pr-inappy"
     enterprise_cloud_yearly = "users-enterprisey"
     enterprise_cloud_monthly = "users-enterprisem"
+    team_monthly = "users-teamm"
+    team_yearly = "users-teamy"
 
 
 def is_pr_billing_plan(plan: str) -> bool:
@@ -30,6 +32,8 @@ def is_pr_billing_plan(plan: str) -> bool:
             BillingPlan.users_trial.value,
             BillingPlan.enterprise_cloud_monthly.value,
             BillingPlan.enterprise_cloud_yearly.value,
+            BillingPlan.team_monthly.value,
+            BillingPlan.team_yearly.value,
         ]
     else:
         license = get_current_license()

--- a/services/tests/test_decoration.py
+++ b/services/tests/test_decoration.py
@@ -205,7 +205,9 @@ class TestDecorationServiceTestCase(object):
         assert decoration_details.decoration_type == Decoration.upload_limit
         assert decoration_details.reason == "Org has exceeded the upload limit"
 
-    def test_decoration_type_team_plan_upload_limit(self, enriched_pull, dbsession, mocker):
+    def test_decoration_type_team_plan_upload_limit(
+        self, enriched_pull, dbsession, mocker
+    ):
         mocker.patch("services.license.is_enterprise", return_value=False)
         pr_author = OwnerFactory.create(
             service="github",


### PR DESCRIPTION
<!-- Describe your PR here. -->

- Add Team plan concept to upload limits, this plan has a 2500 limit.
- Add Team plan to be recognized as a billing plan


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.