### PR TITLE
WIP - encode labels into index

### DIFF
--- a/helpers/labels.py
+++ b/helpers/labels.py
@@ -32,27 +32,23 @@ class SpecialLabelsEnum(Enum):
 
 
 @sentry_sdk.trace
-def get_labels_per_session(report: Report, sess_id: int):
+def get_label_indexes_per_session(report: Report, sess_id: int):
     all_labels = set()
     for rf in report:
         for _, line in rf.lines:
             if line.datapoints:
                 for datapoint in line.datapoints:
                     if datapoint.sessionid == sess_id:
-                        all_labels.update(datapoint.labels or [])
-    return all_labels - set(
-        [SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label]
-    )
+                        all_labels.update(datapoint.label_ids or [])
+    return all_labels - set([0])  # This is always the index for the SpecialLabelsEnum
 
 
 @sentry_sdk.trace
-def get_all_report_labels(report: Report) -> set:
+def get_all_report_label_indexes(report: Report) -> set:
     all_labels = set()
     for rf in report:
         for _, line in rf.lines:
             if line.datapoints:
                 for datapoint in line.datapoints:
-                    all_labels.update(datapoint.labels or [])
-    return all_labels - set(
-        [SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label]
-    )
+                    all_labels.update(datapoint.label_ids or [])
+    return all_labels - set([0])  # This is always the index for the SpecialLabelsEnum

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/6ef3d6d45afe82000275504e289a463f40137e54.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/92258e4f608699394f226ef74ce28ad327b28f93.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 boto3
 celery

--- a/requirements.txt
+++ b/requirements.txt
@@ -305,7 +305,7 @@ s3transfer==0.3.4
     # via boto3
 sentry-sdk==1.19.1
     # via -r requirements.in
-shared @ https://github.com/codecov/shared/archive/6ef3d6d45afe82000275504e289a463f40137e54.tar.gz
+shared @ https://github.com/codecov/shared/archive/92258e4f608699394f226ef74ce28ad327b28f93.tar.gz
     # via -r requirements.in
 six==1.15.0
     # via

--- a/services/archive.py
+++ b/services/archive.py
@@ -4,11 +4,12 @@ from base64 import b16encode
 from datetime import datetime
 from enum import Enum
 from hashlib import md5
-from typing import Any
+from typing import Dict
 from uuid import uuid4
 
 from shared.config import get_config
 from shared.storage.base import BaseStorageService
+from shared.storage.exceptions import FileNotInStorageError
 from shared.utils.ReportEncoder import ReportEncoder
 
 from helpers.metrics import metrics
@@ -19,6 +20,9 @@ log = logging.getLogger(__name__)
 
 class MinioEndpoints(Enum):
     chunks = "{version}/repos/{repo_hash}/commits/{commitid}/{chunks_file_name}.txt"
+    label_index = (
+        "{version}/repos/{repo_hash}/commits/{commitid}/{label_index_file_name}.json"
+    )
     json_data = "{version}/repos/{repo_hash}/commits/{commitid}/json_data/{table}/{field}/{external_id}.json"
     json_data_no_commit = (
         "{version}/repos/{repo_hash}/json_data/{table}/{field}/{external_id}.json"
@@ -226,6 +230,20 @@ class ArchiveService(object):
         self.write_file(path, stringified_data)
         return path
 
+    def write_label_index(self, commit_sha, json_data, report_code=None) -> str:
+        label_index_file_name = (
+            report_code + "_" if report_code is not None else ""
+        ) + "labels_index"
+        path = MinioEndpoints.label_index.get_path(
+            version="v4",
+            repo_hash=self.storage_hash,
+            commitid=commit_sha,
+            label_index_file_name=label_index_file_name,
+        )
+        string_data = json.dumps(json_data)
+        self.write_file(path, string_data)
+        return path
+
     """
     Convenience method to write a chunks.txt file to storage.
     """
@@ -285,6 +303,22 @@ class ArchiveService(object):
         )
 
         return self.read_file(path).decode(errors="replace")
