### PR TITLE
feat: call CleanLabelsIndexTask

### DIFF
--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -403,6 +403,7 @@ class TestUploadFinisherTask(object):
                 "app.tasks.notify.Notify": mocker.MagicMock(),
                 "app.tasks.pulls.Sync": mocker.MagicMock(),
                 "app.tasks.compute_comparison.ComputeComparison": mocker.MagicMock(),
+                "app.tasks.upload.UploadCleanLabelsIndex": mocker.MagicMock(),
             },
         )
         repository = RepositoryFactory.create(
@@ -457,6 +458,71 @@ class TestUploadFinisherTask(object):
         mocked_app.tasks[
             "app.tasks.compute_comparison.ComputeComparison"
         ].apply_async.assert_called_once()
+        mocked_app.tasks[
+            "app.tasks.upload.UploadCleanLabelsIndex"
+        ].apply_async.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_finish_reports_processing_call_clean_labels(self, dbsession, mocker):
+        commit_yaml = {
+            "flag_management": {
+                "individual_flags": [
+                    {
+                        "name": "smart-tests",
+                        "carryforward": True,
+                        "carryforward_mode": "labels",
+                    },
+                    {
+                        "name": "just-tests",
+                        "carryforward": True,
+                    },
+                ]
+            }
+        }
+        mocked_app = mocker.patch.object(UploadFinisherTask, "app")
+        commit = CommitFactory.create(
+            message="dsidsahdsahdsa",
+            commitid="abf6d4df662c47e32460020ab14abf9303581429",
+            repository__owner__unencrypted_oauth_token="testulk3d54rlhxkjyzomq2wh8b7np47xabcrkx8",
+            repository__owner__username="ThiagoCodecov",
+            repository__yaml=commit_yaml,
+        )
+        processing_results = {
+            "processings_so_far": [
+                {"successful": True, "arguments": {"flags": "smart-tests"}}
+            ]
+        }
+        dbsession.add(commit)
+        dbsession.flush()
+
+        checkpoints = _create_checkpoint_logger(mocker)
+        res = await UploadFinisherTask().finish_reports_processing(
+            dbsession,
+            commit,
+            UserYaml(commit_yaml),
+            processing_results,
+            None,
+            checkpoints,
+        )
+        assert res == {"notifications_called": True}
+        mocked_app.tasks["app.tasks.notify.Notify"].apply_async.assert_any_call(
+            kwargs={
+                "commitid": commit.commitid,
+                "current_yaml": commit_yaml,
+                "repoid": commit.repoid,
+                _kwargs_key(UploadFlow): ANY,
+            },
+        )
+        mocked_app.tasks[
+            "app.tasks.upload.UploadCleanLabelsIndex"
+        ].apply_async.assert_called_with(
+            kwargs={
+                "repoid": commit.repoid,
+                "commitid": commit.commitid,
+                "report_code": None,
+            },
+        )
+        assert mocked_app.send_task.call_count == 0
 
     @pytest.mark.asyncio
     async def test_finish_reports_processing_no_notification(self, dbsession, mocker):
@@ -507,3 +573,78 @@ class TestUploadFinisherTask(object):
         )
 
         mocked_save_commit_measurements.assert_called_once_with(commit)
+
+
+class TestShouldCleanLabelsIndex(object):
+    @pytest.mark.parametrize(
+        "processing_results, expected",
+        [
+            (
+                {
+                    "processings_so_far": [
+                        {"successful": True, "arguments": {"flags": "smart-tests"}}
+                    ]
+                },
+                True,
+            ),
+            (
+                {
+                    "processings_so_far": [
+                        {"successful": True, "arguments": {"flags": "just-tests"}}
+                    ]
+                },
+                False,
+            ),
+            (
+                {
+                    "processings_so_far": [
+                        {
+                            "successful": True,
+                            "arguments": {"flags": "just-tests,smart-tests"},
+                        }
+                    ]
+                },
+                True,
+            ),
+            (
+                {
+                    "processings_so_far": [
+                        {"successful": False, "arguments": {"flags": "smart-tests"}}
+                    ]
+                },
+                False,
+            ),
+            (
+                {
+                    "processings_so_far": [
+                        {"successful": True, "arguments": {"flags": "just-tests"}},
+                        {"successful": True, "arguments": {"flags": "smart-tests"}},
+                    ]
+                },
+                True,
+            ),
+        ],
+    )
+    def test_should_clean_labels_index(self, processing_results, expected):
+        commit_yaml = UserYaml(
+            {
+                "flag_management": {
+                    "individual_flags": [
+                        {
+                            "name": "smart-tests",
+                            "carryforward": True,
+                            "carryforward_mode": "labels",
+                        },
+                        {
+                            "name": "just-tests",
+                            "carryforward": True,
+                        },
+                    ]
+                }
+            }
+        )
+        instance = (
+            UploadFinisherTask()
+        )  # Replace with the actual class name where the method is defined
+        result = instance.should_clean_labels_index(commit_yaml, processing_results)
+        assert result == expected

