### PR TITLE
fix: commit to db after computing flag and component comparisons

### DIFF
--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -69,9 +69,11 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
         db_session.commit()
 
         await self.compute_flag_comparison(db_session, comparison, comparison_proxy)
+        db_session.commit()
         await self.compute_component_comparisons(
             db_session, comparison, comparison_proxy
         )
+        db_session.commit()
         return {"successful": True}
 
     async def compute_flag_comparison(self, db_session, comparison, comparison_proxy):


### PR DESCRIPTION
This is an attempt to fix an issue where flag comparisons are not being saved to the database.