+
+    def read_label_index(self, commit_sha, report_code=None) -> Dict[str, str]:
+        label_index_file_name = (
+            report_code + "_" if report_code is not None else ""
+        ) + "labels_index"
+        path = MinioEndpoints.label_index.get_path(
+            version="v4",
+            repo_hash=self.storage_hash,
+            commitid=commit_sha,
+            label_index_file_name=label_index_file_name,
+        )
+
+        try:
+            return json.loads(self.read_file(path).decode(errors="replace"))
+        except FileNotInStorageError:
+            return dict()
 
     """
     Delete a chunk file from the archive

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -38,7 +38,7 @@ from helpers.exceptions import (
     ReportExpiredException,
     RepositoryWithoutValidBotError,
 )
-from helpers.labels import get_all_report_labels, get_labels_per_session
+from helpers.labels import get_label_indexes_per_session
 from services.archive import ArchiveService
 from services.report.parser import get_proper_parser
 from services.report.parser.types import ParsedRawReport
@@ -523,7 +523,7 @@ class ReportService(object):
             # `PARTIALLY_OVERWRITTEN` and `FULLY_OVERWRITTEN` states are being saved
             labels_session = self._is_labels_flags(session.flags)
             if labels_session:
-                labels = get_labels_per_session(report, sid)
+                labels = get_label_indexes_per_session(report, sid)
                 if not labels:
                     sessions_to_delete.append(sid)
 
@@ -786,7 +786,12 @@ class ReportService(object):
         try:
             with metrics.timer(f"{self.metrics_prefix}.process_report") as t:
                 result = process_raw_upload(
-                    self.current_yaml, master, raw_uploaded_report, flags, session
+                    self.current_yaml,
+                    master,
+                    raw_uploaded_report,
+                    flags,
+                    session=session,
+                    upload=upload,
                 )
                 report = result.report
             log.info(

--- a/services/report/labels_index.py
+++ b/services/report/labels_index.py
@@ -1,0 +1,36 @@
+from shared.reports.resources import Report
+
+from database.models.reports import CommitReport
+from services.archive import ArchiveService
+
+
+class LabelsIndexService(object):
+    _archive_client: ArchiveService
+
+    def __init__(self, commit_report: CommitReport) -> None:
+        self.commit_report = commit_report
+        self._archive_client = ArchiveService(
+            repository=commit_report.commit.repository
+        )
+        self.commit_sha = commit_report.commit.commitid
+
+    def set_label_idx(self, report: Report):
+        if report._labels_index is not None:
+            raise Exception(
+                "Trying to set labels_index of Report, but it's already set"
+            )
+        # Load label index from storage
+        # JSON uses strings are keys, but we are using ints.
+        map_with_str_keys = self._archive_client.read_label_index(
+            self.commit_sha, self.commit_report.code
+        )
+        loaded_index = {int(k): v for k, v in map_with_str_keys.items()}
+        report.set_label_idx(loaded_index)
+
+    def unset_label_idx(self, report: Report):
+        # Write the updated index back into storage
+        self._archive_client.write_label_index(
+            self.commit_sha, report._labels_index, self.commit_report.code
+        )
+        # Remove reference to it
+        report.unset_label_idx()

--- a/services/report/languages/pycoverage.py
+++ b/services/report/languages/pycoverage.py
@@ -1,4 +1,4 @@
-import typing
+from typing import Any, Dict, List, Optional, Union
 
 from shared.reports.resources import Report
 
@@ -22,23 +22,54 @@ class PyCoverageProcessor(BaseLanguageProcessor):
             and "files" in content
         )
 
-    def _convert_testname_to_label(self, testname, labels_table):
+    def _convert_testname_to_label(self, testname) -> str:
         if type(testname) == int or type(testname) == float:
             # This is from a compressed report.
             # Pull label from the labels_table
             # But the labels_table keys are strings, because of JSON format
-            testname = labels_table[str(testname)]
+            testname = self.labels_table[str(testname)]
         if testname == "":
             return SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER
         return testname.split("|", 1)[0]
 
-    def process(
-        self, name: str, content: typing.Any, report_builder: ReportBuilder
-    ) -> Report:
+    def _get_list_of_label_ids(
+        self,
+        current_label_idx: Optional[Dict[int, str]],
+        line_contexts: List[Union[str, int]] = None,
+    ) -> List[int]:
+        if self.are_labels_already_encoded:
+            # The line contexts already include indexes in the table.
+            # We can re-use the table and don't have to do anything with contexts.
+            return sorted(map(int, line_contexts))
+
+        # In this case we do need to fix the labels
+        label_ids_for_line = set()
+        for testname in line_contexts:
+            clean_label = self._convert_testname_to_label(testname)
+            if clean_label in self.reverse_table:
+                label_ids_for_line.add(self.reverse_table[clean_label])
+            else:
+                label_id = max([*current_label_idx.keys(), 0]) + 1
+                current_label_idx[label_id] = clean_label
+                self.reverse_table[clean_label] = label_id
+                label_ids_for_line.add(label_id)
+
+        return sorted(label_ids_for_line)
+
+    def process(self, name: str, content: Any, report_builder: ReportBuilder) -> Report:
         report_builder_session = report_builder.create_report_builder_session(name)
-        labels_table = None
+        # Compressed pycoverage files will include a labels_table
+        # Mapping label_idx: int --> label: str
+        self.labels_table: Dict[int, str] = None
+        self.reverse_table = {}
+        self.are_labels_already_encoded = False
         if "labels_table" in content:
-            labels_table = content["labels_table"]
+            self.labels_table = content["labels_table"]
+            # We can pre-populate some of the indexes that will be used
+            for idx, testname in self.labels_table.items():
+                clean_label = self._convert_testname_to_label(testname)
+                report_builder_session.label_index[int(idx)] = clean_label
+            self.are_labels_already_encoded = True
         for filename, file_coverage in content["files"].items():
             fixed_filename = report_builder.path_fixer(filename)
             if fixed_filename:
@@ -47,10 +78,10 @@ class PyCoverageProcessor(BaseLanguageProcessor):
                     (COVERAGE_HIT, ln) for ln in file_coverage["executed_lines"]
                 ] + [(COVERAGE_MISS, ln) for ln in file_coverage["missing_lines"]]
                 for cov, ln in lines_and_coverage:
-                    label_list_of_lists = [
-                        [self._convert_testname_to_label(testname, labels_table)]
-                        for testname in file_coverage.get("contexts", {}).get(
-                            str(ln), []
+                    label_ids_list_of_lists = [
+                        self._get_list_of_label_ids(
+                            report_builder_session.label_index,
+                            file_coverage.get("contexts", {}).get(str(ln), []),
                         )
                     ]
                     if ln > 0:
@@ -60,8 +91,11 @@ class PyCoverageProcessor(BaseLanguageProcessor):
                                 fixed_filename,
                                 cov,
                                 coverage_type=CoverageType.line,
-                                labels_list_of_lists=label_list_of_lists,
+                                label_ids_list_of_lists=label_ids_list_of_lists,
                             ),
                         )
                 report_builder_session.append(report_file)
+        # I don't know if we reuse this processor, but just to be sure
+        # Erase the reverse table
+        self.reverse_table = None
         return report_builder_session.output_report()

--- a/services/report/report_builder.py
+++ b/services/report/report_builder.py
@@ -30,7 +30,7 @@ class ReportBuilderSession(object):
         self._report_builder = report_builder
         self._report_filepath = report_filepath
         self._report = Report()
-        self._present_labels = set()
+        self.label_index = {}
 
     @property
     def file_class(self):
@@ -66,13 +66,6 @@ class ReportBuilderSession(object):
         return self._report.get(filename)
 
     def append(self, file):
-        if file is not None:
-            for line_number, line in file.lines:
-                if line.datapoints:
-                    for datapoint in line.datapoints:
-                        if datapoint.labels:
-                            for label in datapoint.labels:
-                                self._present_labels.add(label)
         return self._report.append(file)
 
     def output_report(self) -> Report:
@@ -84,88 +77,16 @@ class ReportBuilderSession(object):
         Returns:
             Report: The legacy report desired
         """
