### PR TITLE
Prep the terrain for reports with label compression.

### DIFF
--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -84,7 +84,7 @@ class Upload(CodecovBaseModel, MixinBaseClass):
     name = Column(types.String(100))
     provider = Column(types.String(50))
     report_id = Column(types.BigInteger, ForeignKey("reports_commitreport.id"))
-    report = relationship(
+    report: CommitReport = relationship(
         "CommitReport", foreign_keys=[report_id], back_populates="uploads"
     )
     state = Column(types.String(100), nullable=False)

--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -22,3 +22,11 @@ LIST_REPOS_GENERATOR_BY_OWNER_SLUG = Feature(
         "gitlab/codecov": "enabled",
     },
 )
+
+# Eventually we want all repos to use this
+# This flag will just help us with the rollout process
+USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_SLUG = Feature(
+    "use_label_index_in_report_processing",
+    0.0,
+    overrides={"github/giovanni-guidini/sentry": "enabled"},
+)

--- a/services/archive.py
+++ b/services/archive.py
@@ -4,11 +4,12 @@ from base64 import b16encode
 from datetime import datetime
 from enum import Enum
 from hashlib import md5
-from typing import Any
+from typing import Dict
 from uuid import uuid4
 
 from shared.config import get_config
 from shared.storage.base import BaseStorageService
+from shared.storage.exceptions import FileNotInStorageError
 from shared.utils.ReportEncoder import ReportEncoder
 
 from helpers.metrics import metrics
@@ -19,6 +20,9 @@ log = logging.getLogger(__name__)
 
 class MinioEndpoints(Enum):
     chunks = "{version}/repos/{repo_hash}/commits/{commitid}/{chunks_file_name}.txt"
+    label_index = (
+        "{version}/repos/{repo_hash}/commits/{commitid}/{label_index_file_name}.json"
+    )
     json_data = "{version}/repos/{repo_hash}/commits/{commitid}/json_data/{table}/{field}/{external_id}.json"
     json_data_no_commit = (
         "{version}/repos/{repo_hash}/json_data/{table}/{field}/{external_id}.json"
@@ -226,6 +230,20 @@ class ArchiveService(object):
         self.write_file(path, stringified_data)
         return path
 
+    def write_label_index(self, commit_sha, json_data, report_code=None) -> str:
+        label_index_file_name = (
+            report_code + "_" if report_code is not None else ""
+        ) + "labels_index"
+        path = MinioEndpoints.label_index.get_path(
+            version="v4",
+            repo_hash=self.storage_hash,
+            commitid=commit_sha,
+            label_index_file_name=label_index_file_name,
+        )
+        string_data = json.dumps(json_data)
+        self.write_file(path, string_data)
+        return path
+
     """
     Convenience method to write a chunks.txt file to storage.
     """
@@ -285,6 +303,22 @@ class ArchiveService(object):
         )
 
         return self.read_file(path).decode(errors="replace")
