### PR TITLE
chore: rename comparison base commit fields to project/patch base

### DIFF
--- a/services/comparison/conftest.py
+++ b/services/comparison/conftest.py
@@ -84,8 +84,8 @@ def sample_comparison(dbsession, request, sample_report):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={

--- a/services/comparison/overlays/critical_path.py
+++ b/services/comparison/overlays/critical_path.py
@@ -18,7 +18,7 @@ def _get_latest_profiling_commit(comparison):
     return (
         db_session.query(ProfilingCommit)
         .filter(
-            ProfilingCommit.repoid == comparison.base.commit.repoid,
+            ProfilingCommit.repoid == comparison.project_coverage_base.commit.repoid,
             ~ProfilingCommit.summarized_location.is_(None),
             ~ProfilingCommit.last_summarized_at.is_(None),
         )
@@ -125,7 +125,7 @@ class CriticalPathOverlay(object):
             return None
         diff = rustify_diff(await self._comparison.get_diff())
         return self.full_analyzer.find_impacted_endpoints(
-            self._comparison.base.report.rust_report.get_report(),
+            self._comparison.project_coverage_base.report.rust_report.get_report(),
             self._comparison.head.report.rust_report.get_report(),
             diff,
         )

--- a/services/comparison/tests/unit/overlay/test_critical_path.py
+++ b/services/comparison/tests/unit/overlay/test_critical_path.py
@@ -75,7 +75,7 @@ def test_load_critical_path_report(
     mock_storage.write_file("bucket", url, json.dumps(data))
     pc = ProfilingCommitFactory.create(
         summarized_location=url,
-        repository=sample_comparison.base.commit.repository,
+        repository=sample_comparison.project_coverage_base.commit.repository,
         last_summarized_at=datetime(2021, 10, 10),
     )
     dbsession.add(pc)
@@ -105,12 +105,12 @@ def test_load_critical_path_report_not_summarized(
     mock_storage.write_file("bucket", url, json.dumps(data))
     pc = ProfilingCommitFactory.create(
         summarized_location=None,
-        repository=sample_comparison.base.commit.repository,
+        repository=sample_comparison.project_coverage_base.commit.repository,
         last_summarized_at=datetime(2021, 3, 1, 5),
     )
     second_pc = ProfilingCommitFactory.create(
         summarized_location=url,
-        repository=sample_comparison.base.commit.repository,
+        repository=sample_comparison.project_coverage_base.commit.repository,
         last_summarized_at=datetime(2021, 3, 1, 4),
     )
     dbsession.add(pc)
@@ -134,7 +134,7 @@ def test_load_critical_path_report_yes_commit_no_storage(
     url = "v4/banana/abcdef.json"
     pc = ProfilingCommitFactory.create(
         summarized_location=url,
-        repository=sample_comparison.base.commit.repository,
+        repository=sample_comparison.project_coverage_base.commit.repository,
         last_summarized_at=datetime(2021, 3, 1, 5),
     )
     dbsession.add(pc)
@@ -242,7 +242,7 @@ class TestCriticalPathOverlay(object):
         pc = ProfilingCommitFactory.create(
             summarized_location="someurl",
             joined_location=url,
-            repository=sample_comparison.base.commit.repository,
+            repository=sample_comparison.project_coverage_base.commit.repository,
             last_summarized_at=datetime(2021, 3, 1, 4),
         )
         dbsession.add(pc)

--- a/services/comparison/tests/unit/test_behind_by.py
+++ b/services/comparison/tests/unit/test_behind_by.py
@@ -24,7 +24,7 @@ class TestGetBehindBy(object):
     @pytest.mark.asyncio
     async def test_get_behind_by_no_base_commit(self, mocker):
         comparison = ComparisonProxy(mocker.MagicMock())
-        del comparison.comparison.base.commit.commitid
+        del comparison.comparison.project_coverage_base.commit.commitid
         res = await comparison.get_behind_by()
         assert res is None
 

--- a/services/comparison/tests/unit/test_comparison_proxy.py
+++ b/services/comparison/tests/unit/test_comparison_proxy.py
@@ -15,14 +15,14 @@ def make_sample_comparison(adjusted_base=False):
 
     if adjusted_base:
         # Just getting a random commitid, doesn't need to be in the db
-        original_base_commitid = CommitFactory.create(repository=repo).commitid
+        patch_coverage_base_commitid = CommitFactory.create(repository=repo).commitid
     else:
-        original_base_commitid = adjusted_base_commit.commitid
+        patch_coverage_base_commitid = adjusted_base_commit.commitid
 
     pull = PullFactory.create(
         repository=repo,
         head=head_commit.commitid,
-        base=original_base_commitid,
+        base=patch_coverage_base_commitid,
         compared_to=adjusted_base_commit.commitid,
     )
 
@@ -31,8 +31,8 @@ def make_sample_comparison(adjusted_base=False):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=original_base_commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=patch_coverage_base_commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={},
@@ -56,13 +56,13 @@ class TestComparisonProxy(object):
         assert comparison._adjusted_base_diff == "magic string"
         assert not comparison._original_base_diff
         assert (
-            comparison.comparison.original_base_commitid
-            != comparison.base.commit.commitid
+            comparison.comparison.patch_coverage_base_commitid
+            != comparison.project_coverage_base.commit.commitid
         )
 
         assert mock_get_compare.call_args_list == [
             call(
-                comparison.base.commit.commitid,
+                comparison.project_coverage_base.commit.commitid,
                 comparison.head.commit.commitid,
                 with_commits=False,
             ),
@@ -79,13 +79,13 @@ class TestComparisonProxy(object):
         assert comparison._original_base_diff == "magic string"
         assert not comparison._adjusted_base_diff
         assert (
-            comparison.comparison.original_base_commitid
-            != comparison.base.commit.commitid
+            comparison.comparison.patch_coverage_base_commitid
+            != comparison.project_coverage_base.commit.commitid
         )
 
         assert mock_get_compare.call_args_list == [
             call(
-                comparison.comparison.original_base_commitid,
+                comparison.comparison.patch_coverage_base_commitid,
                 comparison.head.commit.commitid,
                 with_commits=False,
             ),
@@ -101,8 +101,8 @@ class TestComparisonProxy(object):
         assert result == "magic string"
         assert comparison._original_base_diff == "magic string"
         assert (
-            comparison.comparison.original_base_commitid
-            == comparison.base.commit.commitid
+            comparison.comparison.patch_coverage_base_commitid
+            == comparison.project_coverage_base.commit.commitid
         )
 
         # In this test case, the adjusted and original base commits are the
@@ -113,7 +113,7 @@ class TestComparisonProxy(object):
         # Make sure we only called the Git provider API once
         assert mock_get_compare.call_args_list == [
             call(
-                comparison.comparison.original_base_commitid,
+                comparison.comparison.patch_coverage_base_commitid,
                 comparison.head.commit.commitid,
                 with_commits=False,
             ),
@@ -129,8 +129,8 @@ class TestComparisonProxy(object):
         assert result == "magic string"
         assert comparison._adjusted_base_diff == "magic string"
         assert (
-            comparison.comparison.original_base_commitid
-            == comparison.base.commit.commitid
+            comparison.comparison.patch_coverage_base_commitid
+            == comparison.project_coverage_base.commit.commitid
         )
 
         # In this test case, the adjusted and original base commits are the
@@ -141,7 +141,7 @@ class TestComparisonProxy(object):
         # Make sure we only called the Git provider API once
         assert mock_get_compare.call_args_list == [
             call(
-                comparison.comparison.original_base_commitid,
+                comparison.comparison.patch_coverage_base_commitid,
                 comparison.head.commit.commitid,
                 with_commits=False,
             ),

--- a/services/comparison/types.py
+++ b/services/comparison/types.py
@@ -22,19 +22,22 @@ class Comparison(object):
     # report against the base's report, or if the base isn't in our database,
     # the next-oldest commit that is. Be aware that this base commit may not be
     # the true base that, for example, a PR is based on.
-    base: FullCommit
+    project_coverage_base: FullCommit
 
     # Computing patch coverage doesn't require an old report to compare against,
     # so doing the "next-oldest" adjustment described above is unnecessary and
     # makes the results less correct. All it requires is a head report and the
     # patch diff, and the original base's commit SHA is enough to get that.
-    original_base_commitid: str
+    patch_coverage_base_commitid: str
 
     enriched_pull: EnrichedPull
     current_yaml: Optional[UserYaml] = None
 
-    def has_base_report(self):
-        return bool(self.base is not None and self.base.report is not None)
+    def has_project_coverage_base_report(self):
+        return bool(
+            self.project_coverage_base is not None
+            and self.project_coverage_base.report is not None
+        )
 
     def has_head_report(self):
         return bool(self.head is not None and self.head.report is not None)

--- a/services/notification/__init__.py
+++ b/services/notification/__init__.py
@@ -179,8 +179,8 @@ class NotificationService(object):
             f"Notifying with decoration type {self.decoration_type}",
             extra=dict(
                 head_commit=comparison.head.commit.commitid,
-                base_commit=comparison.base.commit.commitid
-                if comparison.base.commit is not None
+                base_commit=comparison.project_coverage_base.commit.commitid
+                if comparison.project_coverage_base.commit is not None
                 else "NO_BASE",
                 repoid=comparison.head.commit.repoid,
             ),
@@ -204,7 +204,7 @@ class NotificationService(object):
         self, notifier, comparison
     ) -> NotificationResult:
         commit = comparison.head.commit
-        base_commit = comparison.base.commit
+        base_commit = comparison.project_coverage_base.commit
         log.info(
             "Attempting individual notification",
             extra=dict(

--- a/services/notification/notifiers/codecov_slack_app.py
+++ b/services/notification/notifiers/codecov_slack_app.py
@@ -56,8 +56,8 @@ class CodecovSlackAppNotifier(AbstractBaseNotifier):
 
     def build_payload(self, comparison: Comparison):
         head_full_commit = comparison.head
-        base_full_commit = comparison.base
-        if comparison.has_base_report():
+        base_full_commit = comparison.project_coverage_base
+        if comparison.has_project_coverage_base_report():
             difference = None
             head_report_coverage = head_full_commit.report.totals.coverage
             base_report_coverage = base_full_commit.report.totals.coverage
@@ -94,7 +94,9 @@ class CodecovSlackAppNotifier(AbstractBaseNotifier):
                 comparison.head.commit if comparison.head else None
             ),
             "base_commit": self.serialize_commit(
-                comparison.base.commit if comparison.base else None
+                comparison.project_coverage_base.commit
+                if comparison.project_coverage_base
+                else None
             ),
             "head_totals_c": str(comparison.head.report.totals.coverage),
         }

--- a/services/notification/notifiers/generics.py
+++ b/services/notification/notifiers/generics.py
@@ -128,11 +128,11 @@ class StandardNotifier(AbstractBaseNotifier):
 
     def is_above_threshold(self, comparison: Comparison):
         head_full_commit = comparison.head
-        base_full_commit = comparison.base
+        base_full_commit = comparison.project_coverage_base
         threshold = self.notifier_yaml_settings.get("threshold")
         if threshold is None:
             return True
-        if not comparison.has_base_report():
+        if not comparison.has_project_coverage_base_report():
             log.info(
                 "Cannot compare commits because base commit does not have a report",
                 extra=dict(
@@ -165,8 +165,8 @@ class StandardNotifier(AbstractBaseNotifier):
 
     def generate_compare_dict(self, comparison: Comparison):
         head_full_commit = comparison.head
-        base_full_commit = comparison.base
-        if comparison.has_base_report():
+        base_full_commit = comparison.project_coverage_base
+        if comparison.has_project_coverage_base_report():
             difference = Decimal(head_full_commit.report.totals.coverage) - Decimal(
                 base_full_commit.report.totals.coverage
             )
@@ -202,7 +202,7 @@ class StandardNotifier(AbstractBaseNotifier):
             return self.notifier_yaml_settings.get("message")
         commit = comparison.head.commit
         comparison_string = ""
-        if comparison.has_base_report():
+        if comparison.has_project_coverage_base_report():
             compare = self.generate_compare_dict(comparison)
             comparison_string = self.COMPARISON_STRING.format(
                 compare_message=compare["message"],

--- a/services/notification/notifiers/hipchat.py
+++ b/services/notification/notifiers/hipchat.py
@@ -35,7 +35,7 @@ class HipchatNotifier(RequestsYamlBasedNotifier):
         comparison_dict = self.generate_compare_dict(comparison)
         if self.notifier_yaml_settings.get("card"):
             compare = []
-            if comparison.base.report is not None:
+            if comparison.project_coverage_base.report is not None:
                 compare = [
                     {
                         "label": "Compare",

--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -40,7 +40,7 @@ class MessageMixin(object):
         changes = await comparison.get_changes()
         diff = await comparison.get_diff(use_original_base=True)
         behind_by = await comparison.get_behind_by()
-        base_report = comparison.base.report
+        base_report = comparison.project_coverage_base.report
         head_report = comparison.head.report
         pull = comparison.pull
 
@@ -51,8 +51,8 @@ class MessageMixin(object):
 
         links = {
             "pull": get_pull_url(pull),
-            "base": get_commit_url(comparison.base.commit)
-            if comparison.base.commit is not None
+            "base": get_commit_url(comparison.project_coverage_base.commit)
+            if comparison.project_coverage_base.commit is not None
             else None,
         }
 

--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -105,7 +105,7 @@ class NewFooterSectionWriter(BaseSectionWriter):
 class NewHeaderSectionWriter(BaseSectionWriter):
     async def do_write_section(self, comparison, diff, changes, links, behind_by=None):
         yaml = self.current_yaml
-        base_report = comparison.base.report
+        base_report = comparison.project_coverage_base.report
         head_report = comparison.head.report
         pull = comparison.pull
         pull_dict = comparison.enriched_pull.provider_pull
@@ -134,7 +134,7 @@ class NewHeaderSectionWriter(BaseSectionWriter):
                     pull=pull.pullid,
                     base=pull_dict["base"]["branch"],
                     commitid_head=comparison.head.commit.commitid[:7],
-                    commitid_base=comparison.base.commit.commitid[:7],
+                    commitid_base=comparison.project_coverage_base.commit.commitid[:7],
                     links=links,
                     base_cov=round_number(yaml, Decimal(base_report.totals.coverage)),
                     head_cov=round_number(yaml, Decimal(head_report.totals.coverage)),
@@ -204,7 +204,7 @@ class NewHeaderSectionWriter(BaseSectionWriter):
 class HeaderSectionWriter(BaseSectionWriter):
     async def do_write_section(self, comparison, diff, changes, links, behind_by=None):
         yaml = self.current_yaml
-        base_report = comparison.base.report
+        base_report = comparison.project_coverage_base.report
         head_report = comparison.head.report
         pull = comparison.pull
         pull_dict = comparison.enriched_pull.provider_pull
@@ -225,7 +225,7 @@ class HeaderSectionWriter(BaseSectionWriter):
                     pull=pull.pullid,
                     base=pull_dict["base"]["branch"],
                     commitid_head=comparison.head.commit.commitid[:7],
-                    commitid_base=comparison.base.commit.commitid[:7],
+                    commitid_base=comparison.project_coverage_base.commit.commitid[:7],
                     # ternary operator, see https://stackoverflow.com/questions/394809/does-python-have-a-ternary-conditional-operator
                     message={False: "decrease", "na": "not change", True: "increase"}[
                         (change > 0) if change != 0 else "na"
@@ -416,7 +416,7 @@ class ReachSectionWriter(BaseSectionWriter):
 
 class DiffSectionWriter(BaseSectionWriter):
     async def do_write_section(self, comparison, diff, changes, links, behind_by=None):
-        base_report = comparison.base.report
+        base_report = comparison.project_coverage_base.report
         head_report = comparison.head.report
         if base_report is None:
             base_report = Report()
@@ -438,7 +438,7 @@ class DiffSectionWriter(BaseSectionWriter):
 class NewFilesSectionWriter(BaseSectionWriter):
     async def do_write_section(self, comparison, diff, changes, links, behind_by=None):
         # create list of files changed in diff
-        base_report = comparison.base.report
+        base_report = comparison.project_coverage_base.report
         head_report = comparison.head.report
         if base_report is None:
             base_report = Report()
@@ -520,7 +520,7 @@ class NewFilesSectionWriter(BaseSectionWriter):
 class FileSectionWriter(BaseSectionWriter):
     async def do_write_section(self, comparison, diff, changes, links, behind_by=None):
         # create list of files changed in diff
-        base_report = comparison.base.report
+        base_report = comparison.project_coverage_base.report
         head_report = comparison.head.report
         if base_report is None:
             base_report = Report()
@@ -613,7 +613,7 @@ class FileSectionWriter(BaseSectionWriter):
 class FlagSectionWriter(BaseSectionWriter):
     async def do_write_section(self, comparison, diff, changes, links, behind_by=None):
         # flags
-        base_report = comparison.base.report
+        base_report = comparison.project_coverage_base.report
         head_report = comparison.head.report
         if base_report is None:
             base_report = Report()
@@ -754,8 +754,8 @@ class ComponentsSectionWriter(BaseSectionWriter):
             component_data.append(
                 {
                     "name": component.get_display_name(),
-                    "before": filtered_comparison.base.report.totals
-                    if filtered_comparison.base.report is not None
+                    "before": filtered_comparison.project_coverage_base.report.totals
+                    if filtered_comparison.project_coverage_base.report is not None
                     else None,
                     "after": filtered_comparison.head.report.totals,
                     "diff": filtered_comparison.head.report.apply_diff(

--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -262,7 +262,11 @@ class StatusNotifier(AbstractBaseNotifier):
     async def maybe_send_notification(
         self, comparison: Comparison, payload: dict
     ) -> NotificationResult:
-        base_commit = comparison.base.commit if comparison.base else None
+        base_commit = (
+            comparison.project_coverage_base.commit
+            if comparison.project_coverage_base
+            else None
+        )
         head_commit = comparison.head.commit if comparison.head else None
 
         cache_key = make_hash_sha256(

--- a/services/notification/notifiers/tests/conftest.py
+++ b/services/notification/notifiers/tests/conftest.py
@@ -367,8 +367,8 @@ def create_sample_comparison(dbsession, request, sample_report, mocker):
         return ComparisonProxy(
             Comparison(
                 head=head_full_commit,
-                base=base_full_commit,
-                original_base_commitid=base_commit.commitid,
+                project_coverage_base=base_full_commit,
+                patch_coverage_base_commitid=base_commit.commitid,
                 enriched_pull=EnrichedPull(database_pull=pull, provider_pull={}),
             )
         )
@@ -411,8 +411,8 @@ def sample_comparison(dbsession, request, sample_report, mocker):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -469,8 +469,8 @@ async def sample_comparison_coverage_carriedforward(
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -523,8 +523,8 @@ def sample_comparison_negative_change(dbsession, request, sample_report, mocker)
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -577,8 +577,8 @@ def sample_comparison_no_change(dbsession, request, sample_report, mocker):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -629,8 +629,8 @@ def sample_comparison_without_pull(dbsession, request, sample_report, mocker):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(database_pull=None, provider_pull=None),
         )
     )
@@ -670,8 +670,8 @@ def sample_comparison_database_pull_without_provider(
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(database_pull=pull, provider_pull=None),
         )
     )
@@ -703,8 +703,8 @@ def generate_sample_comparison(username, dbsession, base_report, head_report):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -756,8 +756,8 @@ def sample_comparison_without_base_report(dbsession, request, sample_report, moc
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -814,8 +814,8 @@ def sample_comparison_without_base_with_pull(dbsession, request, sample_report, 
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid="cdf9aa4bd2c6bcd8a662864097cb62a85a2fd55b",
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid="cdf9aa4bd2c6bcd8a662864097cb62a85a2fd55b",
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -881,8 +881,8 @@ def sample_comparison_head_and_pull_head_differ(
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={

--- a/services/notification/notifiers/tests/integration/test_comment.py
+++ b/services/notification/notifiers/tests/integration/test_comment.py
@@ -58,8 +58,8 @@ def codecove2e_comparison(dbsession, request, sample_report, small_report):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -121,8 +121,8 @@ def sample_comparison(dbsession, request, sample_report, small_report):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -185,8 +185,8 @@ def sample_comparison_gitlab(dbsession, request, sample_report, small_report):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -248,8 +248,8 @@ def sample_comparison_for_upgrade(dbsession, request, sample_report, small_repor
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={
@@ -309,8 +309,8 @@ def sample_comparison_for_limited_upload(
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -198,7 +198,9 @@ def comparison_with_multiple_changes(sample_comparison):
     second_unrelated_file.append(16, ReportLine.create(coverage=1))
     second_unrelated_file.append(32, ReportLine.create(coverage=0))
     second_report.append(second_unrelated_file)
-    sample_comparison.base.report = ReadOnlyReport.create_from_report(first_report)
+    sample_comparison.project_coverage_base.report = ReadOnlyReport.create_from_report(
+        first_report
+    )
     sample_comparison.head.report = ReadOnlyReport.create_from_report(second_report)
     return sample_comparison
 
@@ -824,7 +826,7 @@ class TestPatchChecksNotifier(object):
         third_file.append(101, ReportLine.create(coverage=1, sessions=[[0, 1]]))
         third_file.append(102, ReportLine.create(coverage=1, sessions=[[0, 1]]))
         third_file.append(103, ReportLine.create(coverage=1, sessions=[[0, 1]]))
-        sample_comparison.base.report.append(third_file)
+        sample_comparison.project_coverage_base.report.append(third_file)
         notifier = PatchChecksNotifier(
             repository=sample_comparison.head.commit.repository,
             title="default",
@@ -943,7 +945,7 @@ class TestPatchChecksNotifier(object):
         )
         assert notifier.is_enabled()
         notifier.name
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         expected_result = {
             "state": "success",
@@ -1058,7 +1060,7 @@ class TestPatchChecksNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         result = await notifier.notify(sample_comparison)
         assert result.notification_successful == True
@@ -1352,7 +1354,7 @@ class TestProjectChecksNotifier(object):
     ):
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "codecov.io"
         repo = sample_comparison.head.commit.repository
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         payload = {
             "state": "success",
@@ -1362,7 +1364,7 @@ class TestProjectChecksNotifier(object):
                 "text": "\n".join(
                     [
                         f"## [Codecov](codecov.io/gh/test_build_default_payload/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=h1) Report",
-                        f"> Merging [#{sample_comparison.pull.pullid}](codecov.io/gh/test_build_default_payload/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=desc) ({head_commit.commitid[:7]}) into [master](codecov.io/gh/test_build_default_payload/{repo.name}/commit/{sample_comparison.base.commit.commitid}?el=desc) ({base_commit.commitid[:7]}) will **increase** coverage by `10.00%`.",
+                        f"> Merging [#{sample_comparison.pull.pullid}](codecov.io/gh/test_build_default_payload/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=desc) ({head_commit.commitid[:7]}) into [master](codecov.io/gh/test_build_default_payload/{repo.name}/commit/{sample_comparison.project_coverage_base.commit.commitid}?el=desc) ({base_commit.commitid[:7]}) will **increase** coverage by `10.00%`.",
                         f"> The diff coverage is `66.67%`.",
                         f"",
                         f"| [Files](codecov.io/gh/test_build_default_payload/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=tree) | Coverage Δ | Complexity Δ | |",
@@ -1390,7 +1392,7 @@ class TestProjectChecksNotifier(object):
                 "text": "\n".join(
                     [
                         f"## [Codecov](codecov.io/gh/test_build_default_payload/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=h1&utm_medium=referral&utm_source=github&utm_content=checks&utm_campaign=pr+comments&utm_term={quote_plus(repo.owner.name)}) Report",
-                        f"> Merging [#{sample_comparison.pull.pullid}](codecov.io/gh/test_build_default_payload/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=desc&utm_medium=referral&utm_source=github&utm_content=checks&utm_campaign=pr+comments&utm_term={quote_plus(repo.owner.name)}) ({head_commit.commitid[:7]}) into [master](codecov.io/gh/test_build_default_payload/{repo.name}/commit/{sample_comparison.base.commit.commitid}?el=desc&utm_medium=referral&utm_source=github&utm_content=checks&utm_campaign=pr+comments&utm_term={quote_plus(repo.owner.name)}) ({base_commit.commitid[:7]}) will **increase** coverage by `10.00%`.",
+                        f"> Merging [#{sample_comparison.pull.pullid}](codecov.io/gh/test_build_default_payload/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=desc&utm_medium=referral&utm_source=github&utm_content=checks&utm_campaign=pr+comments&utm_term={quote_plus(repo.owner.name)}) ({head_commit.commitid[:7]}) into [master](codecov.io/gh/test_build_default_payload/{repo.name}/commit/{sample_comparison.project_coverage_base.commit.commitid}?el=desc&utm_medium=referral&utm_source=github&utm_content=checks&utm_campaign=pr+comments&utm_term={quote_plus(repo.owner.name)}) ({base_commit.commitid[:7]}) will **increase** coverage by `10.00%`.",
                         f"> The diff coverage is `66.67%`.",
                         f"",
                         f"| [Files](codecov.io/gh/test_build_default_payload/{repo.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=checks&utm_campaign=pr+comments&utm_term={quote_plus(repo.owner.name)}) | Coverage Δ | Complexity Δ | |",
@@ -1420,7 +1422,7 @@ class TestProjectChecksNotifier(object):
             current_yaml=UserYaml({}),
         )
         result = await notifier.build_payload(sample_comparison)
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         expected_result = {
             "state": "success",
             "output": {
@@ -1497,7 +1499,7 @@ class TestProjectChecksNotifier(object):
         )
         result = await notifier.build_payload(sample_comparison)
         repo = sample_comparison.head.commit.repository
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         expected_result = {
             "state": "success",
@@ -1540,7 +1542,7 @@ class TestProjectChecksNotifier(object):
         )
         result = await notifier.build_payload(sample_comparison)
         repo = sample_comparison.head.commit.repository
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         expected_result = {
             "state": "success",
@@ -1584,7 +1586,7 @@ class TestProjectChecksNotifier(object):
         )
         result = await notifier.build_payload(sample_comparison)
         repo = sample_comparison.head.commit.repository
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         expected_result = {
             "state": "success",
@@ -1633,7 +1635,7 @@ class TestProjectChecksNotifier(object):
         )
         result = await notifier.build_payload(sample_comparison)
         repo = sample_comparison.head.commit.repository
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         expected_result = {
             "state": "success",
             "output": {
@@ -1657,7 +1659,7 @@ class TestProjectChecksNotifier(object):
         )
         result = await notifier.build_payload(sample_comparison_negative_change)
         repo = sample_comparison_negative_change.head.commit.repository
-        base_commit = sample_comparison_negative_change.base.commit
+        base_commit = sample_comparison_negative_change.project_coverage_base.commit
         expected_result = {
             "state": "failure",
             "output": {
@@ -1737,7 +1739,7 @@ class TestProjectChecksNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         result = await notifier.notify(sample_comparison)
         assert result.notification_successful == True
@@ -1772,7 +1774,7 @@ class TestProjectChecksNotifier(object):
             current_yaml=UserYaml({}),
         )
 
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         result = await notifier.notify(sample_comparison)
         assert result.notification_successful is True
@@ -1813,7 +1815,7 @@ class TestProjectChecksNotifier(object):
             current_yaml=UserYaml({}),
         )
 
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         result = await notifier.notify(sample_comparison)
         assert result.notification_successful == True
@@ -1847,7 +1849,7 @@ class TestProjectChecksNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         result = await notifier.notify(sample_comparison)
         assert result.notification_successful == True
@@ -1881,7 +1883,9 @@ class TestProjectChecksNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         head_commit = sample_comparison_coverage_carriedforward.head.commit
 
         expected_result = NotificationResult(
@@ -1925,7 +1929,9 @@ class TestProjectChecksNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         head_commit = sample_comparison_coverage_carriedforward.head.commit
         expected_result = NotificationResult(
             notification_attempted=True,
@@ -1963,7 +1969,9 @@ class TestProjectChecksNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         head_commit = sample_comparison_coverage_carriedforward.head.commit
 
         expected_result = NotificationResult(
@@ -2032,7 +2040,9 @@ class TestProjectChecksNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         head_commit = sample_comparison_coverage_carriedforward.head.commit
 
         expected_result = NotificationResult(
@@ -2075,7 +2085,9 @@ class TestProjectChecksNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         head_commit = sample_comparison_coverage_carriedforward.head.commit
 
         expected_result = NotificationResult(
@@ -2114,7 +2126,9 @@ class TestProjectChecksNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         head_commit = sample_comparison_coverage_carriedforward.head.commit
 
         # should send the check as normal if there are no flags
@@ -2144,7 +2158,7 @@ class TestProjectChecksNotifier(object):
     async def test_build_payload_comments_true(
         self, sample_comparison, mock_configuration
     ):
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
         notifier = ProjectChecksNotifier(
@@ -2167,7 +2181,7 @@ class TestProjectChecksNotifier(object):
     async def test_build_payload_comments_false(
         self, sample_comparison, mock_configuration
     ):
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
         notifier = ProjectChecksNotifier(

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -182,7 +182,7 @@ def mock_repo_provider(mock_repo_provider):
         },
         "commits": [
             {
-                "commitid": "{comparison.base.commit[:7]}44fdd29fcc506317cc3ddeae1a723dd08",
+                "commitid": "{comparison.project_coverage_base.commit[:7]}44fdd29fcc506317cc3ddeae1a723dd08",
                 "message": "Update README.rst",
                 "timestamp": "2018-07-09T23:51:16Z",
                 "author": {
@@ -709,7 +709,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{sample_comparison.base.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/commit/{sample_comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{sample_comparison.project_coverage_base.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/commit/{sample_comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"| [Files](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree) | Coverage Δ | Complexity Δ | |",
             f"|---|---|---|---|",
@@ -866,7 +866,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{sample_comparison.base.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/commit/{sample_comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{sample_comparison.project_coverage_base.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/commit/{sample_comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             "",
             "Changes have been made to critical files, which contain lines commonly executed in production. [Learn more](https://docs.codecov.com/docs/impact-analysis)",
             "",
@@ -903,7 +903,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{sample_comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{sample_comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{sample_comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{sample_comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -946,7 +946,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{sample_comparison.base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{sample_comparison.project_coverage_base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -977,7 +977,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 100.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 100.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 100.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 100.00%.",
             f"",
             f"| [Flag](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/flags?src=pr&el=flags) | Coverage Δ | |",
             "|---|---|---|",
@@ -1029,7 +1029,7 @@ class TestCommentNotifier(object):
         result = await notifier.build_message(comparison)
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
-            f"> Merging [#{pull.pullid}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) ({comparison.head.commit.commitid[:7]}) into [master](test.example.br/gh/{repository.slug}/commit/{sample_comparison.base.commit.commitid}?el=desc) ({sample_comparison.base.commit.commitid[:7]}) will **increase** coverage by `10.00%`.",
+            f"> Merging [#{pull.pullid}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) ({comparison.head.commit.commitid[:7]}) into [master](test.example.br/gh/{repository.slug}/commit/{sample_comparison.project_coverage_base.commit.commitid}?el=desc) ({sample_comparison.project_coverage_base.commit.commitid[:7]}) will **increase** coverage by `10.00%`.",
             f"> The diff coverage is `66.67%`.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
@@ -1073,7 +1073,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{sample_comparison.base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{sample_comparison.project_coverage_base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
             f"",
@@ -1328,7 +1328,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -1371,7 +1371,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{sample_comparison.base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{sample_comparison.project_coverage_base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -1402,7 +1402,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> :exclamation: No coverage uploaded for pull request base (`master@{comparison.base.commit.commitid[:7]}`). [Click here to learn what that means](https://docs.codecov.io/docs/error-reference#section-missing-base-commit).",
+            f"> :exclamation: No coverage uploaded for pull request base (`master@{comparison.project_coverage_base.commit.commitid[:7]}`). [Click here to learn what that means](https://docs.codecov.io/docs/error-reference#section-missing-base-commit).",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -1442,7 +1442,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{comparison.project_coverage_base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -1546,7 +1546,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 60.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 60.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -1586,7 +1586,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{sample_comparison_no_change.base.commit.commitid[:7]}...{sample_comparison_no_change.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{sample_comparison_no_change.project_coverage_base.commit.commitid[:7]}...{sample_comparison_no_change.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -1621,7 +1621,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 60.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 50.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 60.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 50.00%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -1664,7 +1664,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{comparison.project_coverage_base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -1703,7 +1703,9 @@ class TestCommentNotifier(object):
         for i in range(6760, 7631):
             new_base_file.append(i, ReportLine.create(coverage=0))
         new_base_report.append(new_base_file)
-        comparison.base.report = ReadOnlyReport.create_from_report(new_base_report)
+        comparison.project_coverage_base.report = ReadOnlyReport.create_from_report(
+            new_base_report
+        )
         new_head_report = Report()
         new_head_file = ReportFile("file.py")
         for i in range(1, 6758):
@@ -1716,7 +1718,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 88.58% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 88.54%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 88.58% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 88.54%.",
             f"",
             f"```diff",
             f"@@            Coverage Diff             @@",
@@ -1770,7 +1772,9 @@ class TestCommentNotifier(object):
         for i in range(6760, 7631):
             new_base_file.append(i, ReportLine.create(coverage=0))
         new_base_report.append(new_base_file)
-        comparison.base.report = ReadOnlyReport.create_from_report(new_base_report)
+        comparison.project_coverage_base.report = ReadOnlyReport.create_from_report(
+            new_base_report
+        )
         new_head_report = Report()
         new_head_file = ReportFile("file.py")
         for i in range(1, 6758):
@@ -1783,7 +1787,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             f"All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 88.58% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 88.54%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 88.58% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 88.54%.",
             f"",
         ]
         li = 0
@@ -1814,7 +1818,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -1855,7 +1859,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{sample_comparison.base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{sample_comparison.project_coverage_base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -1890,7 +1894,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -1919,7 +1923,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{comparison.project_coverage_base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -1950,7 +1954,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -1988,7 +1992,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{comparison.project_coverage_base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -2026,7 +2030,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -2064,7 +2068,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{comparison.project_coverage_base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -2102,7 +2106,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -2138,7 +2142,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{comparison.project_coverage_base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -2203,7 +2207,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -2245,7 +2249,7 @@ class TestCommentNotifier(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{comparison.project_coverage_base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -3258,7 +3262,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"<details><summary>Additional details and impacted files</summary>\n",
             f"",
@@ -3293,7 +3297,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             "",
             ":mega: message",
             "",
@@ -3330,7 +3334,7 @@ class TestCommentNotifier(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             "Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -3943,7 +3947,7 @@ class TestNewHeaderSectionWriter(object):
         print(res)
         assert res == [
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{sample_comparison.base.commit.commitid[:7]}`)](urlurl?el=desc) 0% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](urlurl?src=pr&el=desc) 0%.",
+            f"> Comparison is base [(`{sample_comparison.project_coverage_base.commit.commitid[:7]}`)](urlurl?el=desc) 0% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](urlurl?src=pr&el=desc) 0%.",
         ]
 
     @pytest.mark.asyncio
@@ -3973,7 +3977,7 @@ class TestNewHeaderSectionWriter(object):
         print(res)
         assert res == [
             "All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{sample_comparison.base.commit.commitid[:7]}`)](urlurl?el=desc) 0% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](urlurl?src=pr&el=desc) 0%.",
+            f"> Comparison is base [(`{sample_comparison.project_coverage_base.commit.commitid[:7]}`)](urlurl?el=desc) 0% compared to head [(`{sample_comparison.head.commit.commitid[:7]}`)](urlurl?src=pr&el=desc) 0%.",
             "> Report is 3 commits behind head on master.",
         ]
 
@@ -4285,7 +4289,7 @@ class TestCommentNotifierInNewLayout(object):
         expected_result = [
             f"## [Codecov](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             f"All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](https://app.codecov.io/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             "",
             "Changes have been made to critical files, which contain lines commonly executed in production. [Learn more](https://docs.codecov.com/docs/impact-analysis)",
             "",
@@ -4395,7 +4399,7 @@ class TestCommentNotifierInNewLayout(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             f"Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> :exclamation: No coverage uploaded for pull request base (`master@{comparison.base.commit.commitid[:7]}`). [Click here to learn what that means](https://docs.codecov.io/docs/error-reference#section-missing-base-commit).",
+            f"> :exclamation: No coverage uploaded for pull request base (`master@{comparison.project_coverage_base.commit.commitid[:7]}`). [Click here to learn what that means](https://docs.codecov.io/docs/error-reference#section-missing-base-commit).",
             f"",
             f"<details><summary>Additional details and impacted files</summary>\n",
             f"",
@@ -4546,7 +4550,7 @@ class TestCommentNotifierInNewLayout(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             f"Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"> :exclamation: Current head {comparison.head.commit.commitid[:7]} differs from pull request most recent head {comparison.enriched_pull.provider_pull['head']['commitid'][:7]}. Consider uploading reports for the commit {comparison.enriched_pull.provider_pull['head']['commitid'][:7]} to get more accurate results",
             f"",
@@ -4621,7 +4625,7 @@ class TestCommentNotifierInNewLayout(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             f"Attention: `1 lines` in your changes are missing coverage. Please review.",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 50.00% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 60.00%.",
             f"",
             f"> :exclamation: Current head {comparison.head.commit.commitid[:7]} differs from pull request most recent head {comparison.enriched_pull.provider_pull['head']['commitid'][:7]}. Consider uploading reports for the commit {comparison.enriched_pull.provider_pull['head']['commitid'][:7]} to get more accurate results",
             f"",
@@ -4692,7 +4696,7 @@ class TestCommentNotifierInNewLayout(object):
         expected_result = [
             f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=h1) Report",
             f"All modified and coverable lines are covered by tests :white_check_mark:",
-            f"> Comparison is base [(`{comparison.base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
+            f"> Comparison is base [(`{comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{comparison.project_coverage_base.commit.commitid}?el=desc) 65.38% compared to head [(`{comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=desc) 65.38%.",
             f"",
             f"[![Impacted file tree graph](test.example.br/gh/{repository.slug}/pull/{pull.pullid}/graphs/tree.svg?width=650&height=150&src=pr&token={repository.image_token})](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=tree)",
             f"",
@@ -4728,7 +4732,7 @@ class TestCommentNotifierInNewLayout(object):
             f"> Powered by "
             f"[Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=footer). "
             f"Last update "
-            f"[{comparison.base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
+            f"[{comparison.project_coverage_base.commit.commitid[:7]}...{comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             f"",
         ]
@@ -4899,8 +4903,8 @@ class TestComponentWriterSection(object):
         sample_comparison,
     ):
         comparison = sample_comparison
-        comparison.base.report = None
-        comparison.base.commit = None
+        comparison.project_coverage_base.report = None
+        comparison.project_coverage_base.commit = None
         section_writer = ComponentsSectionWriter(
             repository=comparison.head.commit.repository,
             layout="layout",
@@ -5008,8 +5012,8 @@ class TestComponentWriterSection(object):
         sample_comparison,
     ):
         comparison = sample_comparison
-        comparison.base.report = None
-        comparison.base.commit = None
+        comparison.project_coverage_base.report = None
+        comparison.project_coverage_base.commit = None
         section_writer = ComponentsSectionWriter(
             repository=comparison.head.commit.repository,
             layout="layout",

--- a/services/notification/notifiers/tests/unit/test_hipchat.py
+++ b/services/notification/notifiers/tests/unit/test_hipchat.py
@@ -33,7 +33,7 @@ class TestHipchatkNotifier(object):
     def test_build_payload_without_base_report(
         self, sample_comparison, mock_configuration
     ):
-        sample_comparison.base.report = None
+        sample_comparison.project_coverage_base.report = None
         url = "test.example.br"
         mock_configuration.params["setup"]["codecov_dashboard_url"] = url
         comparison = sample_comparison

--- a/services/notification/notifiers/tests/unit/test_slack.py
+++ b/services/notification/notifiers/tests/unit/test_slack.py
@@ -16,7 +16,7 @@ class TestSlackNotifier(object):
         )
         result = notifier.build_payload(comparison)
         commit = comparison.head.commit
-        base_commit = comparison.base.commit
+        base_commit = comparison.project_coverage_base.commit
         repository = commit.repository
         text = f"Coverage for <test.example.br/gh/{repository.slug}/commit/{commit.commitid}|{repository.slug}> *increased* `<test.example.br/gh/{repository.slug}/pull/{comparison.pull.pullid}|+10.00%>` on `new_branch` is `60.00000%` via `<test.example.br/gh/{repository.slug}/commit/{commit.commitid}|{commit.commitid[:7]}>`"
         expected_result = {
@@ -42,7 +42,7 @@ class TestSlackNotifier(object):
         )
         result = notifier.build_payload(comparison)
         commit = comparison.head.commit
-        base_commit = comparison.base.commit
+        base_commit = comparison.project_coverage_base.commit
         repository = commit.repository
         text = f"Coverage for <test.example.br/gh/{repository.slug}/commit/{commit.commitid}|{repository.slug}> *increased* `<test.example.br/gh/{repository.slug}/pull/{comparison.pull.pullid}|+10.00%>` on `new_branch` is `60.00000%` via `<test.example.br/gh/{repository.slug}/commit/{commit.commitid}|{commit.commitid[:7]}>`"
         expected_result = {
@@ -91,7 +91,7 @@ class TestSlackNotifier(object):
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
         comparison = sample_comparison_without_pull
         commit = sample_comparison_without_pull.head.commit
-        base_commit = comparison.base.commit
+        base_commit = comparison.project_coverage_base.commit
         repository = commit.repository
         notifier = SlackNotifier(
             repository=comparison.head.commit.repository,

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -128,7 +128,9 @@ def comparison_100_percent_patch(sample_comparison):
     second_modified_file.append(23, ReportLine.create(coverage=1))
     second_modified_file.append(24, ReportLine.create(coverage=1))
     second_report.append(second_modified_file)
-    sample_comparison.base.report = ReadOnlyReport.create_from_report(first_report)
+    sample_comparison.project_coverage_base.report = ReadOnlyReport.create_from_report(
+        first_report
+    )
     sample_comparison.head.report = ReadOnlyReport.create_from_report(second_report)
     return sample_comparison
 
@@ -213,7 +215,9 @@ def comparison_with_multiple_changes(sample_comparison):
     second_unrelated_file.append(16, ReportLine.create(coverage=1))
     second_unrelated_file.append(32, ReportLine.create(coverage=0))
     second_report.append(second_unrelated_file)
-    sample_comparison.base.report = ReadOnlyReport.create_from_report(first_report)
+    sample_comparison.project_coverage_base.report = ReadOnlyReport.create_from_report(
+        first_report
+    )
     sample_comparison.head.report = ReadOnlyReport.create_from_report(second_report)
     return sample_comparison
 
@@ -786,7 +790,7 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         expected_result = {
             "message": f"60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
             "state": "success",
@@ -847,7 +851,7 @@ class TestProjectStatusNotifier(object):
             current_yaml=UserYaml({}),
             decoration_type=Decoration.upgrade,
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         expected_result = {
             "message": "Please activate this user to display a detailed status check",
             "state": "success",
@@ -906,7 +910,7 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = comparison.base.commit
+        base_commit = comparison.project_coverage_base.commit
         head_commit = comparison.head.commit
         expected_result = {
             "message": "No report found to compare against",
@@ -929,7 +933,7 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         expected_result = NotificationResult(
             notification_attempted=True,
             notification_successful=True,
@@ -961,7 +965,7 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         repo = sample_comparison.head.commit.repository
         expected_result = NotificationResult(
@@ -995,7 +999,7 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         repo = sample_comparison.head.commit.repository
         expected_result = NotificationResult(
@@ -1029,7 +1033,9 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         expected_result = NotificationResult(
             notification_attempted=True,
             notification_successful=True,
@@ -1060,7 +1066,9 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         expected_result = NotificationResult(
             notification_attempted=True,
             notification_successful=True,
@@ -1091,7 +1099,9 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         expected_result = NotificationResult(
             notification_attempted=True,
             notification_successful=True,
@@ -1147,7 +1157,9 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         expected_result = NotificationResult(
             notification_attempted=True,
             notification_successful=True,
@@ -1182,7 +1194,9 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         expected_result = NotificationResult(
             notification_attempted=True,
             notification_successful=True,
@@ -1213,7 +1227,9 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_coverage_carriedforward.base.commit
+        base_commit = (
+            sample_comparison_coverage_carriedforward.project_coverage_base.commit
+        )
         # should send the check as normal if there are no flags
         expected_result = NotificationResult(
             notification_attempted=True,
@@ -1244,7 +1260,7 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         expected_result = {
             "message": f"62.50% (+12.50%) compared to {base_commit.commitid[:7]}",
             "state": "success",
@@ -1269,7 +1285,7 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         expected_result = {
             # base report does not have unit flag, so there is no coverage there
             "message": "No coverage information found on base report",
@@ -1299,7 +1315,7 @@ class TestProjectStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison_matching_flags.base.commit
+        base_commit = sample_comparison_matching_flags.project_coverage_base.commit
         expected_result = {
             # base report does not have unit flag, so there is no coverage there
             "message": f"100.00% (+0.00%) compared to {base_commit.commitid[:7]}",
@@ -1395,7 +1411,7 @@ class TestProjectStatusNotifier(object):
             current_yaml=UserYaml({}),
         )
         expected_result = {
-            "message": f"50.00% (-10.00%) compared to {sample_comparison.base.commit.commitid[:7]}, passed because coverage increased by +0.00% when compared to adjusted base (50.00%)",
+            "message": f"50.00% (-10.00%) compared to {sample_comparison.project_coverage_base.commit.commitid[:7]}, passed because coverage increased by +0.00% when compared to adjusted base (50.00%)",
             "state": "success",
         }
         result = await notifier.build_payload(sample_comparison)
@@ -1485,7 +1501,7 @@ class TestProjectStatusNotifier(object):
             current_yaml=UserYaml({}),
         )
         expected_result = {
-            "message": f"50.00% (-10.00%) compared to {sample_comparison.base.commit.commitid[:7]}",
+            "message": f"50.00% (-10.00%) compared to {sample_comparison.project_coverage_base.commit.commitid[:7]}",
             "state": "failure",
         }
         result = await notifier.build_payload(sample_comparison)
@@ -1897,7 +1913,7 @@ class TestPatchStatusNotifier(object):
         third_file.append(101, ReportLine.create(coverage=1, sessions=[[0, 1]]))
         third_file.append(102, ReportLine.create(coverage=1, sessions=[[0, 1]]))
         third_file.append(103, ReportLine.create(coverage=1, sessions=[[0, 1]]))
-        sample_comparison.base.report.append(third_file)
+        sample_comparison.project_coverage_base.report.append(third_file)
         notifier = PatchStatusNotifier(
             repository=sample_comparison.head.commit.repository,
             title="title",
@@ -1953,7 +1969,7 @@ class TestPatchStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         expected_result = {
             "message": f"Coverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
@@ -2165,7 +2181,7 @@ class TestChangesStatusNotifier(object):
             notifier_site_settings=True,
             current_yaml=UserYaml({}),
         )
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         expected_result = {
             "message": "No unexpected coverage changes found",
             "state": "success",

--- a/services/notification/notifiers/tests/unit/test_webhook.py
+++ b/services/notification/notifiers/tests/unit/test_webhook.py
@@ -15,7 +15,7 @@ class TestWebhookNotifier(object):
         )
         dbsession.add(repository)
         dbsession.flush()
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         pull = sample_comparison.pull
         dbsession.add(base_commit)
@@ -75,7 +75,7 @@ class TestWebhookNotifier(object):
         )
 
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "codecov.io"
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         pull = sample_comparison.pull
         dbsession.add(base_commit)
@@ -181,7 +181,7 @@ class TestWebhookNotifier(object):
         )
         dbsession.add(repository)
         dbsession.flush()
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         pull = sample_comparison.pull
         dbsession.add(base_commit)
@@ -304,7 +304,7 @@ class TestWebhookNotifier(object):
         )
         dbsession.add(repository)
         dbsession.flush()
-        base_commit = sample_comparison.base.commit
+        base_commit = sample_comparison.project_coverage_base.commit
         head_commit = sample_comparison.head.commit
         pull = sample_comparison.pull
         dbsession.add(base_commit)
@@ -424,7 +424,7 @@ class TestWebhookNotifier(object):
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
         comparison = sample_comparison_without_pull
         commit = sample_comparison_without_pull.head.commit
-        base_commit = comparison.base.commit
+        base_commit = comparison.project_coverage_base.commit
         head_commit = comparison.head.commit
         repository = commit.repository
         notifier = WebhookNotifier(
@@ -541,7 +541,7 @@ class TestWebhookNotifier(object):
         )
         result = notifier.build_payload(comparison)
         head_commit = comparison.head.commit
-        base_commit = comparison.base.commit
+        base_commit = comparison.project_coverage_base.commit
         pull = comparison.pull
         expected_result = {
             "repo": {

--- a/services/notification/notifiers/webhook.py
+++ b/services/notification/notifiers/webhook.py
@@ -45,7 +45,7 @@ class WebhookNotifier(RequestsYamlBasedNotifier):
 
     def build_payload(self, comparison: Comparison):
         head_full_commit = comparison.head
-        base_full_commit = comparison.base
+        base_full_commit = comparison.project_coverage_base
         pull = comparison.pull
         head_commit = head_full_commit.commit
         repository = head_commit.repository

--- a/services/notification/tests/unit/test_notification_service.py
+++ b/services/notification/tests/unit/test_notification_service.py
@@ -39,8 +39,8 @@ def sample_comparison(dbsession, request):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(database_pull=pull, provider_pull={}),
         )
     )

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -338,28 +338,30 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
         #
         # For now, fix this for the patch-coverage-focused team plan and avoid
         # maybe perturbing anything for project coverage. For other plans, set
-        # `original_base_commitid` to the adjusted base commitid.
+        # `patch_coverage_base_commitid` to the adjusted base commitid.
         # Follow-up: https://github.com/codecov/engineering-team/issues/887
         plan = commit.repository.owner.plan
         pull = enriched_pull.database_pull if enriched_pull else None
 
         if pull and plan in (BillingPlan.team_monthly, BillingPlan.team_yearly):
-            original_base_commitid = pull.base
+            patch_coverage_base_commitid = pull.base
         elif base_commit is not None:
-            original_base_commitid = base_commit.commitid
+            patch_coverage_base_commitid = base_commit.commitid
         else:
             log.warning(
                 "Neither the original nor updated base commit are known",
                 extra=dict(repoid=commit.repository.repoid, commit=commit.commitid),
             )
-            original_base_commitid = None
+            patch_coverage_base_commitid = None
 
         comparison = ComparisonProxy(
             Comparison(
                 head=FullCommit(commit=commit, report=head_report),
                 enriched_pull=enriched_pull,
-                base=FullCommit(commit=base_commit, report=base_report),
-                original_base_commitid=original_base_commitid,
+                project_coverage_base=FullCommit(
+                    commit=base_commit, report=base_report
+                ),
+                patch_coverage_base_commitid=patch_coverage_base_commitid,
                 current_yaml=current_yaml,
             )
         )

--- a/tasks/save_report_results.py
+++ b/tasks/save_report_results.py
@@ -49,9 +49,9 @@ class SaveReportResultsTask(
         )
 
         if enriched_pull and enriched_pull.database_pull:
-            original_base_commitid = enriched_pull.database_pull.base
+            patch_coverage_base_commitid = enriched_pull.database_pull.base
         else:
-            original_base_commitid = base_commit.commitid if base_commit else None
+            patch_coverage_base_commitid = base_commit.commitid if base_commit else None
 
         if head_report is None:
             log.warning(
@@ -64,8 +64,10 @@ class SaveReportResultsTask(
             Comparison(
                 head=FullCommit(commit=commit, report=head_report),
                 enriched_pull=enriched_pull,
-                base=FullCommit(commit=base_commit, report=base_report),
-                original_base_commitid=original_base_commitid,
+                project_coverage_base=FullCommit(
+                    commit=base_commit, report=base_report
+                ),
+                patch_coverage_base_commitid=patch_coverage_base_commitid,
             )
         )
 

--- a/tasks/tests/unit/conftest.py
+++ b/tasks/tests/unit/conftest.py
@@ -135,8 +135,8 @@ def sample_comparison(dbsession, request, sample_report):
     return ComparisonProxy(
         Comparison(
             head=head_full_commit,
-            base=base_full_commit,
-            original_base_commitid=base_commit.commitid,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
             enriched_pull=EnrichedPull(
                 database_pull=pull,
                 provider_pull={


### PR DESCRIPTION
closes https://github.com/codecov/worker/issues/203

no logical changes, pure rename

hoping tests exercised every usage of these variables. i grepped for some usage patterns but my brain would melt if i tried to go through every occurrence of the word "base" to make sure none refer to this

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.