-        if self._present_labels:
-            if self._present_labels == {
+        if len(self.label_index) > 0:
+            if len(self.label_index) == 1 and self.label_index.values() == [
                 SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER
-            }:
+            ]:
                 log.warning(
                     "Report only has SpecialLabels. Might indicate it was not generated with contexts"
                 )
-            for file in self._report:
-                for line_number, line in file.lines:
-                    self._possibly_modify_line_to_account_for_special_labels(
-                        file, line_number, line
-                    )
             self._report._totals = None
+            self._report.set_label_idx(self.label_index)
         return self._report
-
-    def _possibly_modify_line_to_account_for_special_labels(
-        self, file: ReportFile, line_number: int, line: ReportLine
-    ) -> None:
-        """Possibly modify the report line in the file
-        to account for any label in the SpecialLabelsEnum
-
-        Args:
-            file (ReportFile): The file we want to modify
-            line_number (int): The line number in case we
-                need to set the new line back into the files
-            line (ReportLine): The original line
-        """
-        new_datapoints = []
-        if line.datapoints:
-            new_datapoints = [
-                self._possibly_convert_datapoints(datapoint)
-                for datapoint in line.datapoints
-            ]
-            new_datapoints = [item for dp_list in new_datapoints for item in dp_list]
-            if new_datapoints and new_datapoints != line.datapoints:
-                # A check to avoid unnecessary replacement
-                file[line_number] = dataclasses.replace(
-                    line,
-                    datapoints=sorted(
-                        new_datapoints,
-                        key=lambda x: (
-                            x.sessionid,
-                            x.coverage,
-                            x.coverage_type,
-                        ),
-                    ),
-                )
-                file._totals = None
-
-    def _possibly_convert_datapoints(
-        self, datapoint: CoverageDatapoint
-    ) -> typing.List[CoverageDatapoint]:
-        """Possibly convert datapoints
-            The datapoint that might need to be converted
-
-        Args:
-            datapoint (CoverageDatapoint): The datapoint to convert
-        """
-        if datapoint.labels and any(
-            label == SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER
-            for label in datapoint.labels
-        ):
-            new_label = (
-                SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label
-            )
-            return [
-                dataclasses.replace(
-                    datapoint,
-                    labels=sorted(
-                        set(
-                            [
-                                label
-                                for label in datapoint.labels
-                                if label
-                                != SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER
-                            ]
-                            + [new_label]
-                        )
-                    ),
-                )
-            ]
-        return [datapoint]
 
     def create_coverage_line(
         self,
@@ -173,7 +94,7 @@ class ReportBuilderSession(object):
         coverage,
         *,
         coverage_type: CoverageType,
-        labels_list_of_lists: typing.List[typing.Union[str, SpecialLabelsEnum]] = None,
+        label_ids_list_of_lists: typing.List[int] = None,
         partials=None,
         missing_branches=None,
         complexity=None
@@ -185,9 +106,9 @@ class ReportBuilderSession(object):
                     sessionid=self.sessionid,
                     coverage=coverage,
                     coverage_type=coverage_type_str,
-                    labels=labels,
+                    label_ids=label_ids,
                 )