--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -643,8 +643,6 @@ class TestShouldCleanLabelsIndex(object):
                 }
             }
         )
-        instance = (
-            UploadFinisherTask()
-        )  # Replace with the actual class name where the method is defined
-        result = instance.should_clean_labels_index(commit_yaml, processing_results)
+        task = UploadFinisherTask()
+        result = task.should_clean_labels_index(commit_yaml, processing_results)
         assert result == expected

--- a/tasks/upload_clean_labels_index.py
+++ b/tasks/upload_clean_labels_index.py
@@ -38,9 +38,13 @@ class ReadOnlyArgs(TypedDict):
     commit_yaml: Optional[Dict]
 
 
+# TODO: Move to shared
+task_name = f"app.tasks.{TaskConfigGroup.upload.value}.UploadCleanLabelsIndex"
+
+
 class CleanLabelsIndexTask(
     BaseCodecovTask,
-    name=f"app.tasks.{TaskConfigGroup.upload.value}.UploadCleanLabelsIndex",
+    name=task_name,
 ):
     async def run_async(
         self, db_session, repoid, commitid, report_code=None, *args, **kwargs

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -22,6 +22,7 @@ from services.report import ReportService
 from services.timeseries import save_commit_measurements
 from services.yaml import read_yaml_field
 from tasks.base import BaseCodecovTask
+from tasks.upload_clean_labels_index import task_name as clean_labels_index_task_name
 
 log = logging.getLogger(__name__)
 
@@ -207,12 +208,46 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         else:
             commit.state = "skipped"
 
+        if self.should_clean_labels_index(commit_yaml, processing_results):
+            task = self.app.tasks[clean_labels_index_task_name].apply_async(
+                kwargs={
+                    "repoid": repoid,
+                    "commitid": commitid,
+                    "report_code": report_code,
+                },
+            )
+            log.info(
+                "Scheduling clean_labels_index task",
+                extra=dict(
+                    repoid=repoid,
+                    commit=commitid,
+                    clean_labels_index_task_id=task.id,
+                    parent_task=self.request.parent_id,
+                ),
+            )
+
         if checkpoints:
             checkpoints.log(UploadFlow.PROCESSING_COMPLETE)
             if not notifications_called:
                 checkpoints.log(UploadFlow.SKIPPING_NOTIFICATION)
 
         return {"notifications_called": notifications_called}
+
+    def should_clean_labels_index(self, commit_yaml: UserYaml, processing_results):
+        """Returns True if any of the successful processings was uploaded using a flag
+        that implies labels were uploaded with the report.
+        """
+        actual_processing_results = processing_results.get("processings_so_far", [])
+        for result in actual_processing_results:
+            if result["successful"]:
+                flags_str: str = result.get("arguments", {}).get("flags", "")
+                if flags_str:
+                    individual_flags = flags_str.split(",")
+                    for flag in individual_flags:
+                        config = commit_yaml.get_flag_configuration(flag)
+                        if config and config.get("carryforward_mode") == "labels":
+                            return True
+        return False
 
     def should_call_notifications(
         self, commit, commit_yaml, processing_results, report_code


### PR DESCRIPTION
If the processed upload includes a flag that is carryforward
AND "labels" mode, we enqueue the CleanLabelsIndexTask.

Depends on https://github.com/codecov/worker/pull/205

I tried to be conservative, but it's possible that - despite
using the flag with labels - no labels are uploaded. It's
also possible that there's nothing to do. But these are small
details.

ps.: To see that indeed we have an "arguments" and "flag" in
"processing_results" I looked at logs for the message
"Scheduling notify task" :wink:

closes codecov/engineering-team#768

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.