+
+    def read_label_index(self, commit_sha, report_code=None) -> Dict[str, str]:
+        label_index_file_name = (
+            report_code + "_" if report_code is not None else ""
+        ) + "labels_index"
+        path = MinioEndpoints.label_index.get_path(
+            version="v4",
+            repo_hash=self.storage_hash,
+            commitid=commit_sha,
+            label_index_file_name=label_index_file_name,
+        )
+
+        try:
+            return json.loads(self.read_file(path).decode(errors="replace"))
+        except FileNotInStorageError:
+            return dict()
 
     """
     Delete a chunk file from the archive

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -786,7 +786,12 @@ class ReportService(object):
         try:
             with metrics.timer(f"{self.metrics_prefix}.process_report") as t:
                 result = process_raw_upload(
-                    self.current_yaml, master, raw_uploaded_report, flags, session
+                    self.current_yaml,
+                    master,
+                    raw_uploaded_report,
+                    flags,
+                    session,
+                    upload=upload,
                 )
                 report = result.report
             log.info(

--- a/services/report/labels_index.py
+++ b/services/report/labels_index.py
@@ -1,0 +1,46 @@
+from typing import Dict
+
+from shared.reports.resources import Report
+
+from database.models.reports import CommitReport
+from services.archive import ArchiveService
+
+
+class LabelsIndexService(object):
+    _archive_client: ArchiveService
+
+    def __init__(self, commit_report: CommitReport) -> None:
+        self.commit_report = commit_report
+        self._archive_client = ArchiveService(
+            repository=commit_report.commit.repository
+        )
+        self.commit_sha = commit_report.commit.commitid
+
+    def set_label_idx(self, report: Report):
+        # TODO: Needs shared update.
+        # if report._labels_index is not None:
+        #     raise Exception(
+        #         "Trying to set labels_index of Report, but it's already set"
+        #     )
+        # Load label index from storage
+        # JSON uses strings are keys, but we are using ints.
+        map_with_str_keys = self._archive_client.read_label_index(
+            self.commit_sha, self.commit_report.code
+        )
+        loaded_index = {int(k): v for k, v in map_with_str_keys.items()}
+        return loaded_index
+        # TODO: Needs shared update.
+        # report.set_label_idx(loaded_index)
+
+    def unset_label_idx(self, report: Report, label_index: Dict[str, str]):
+        # Write the updated index back into storage
+        # TODO: Needs shared update
+        # self._archive_client.write_label_index(
+        #     self.commit_sha, report._labels_index, self.commit_report.code
+        # )
+        self._archive_client.write_label_index(
+            self.commit_sha, label_index, self.commit_report.code
+        )
+        # Remove reference to it
+        # TODO: Needs shared update
+        # report.unset_label_idx()

--- a/services/report/tests/unit/test_labels_index.py
+++ b/services/report/tests/unit/test_labels_index.py
@@ -1,0 +1,85 @@
+import pytest
+from shared.reports.resources import Report
+
+from database.tests.factories.core import ReportFactory
+from helpers.labels import SpecialLabelsEnum
+from services.report.labels_index import ArchiveService, LabelsIndexService
+
+
+class TestLabelsIndex(object):
+    def test_init(self, dbsession, mocker):
+        commit_report = ReportFactory()
+        dbsession.add(commit_report)
+        dbsession.flush()
+
+        labels_index_service = LabelsIndexService(commit_report)
+        assert labels_index_service._archive_client is not None
+        assert labels_index_service.commit_sha == commit_report.commit.commitid
+
+    def test_set_label_idx(self, dbsession, mocker):
+        commit_report = ReportFactory()
+        dbsession.add(commit_report)
+        dbsession.flush()
+        # Notice that the keys are strings
+        # because self._archive_client.read_label_index returns the contents of a JSON file,
+        # and JSON can only have string keys.
+        sample_label_index = {
+            "0": SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+            "1": "some_label",
+            "2": "another_label",
+        }
+        mocker.patch.object(
+            ArchiveService, "read_label_index", return_value=sample_label_index
+        )
+        report = Report()
+        # TODO: Needs shared update
+        # assert report._labels_index == None
+        label_service = LabelsIndexService(commit_report)
+        res = label_service.set_label_idx(report)
+        assert res == {
+            0: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+            1: "some_label",
+            2: "another_label",
+        }
+
+    # TODO: Needs shared update
+    # def test_set_label_idx_already_set(self, dbsession, mocker):
+    #     commit_report = ReportFactory()
+    #     dbsession.add(commit_report)
+    #     dbsession.flush()
+    #     mock_read = mocker.patch.object(ArchiveService, "read_label_index")
+    #     sample_label_index = {
+    #         0: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+    #         1: "some_label",
+    #         2: "another_label",
+    #     }
+    #     report = Report()
+    #     report._labels_index = sample_label_index
+    #     with pytest.raises(Exception) as exp:
+    #         label_service = LabelsIndexService(commit_report)
+    #         label_service.set_label_idx(report)
+    #     mock_read.assert_not_called()
+    #     assert (
+    #         str(exp.value)
+    #         == "Trying to set labels_index of Report, but it's already set"
+    #     )
+
+    def test_unset_label_idx(self, dbsession, mocker):
+        commit_report = ReportFactory()
+        dbsession.add(commit_report)
+        dbsession.flush()
+        sample_label_index = {
+            0: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+            1: "some_label",
+            2: "another_label",
+        }
+        mock_write = mocker.patch.object(ArchiveService, "write_label_index")
+        report = Report()
+        # TODO: Needs shared update
+        # report._labels_index = sample_label_index
+        label_service = LabelsIndexService(commit_report)
+        label_service.unset_label_idx(report, sample_label_index)
+        # assert report._labels_index == None
+        mock_write.assert_called_with(
+            commit_report.commit.commitid, sample_label_index, commit_report.code
+        )

--- a/services/tests/unit/test_archive_service.py
+++ b/services/tests/unit/test_archive_service.py
@@ -1,8 +1,10 @@
 import json
 
 from shared.storage import MinioStorageService
+from shared.storage.exceptions import FileNotInStorageError
 
 from database.tests.factories import RepositoryFactory
+from database.tests.factories.core import CommitFactory
 from services.archive import ArchiveService
 from test_utils.base import BaseTestCase
 
@@ -135,4 +137,81 @@ class TestWriteJsonData(BaseTestCase):
             json.dumps(data),
             is_already_gzipped=False,
             reduced_redundancy=False,
+        )
+
+
+class TestLabelIndex(object):
+    def test_write_label_index_to_storage(self, mocker, dbsession):
+        commit = CommitFactory()
+        dbsession.add(commit)
+        dbsession.flush()
+        mock_write_file = mocker.patch.object(MinioStorageService, "write_file")
+        archive_service = ArchiveService(repository=commit.repository)
+        data = {1: "some_label", 2: "another_label", 3: "yet_another_label"}
+        path_for_default_code = archive_service.write_label_index(
+            commit.commitid, data, report_code=None
+        )
+        assert (
+            path_for_default_code
+            == f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/labels_index.json"
+        )
+        mock_write_file.assert_called_with(
+            archive_service.root,
+            path_for_default_code,
+            json.dumps(data),
+            is_already_gzipped=False,
+            reduced_redundancy=False,
+        )
+
+        path_for_different_code = archive_service.write_label_index(
+            commit.commitid, data, report_code="local"
+        )
+        assert (
+            path_for_different_code
+            == f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/local_labels_index.json"
+        )
+        mock_write_file.assert_called_with(
+            archive_service.root,
+            path_for_different_code,
+            json.dumps(data),
+            is_already_gzipped=False,
+            reduced_redundancy=False,
+        )
+
+    def test_read_label_index_from_storage(self, mocker, dbsession):
+        commit = CommitFactory()
+        dbsession.add(commit)
+        dbsession.flush()
+        # Notice that the keys are string. JSON uses strings as keys.
+        # It's not the responsibility of read_label_index to fix this detail
+        data = {"1": "some_label", "2": "another_label", "3": "yet_another_label"}
+        mock_read_file = mocker.patch.object(
+            ArchiveService, "read_file", return_value=json.dumps(data).encode()
+        )
+        archive_service = ArchiveService(repository=commit.repository)
+
+        assert archive_service.read_label_index(commit.commitid) == data
+        mock_read_file.assert_called_with(
+            f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/labels_index.json"
+        )
+
+        assert (
+            archive_service.read_label_index(commit.commitid, report_code="local")
+            == data
+        )
+        mock_read_file.assert_called_with(
+            f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/local_labels_index.json"
+        )
+
+    def test_read_label_index_from_storage_file_not_found(self, mocker, dbsession):
+        commit = CommitFactory()
+        dbsession.add(commit)
+        dbsession.flush()
+        mock_read_file = mocker.patch.object(
+            ArchiveService, "read_file", side_effect=FileNotInStorageError
+        )
+        archive_service = ArchiveService(repository=commit.repository)
+        assert archive_service.read_label_index(commit.commitid) == {}
+        mock_read_file.assert_called_with(
+            f"v4/repos/{archive_service.storage_hash}/commits/{commit.commitid}/labels_index.json"
         )


### PR DESCRIPTION
context: codecov/engineering-team #768

Creates a rollout for label compression. This is gonna help us to test and safely release the feature in the wild.
Notice that currently the label compression does nothing.
There are comments similar to `TODO: needs shared update`.
The update in question is https://github.com/codecov/shared/pull/79

So these changes mostly prep the terrain for future changes that will actually do something,
and add the guardrails to avoid issues when deploying.
In particular it adds some helper methods to the `ArchiveService`, creates a kinda-stubbed `LabelsIndexService`,
passes more data to the `_adjust_sessions` portion of `raw_upload_processor` where most changes will occur.

If you're curious as to what the end result will probably look like see https://github.com/codecov/worker/pull/180

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.