-                for labels in (labels_list_of_lists or [[]])
+                for label_ids in (label_ids_list_of_lists or [[]])
             ]
             if self._report_builder.supports_labels()
             else None
@@ -233,6 +154,9 @@ class ReportBuilder(object):
         return ReportBuilderSession(self, filepath)
 
     def supports_labels(self) -> bool:
+        """Returns wether a report supports labels.
+        This is true if the client has configured some flag with carryforward_mode == "labels"
+        """
         if self.current_yaml is None or self.current_yaml == {}:
             return False
         old_flag_style = self.current_yaml.get("flags")

--- a/services/report/tests/unit/test_labels_index.py
+++ b/services/report/tests/unit/test_labels_index.py
@@ -1,0 +1,82 @@
+import pytest
+from shared.reports.resources import Report
+
+from database.tests.factories.core import ReportFactory
+from helpers.labels import SpecialLabelsEnum
+from services.report.labels_index import ArchiveService, LabelsIndexService
+
+
+class TestLabelsIndex(object):
+    def test_init(self, dbsession, mocker):
+        commit_report = ReportFactory()
+        dbsession.add(commit_report)
+        dbsession.flush()
+
+        labels_index_service = LabelsIndexService(commit_report)
+        assert labels_index_service._archive_client is not None
+        assert labels_index_service.commit_sha == commit_report.commit.commitid
+
+    def test_set_label_idx(self, dbsession, mocker):
+        commit_report = ReportFactory()
+        dbsession.add(commit_report)
+        dbsession.flush()
+        # Notice that the keys are strings
+        # because self._archive_client.read_label_index returns the contents of a JSON file,
+        # and JSON can only have string keys.
+        sample_label_index = {
+            "0": SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+            "1": "some_label",
+            "2": "another_label",
+        }
+        mocker.patch.object(
+            ArchiveService, "read_label_index", return_value=sample_label_index
+        )
+        report = Report()
+        assert report._labels_index == None
+        label_service = LabelsIndexService(commit_report)
+        label_service.set_label_idx(report)
+        assert report._labels_index == {
+            0: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+            1: "some_label",
+            2: "another_label",
+        }
+
+    def test_set_label_idx_already_set(self, dbsession, mocker):
+        commit_report = ReportFactory()
+        dbsession.add(commit_report)
+        dbsession.flush()
+        mock_read = mocker.patch.object(ArchiveService, "read_label_index")
+        sample_label_index = {
+            0: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+            1: "some_label",
+            2: "another_label",
+        }
+        report = Report()
+        report._labels_index = sample_label_index
+        with pytest.raises(Exception) as exp:
+            label_service = LabelsIndexService(commit_report)
+            label_service.set_label_idx(report)
+        mock_read.assert_not_called()
+        assert (
+            str(exp.value)
+            == "Trying to set labels_index of Report, but it's already set"
+        )
+
+    def test_unset_label_idx(self, dbsession, mocker):
+        commit_report = ReportFactory()
+        dbsession.add(commit_report)
+        dbsession.flush()
+        sample_label_index = {
+            0: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+            1: "some_label",
+            2: "another_label",
+        }
+        mock_write = mocker.patch.object(ArchiveService, "write_label_index")
+        report = Report()
+        report._labels_index = sample_label_index
+        label_service = LabelsIndexService(commit_report)
+        label_service.unset_label_idx(report)
+        assert report._labels_index == None
+        mock_write.assert_called_with(
+            commit_report.commit.commitid, sample_label_index, commit_report.code
+        )

--- a/services/report/tests/unit/test_report_builder.py
+++ b/services/report/tests/unit/test_report_builder.py
@@ -39,7 +39,7 @@ def test_report_builder_generate_session(mocker):
 
 def test_report_builder_session(mocker):
     current_yaml, sessionid, ignored_lines, path_fixer = (
-        {"beta_groups": ["labels"]},
+        {},
         mocker.MagicMock(),
         mocker.MagicMock(),
         mocker.MagicMock(),
@@ -49,6 +49,12 @@ def test_report_builder_session(mocker):
     builder_session = builder.create_report_builder_session(filepath)
     first_file = ReportFile("filename.py")
     first_file.append(2, ReportLine.create(coverage=0))
+    labels_index = {
+        0: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER,
+        1: "some_label",
+        2: "other",
+    }
+    builder_session.label_index = labels_index
     first_file.append(
         3,
         ReportLine.create(
@@ -58,7 +64,7 @@ def test_report_builder_session(mocker):
                     sessionid=0,
                     coverage=1,
                     coverage_type=None,
-                    labels=[SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER],
+                    label_ids=[0],
                 )
             ],
         ),
@@ -81,13 +87,13 @@ def test_report_builder_session(mocker):
                     sessionid=0,
                     coverage=1,
                     coverage_type=None,
-                    labels=["some_label", "other"],
+                    label_ids=[1, 2],
                 ),
                 CoverageDatapoint(
                     sessionid=0,
                     coverage=1,
                     coverage_type=None,
-                    labels=None,
+                    label_ids=None,
                 ),
             ],
             complexity=None,
@@ -95,6 +101,7 @@ def test_report_builder_session(mocker):
     )
     builder_session.append(first_file)
     final_report = builder_session.output_report()
+    assert final_report._labels_index == labels_index
     assert final_report.files == ["filename.py"]
     assert sorted(final_report.get("filename.py").lines) == [
         (
@@ -114,7 +121,7 @@ def test_report_builder_session(mocker):
                         sessionid=0,
                         coverage=1,
                         coverage_type=None,
-                        labels=["Th2dMtk4M_codecov"],
+                        label_ids=[0],
                     ),
                 ],
                 complexity=None,
@@ -135,13 +142,13 @@ def test_report_builder_session(mocker):
                         sessionid=0,
                         coverage=1,
                         coverage_type=None,
-                        labels=["some_label", "other"],
+                        label_ids=[1, 2],
                     ),
                     CoverageDatapoint(
                         sessionid=0,
                         coverage=1,
                         coverage_type=None,
-                        labels=None,
+                        label_ids=None,
                     ),
                 ],
                 complexity=None,
@@ -157,9 +164,13 @@ def test_report_builder_session_only_all_labels(mocker):
         mocker.MagicMock(),
         mocker.MagicMock(),
     )
+    labels_index = {
+        0: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER,
+    }
     filepath = "filepath"
     builder = ReportBuilder(current_yaml, sessionid, ignored_lines, path_fixer)
     builder_session = builder.create_report_builder_session(filepath)
+    builder_session.label_index = labels_index
     first_file = ReportFile("filename.py")
     first_file.append(2, ReportLine.create(coverage=0))
     first_file.append(
@@ -171,7 +182,7 @@ def test_report_builder_session_only_all_labels(mocker):
                     sessionid=0,
                     coverage=1,
                     coverage_type=None,
-                    labels=[SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER],
+                    label_ids=[0],
                 )
             ],
         ),
@@ -194,13 +205,13 @@ def test_report_builder_session_only_all_labels(mocker):
                     sessionid=0,
                     coverage=1,
                     coverage_type=None,
-                    labels=[SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER],
+                    label_ids=[0],
                 ),
                 CoverageDatapoint(
                     sessionid=0,
                     coverage=1,
                     coverage_type=None,
-                    labels=None,
+                    label_ids=None,
                 ),
             ],
             complexity=None,
@@ -208,6 +219,7 @@ def test_report_builder_session_only_all_labels(mocker):
     )
     builder_session.append(first_file)
     final_report = builder_session.output_report()
+    assert final_report._labels_index == labels_index
     assert final_report.files == ["filename.py"]
     assert sorted(final_report.get("filename.py").lines) == [
         (
@@ -227,7 +239,7 @@ def test_report_builder_session_only_all_labels(mocker):
                         sessionid=0,
                         coverage=1,
                         coverage_type=None,
-                        labels=["Th2dMtk4M_codecov"],
+                        label_ids=[0],
                     ),
                 ],
                 complexity=None,
@@ -248,13 +260,13 @@ def test_report_builder_session_only_all_labels(mocker):
                         sessionid=0,
                         coverage=1,
                         coverage_type=None,
-                        labels=["Th2dMtk4M_codecov"],
+                        label_ids=[0],
                     ),
                     CoverageDatapoint(
                         sessionid=0,
                         coverage=1,
                         coverage_type=None,
-                        labels=None,
+                        label_ids=None,
                     ),
                 ],
                 complexity=None,
@@ -292,7 +304,7 @@ def test_report_builder_session_create_line(mocker):
             )
         ],
         datapoints=[
-            CoverageDatapoint(sessionid=45, coverage=1, coverage_type="b", labels=[])
+            CoverageDatapoint(sessionid=45, coverage=1, coverage_type="b", label_ids=[])
         ],
         complexity=None,
     )

--- a/services/tests/unit/test_archive_service.py
+++ b/services/tests/unit/test_archive_service.py
@@ -1,8 +1,10 @@
 import json
 
 from shared.storage import MinioStorageService
+from shared.storage.exceptions import FileNotInStorageError
 
 from database.tests.factories import RepositoryFactory
+from database.tests.factories.core import CommitFactory
 from services.archive import ArchiveService
 from test_utils.base import BaseTestCase
 
@@ -135,4 +137,81 @@ class TestWriteJsonData(BaseTestCase):
             json.dumps(data),
             is_already_gzipped=False,
             reduced_redundancy=False,
+        )
+
+
+class TestLabelIndex(object):
+    def test_write_label_index_to_storage(self, mocker, dbsession):
+        commit = CommitFactory()
+        dbsession.add(commit)
+        dbsession.flush()
+        mock_write_file = mocker.patch.object(MinioStorageService, "write_file")
+        archive_service = ArchiveService(repository=commit.repository)
+        data = {1: "some_label", 2: "another_label", 3: "yet_another_label"}
+        path_for_default_code = archive_service.write_label_index(
+            commit.commitid, data, report_code=None
+        )
+        assert (
+            path_for_default_code
+            == f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/labels_index.json"
+        )
+        mock_write_file.assert_called_with(
+            archive_service.root,
+            path_for_default_code,
+            json.dumps(data),
+            is_already_gzipped=False,
+            reduced_redundancy=False,
+        )
+
+        path_for_different_code = archive_service.write_label_index(
+            commit.commitid, data, report_code="local"
+        )
+        assert (
+            path_for_different_code
+            == f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/local_labels_index.json"
+        )
+        mock_write_file.assert_called_with(
+            archive_service.root,
+            path_for_different_code,
+            json.dumps(data),
+            is_already_gzipped=False,
+            reduced_redundancy=False,
+        )
+
+    def test_read_label_index_from_storage(self, mocker, dbsession):
+        commit = CommitFactory()
+        dbsession.add(commit)
+        dbsession.flush()
+        # Notice that the keys are string. JSON uses strings as keys.
+        # It's not the responsibility of read_label_index to fix this detail
+        data = {"1": "some_label", "2": "another_label", "3": "yet_another_label"}
+        mock_read_file = mocker.patch.object(
+            ArchiveService, "read_file", return_value=json.dumps(data).encode()
+        )
+        archive_service = ArchiveService(repository=commit.repository)
+
+        assert archive_service.read_label_index(commit.commitid) == data
+        mock_read_file.assert_called_with(
+            f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/labels_index.json"
+        )
+
+        assert (
+            archive_service.read_label_index(commit.commitid, report_code="local")
+            == data
+        )
+        mock_read_file.assert_called_with(
+            f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/local_labels_index.json"
+        )
+
+    def test_read_label_index_from_storage_file_not_found(self, mocker, dbsession):
+        commit = CommitFactory()
+        dbsession.add(commit)
+        dbsession.flush()
+        mock_read_file = mocker.patch.object(
+            ArchiveService, "read_file", side_effect=FileNotInStorageError
+        )
+        archive_service = ArchiveService(repository=commit.repository)
+        assert archive_service.read_label_index(commit.commitid) == {}
+        mock_read_file.assert_called_with(
+            f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/labels_index.json"
         )


### PR DESCRIPTION
This is a lot of code, and I'll probably break this PR in several others. I'm looking for early feedback here. It's a lot of code and a lot of changes.

This depends on the changes in https://github.com/codecov/shared/pull/79. Check that PR for context.

# New things
* `services/report/labels_index.py` houses the `LabelIndexService`. This little bit of code controls read/write in the label index file (that is separate from `chunks.txt`). It does the loading and unloading of the `Report._labels_index` as needed.
* `MinioEndpoints.label_index` and functions to write-to and read-from the file. There can be 1 such file for each `CommitReport`.
* `services/report/raw_upload_processor.py::make_sure_orginal_report_is_using_label_ids` encodes the labels in a `Report` prior to merging it with another report (if needed)
* `services/report/raw_upload_processor.py::make_sure_label_indexes_match` "fixes" the index of the new report to be merged based on the original report's index so that we can be sure that both indexes point to the same labels.

# Important changes
* `pycoverage.py` language processor now spits out reports with a label lookup table and `CoverageDatapoint` already encoded
* The processing of raw reports with labels has extra steps (make_sure_orginal_report_is_using_label_ids, make_sure_label_indexes_match)
* The `label_analysis` task works with label_ids and only translates them in the end.

# Things missing
- [ ] Feature flag changes. I just changes everything to the "ideal" end state, but we'd have issues deploying this with different worker deploys co-existing
- [ ] `label_analysis` has to work if the report is not encoded with IDs as well.