### PR TITLE
feat: Bundle analysis notify task

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -316,6 +316,7 @@ class Pull(CodecovBaseModel):
     compared_to = Column(types.Text)
     head = Column(types.Text)
     commentid = Column(types.Text)
+    bundle_analysis_commentid = Column(types.Text)
     diff = Column(postgresql.JSON)
     flare = Column(postgresql.JSON)
     author_id = Column("author", types.Integer, ForeignKey("owners.ownerid"))

--- a/services/lock_manager.py
+++ b/services/lock_manager.py
@@ -15,6 +15,7 @@ log = logging.getLogger(__name__)
 
 class LockType(Enum):
     BUNDLE_ANALYSIS_PROCESSING = "bundle_analysis_processing"
+    BUNDLE_ANALYSIS_NOTIFY = "bundle_analysis_notify"
     # TODO: port existing task locking to use `LockManager`
 
 

--- a/services/tests/test_bundle_analysis.py
+++ b/services/tests/test_bundle_analysis.py
@@ -1,0 +1,329 @@
+import pytest
+from shared.bundle_analysis.comparison import BundleChange, BundleReport
+from shared.yaml import UserYaml
+
+from database.enums import ReportType
+from database.models import CommitReport
+from database.tests.factories import CommitFactory, PullFactory
+from services.archive import ArchiveService
+from services.bundle_analysis import Notifier, get_bucket_name
+from services.repository import EnrichedPull
+
+expected_message_increase = """## Bundle Report
+
+Changes will increase total bundle size by 3.46KB :arrow_up:
+
+| Bundle name | Size | Change |
+| ----------- | ---- | ------ |
+| test-bundle | 123.46KB | 3.46KB :arrow_up: |"""
+
+expected_message_decrease = """## Bundle Report
+
+Changes will decrease total bundle size by 3.46KB :arrow_down:
+
+| Bundle name | Size | Change |
+| ----------- | ---- | ------ |
+| test-bundle | 123.46KB | 3.46KB :arrow_down: |"""
+
+
+class MockBundleReport:
+    def total_size(self):
+        return 123456
+
+
+def test_bytes_readable():
+    notifier = Notifier(None, UserYaml.from_dict({}))
+    assert notifier._bytes_readable(999) == "999 bytes"
+    assert notifier._bytes_readable(1234) == "1.23KB"
+    assert notifier._bytes_readable(123456) == "123.46KB"
+    assert notifier._bytes_readable(1234567) == "1.23MB"
+    assert notifier._bytes_readable(1234567890) == "1.23GB"
+
+
+@pytest.mark.asyncio
+async def test_bundle_analysis_notify(
+    dbsession, mocker, mock_storage, mock_repo_provider
+):
+    base_commit = CommitFactory()
+    dbsession.add(base_commit)
+    base_commit_report = CommitReport(
+        commit=base_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(base_commit_report)
+
+    head_commit = CommitFactory(repository=base_commit.repository)
+    dbsession.add(head_commit)
+    head_commit_report = CommitReport(
+        commit=head_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(head_commit_report)
+
+    pull = PullFactory(
+        repository=base_commit.repository,
+        head=head_commit.commitid,
+        base=base_commit.commitid,
+        compared_to=base_commit.commitid,
+    )
+    dbsession.add(pull)
+    dbsession.commit()
+
+    notifier = Notifier(head_commit, UserYaml.from_dict({}))
+
+    repo_key = ArchiveService.get_archive_hash(base_commit.repository)
+    mock_storage.write_file(
+        get_bucket_name(),
+        f"v1/repos/{repo_key}/{base_commit_report.external_id}/bundle_report.sqlite",
+        "test-content",
+    )
+    mock_storage.write_file(
+        get_bucket_name(),
+        f"v1/repos/{repo_key}/{head_commit_report.external_id}/bundle_report.sqlite",
+        "test-content",
+    )
+
+    mocker.patch(
+        "services.bundle_analysis.get_appropriate_storage_service",
+        return_value=mock_storage,
+    )
+    mocker.patch("shared.bundle_analysis.report.BundleAnalysisReport._setup")
+    mocker.patch(
+        "services.bundle_analysis.get_repo_provider_service",
+        return_value=mock_repo_provider,
+    )
+
+    bundle_changes = mocker.patch(
+        "shared.bundle_analysis.comparison.BundleAnalysisComparison.bundle_changes"
+    )
+    bundle_changes.return_value = [
+        BundleChange("test-bundle", BundleChange.ChangeType.CHANGED, size_delta=3456),
+    ]
+
+    bundle_report = mocker.patch(
+        "shared.bundle_analysis.report.BundleAnalysisReport.bundle_report"
+    )
+    bundle_report.return_value = MockBundleReport()
+
+    fetch_pr = mocker.patch(
+        "services.bundle_analysis.fetch_and_update_pull_request_information_from_commit"
+    )
+    fetch_pr.return_value = EnrichedPull(
+        database_pull=pull,
+        provider_pull={},
+    )
+
+    mock_repo_provider.post_comment.return_value = {"id": "test-comment-id"}
+
+    success = await notifier.notify()
+    assert success == True
+    mock_repo_provider.post_comment.assert_called_once_with(
+        pull.pullid, expected_message_increase
+    )
+
+    success = await notifier.notify()
+    assert success == True
+    mock_repo_provider.edit_comment.assert_called_once_with(
+        pull.pullid, "test-comment-id", expected_message_increase
+    )
+
+
+@pytest.mark.asyncio
+async def test_bundle_analysis_notify_size_decrease(
+    dbsession, mocker, mock_storage, mock_repo_provider
+):
+    base_commit = CommitFactory()
+    dbsession.add(base_commit)
+    base_commit_report = CommitReport(
+        commit=base_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(base_commit_report)
+
+    head_commit = CommitFactory(repository=base_commit.repository)
+    dbsession.add(head_commit)
+    head_commit_report = CommitReport(
+        commit=head_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(head_commit_report)
+
+    pull = PullFactory(
+        repository=base_commit.repository,
+        head=head_commit.commitid,
+        base=base_commit.commitid,
+        compared_to=base_commit.commitid,
+    )
+    dbsession.add(pull)
+    dbsession.commit()
+
+    notifier = Notifier(head_commit, UserYaml.from_dict({}))
+
+    repo_key = ArchiveService.get_archive_hash(base_commit.repository)
+    mock_storage.write_file(
+        get_bucket_name(),
+        f"v1/repos/{repo_key}/{base_commit_report.external_id}/bundle_report.sqlite",
+        "test-content",
+    )
+    mock_storage.write_file(
+        get_bucket_name(),
+        f"v1/repos/{repo_key}/{head_commit_report.external_id}/bundle_report.sqlite",
+        "test-content",
+    )
+
+    mocker.patch(
+        "services.bundle_analysis.get_appropriate_storage_service",
+        return_value=mock_storage,
+    )
+    mocker.patch("shared.bundle_analysis.report.BundleAnalysisReport._setup")
+    mocker.patch(
+        "services.bundle_analysis.get_repo_provider_service",
+        return_value=mock_repo_provider,
+    )
+
+    bundle_changes = mocker.patch(
+        "shared.bundle_analysis.comparison.BundleAnalysisComparison.bundle_changes"
+    )
+    bundle_changes.return_value = [
+        BundleChange("test-bundle", BundleChange.ChangeType.CHANGED, size_delta=-3456),
+    ]
+
+    bundle_report = mocker.patch(
+        "shared.bundle_analysis.report.BundleAnalysisReport.bundle_report"
+    )
+    bundle_report.return_value = MockBundleReport()
+
+    fetch_pr = mocker.patch(
+        "services.bundle_analysis.fetch_and_update_pull_request_information_from_commit"
+    )
+    fetch_pr.return_value = EnrichedPull(
+        database_pull=pull,
+        provider_pull={},
+    )
+
+    success = await notifier.notify()
+    assert success == True
+    mock_repo_provider.post_comment.assert_called_once_with(
+        pull.pullid, expected_message_decrease
+    )
+
+
+@pytest.mark.asyncio
+async def test_bundle_analysis_notify_missing_commit_report(
+    dbsession, mocker, mock_storage, mock_repo_provider
+):
+    base_commit = CommitFactory()
+    dbsession.add(base_commit)
+    base_commit_report = CommitReport(
+        commit=base_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(base_commit_report)
+
+    head_commit = CommitFactory(repository=base_commit.repository)
+    dbsession.add(head_commit)
+
+    notifier = Notifier(head_commit, UserYaml.from_dict({}))
+
+    success = await notifier.notify()
+    assert success == False
+
+
+@pytest.mark.asyncio
+async def test_bundle_analysis_notify_missing_bundle_report(
+    dbsession, mocker, mock_storage, mock_repo_provider
+):
+    base_commit = CommitFactory()
+    dbsession.add(base_commit)
+    base_commit_report = CommitReport(
+        commit=base_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(base_commit_report)
+
+    head_commit = CommitFactory(repository=base_commit.repository)
+    dbsession.add(head_commit)
+    head_commit_report = CommitReport(
+        commit=head_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(head_commit_report)
+
+    pull = PullFactory(
+        repository=base_commit.repository,
+        head=head_commit.commitid,
+        base=base_commit.commitid,
+        compared_to=base_commit.commitid,
+    )
+    dbsession.add(pull)
+    dbsession.commit()
+
+    notifier = Notifier(head_commit, UserYaml.from_dict({}))
+
+    success = await notifier.notify()
+    assert success == False
+
+
+@pytest.mark.asyncio
+async def test_bundle_analysis_notify_missing_pull(
+    dbsession, mocker, mock_storage, mock_repo_provider
+):
+    base_commit = CommitFactory()
+    dbsession.add(base_commit)
+    base_commit_report = CommitReport(
+        commit=base_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(base_commit_report)
+
+    head_commit = CommitFactory(repository=base_commit.repository)
+    dbsession.add(head_commit)
+    head_commit_report = CommitReport(
+        commit=head_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(head_commit_report)
+
+    pull = PullFactory(
+        repository=base_commit.repository,
+        head=head_commit.commitid,
+        base=base_commit.commitid,
+        compared_to=base_commit.commitid,
+    )
+    dbsession.add(pull)
+    dbsession.commit()
+
+    notifier = Notifier(head_commit, UserYaml.from_dict({}))
+
+    repo_key = ArchiveService.get_archive_hash(base_commit.repository)
+    mock_storage.write_file(
+        get_bucket_name(),
+        f"v1/repos/{repo_key}/{base_commit_report.external_id}/bundle_report.sqlite",
+        "test-content",
+    )
+    mock_storage.write_file(
+        get_bucket_name(),
+        f"v1/repos/{repo_key}/{head_commit_report.external_id}/bundle_report.sqlite",
+        "test-content",
+    )
+
+    mocker.patch(
+        "services.bundle_analysis.get_appropriate_storage_service",
+        return_value=mock_storage,
+    )
+    mocker.patch("shared.bundle_analysis.report.BundleAnalysisReport._setup")
+    mocker.patch(
+        "services.bundle_analysis.get_repo_provider_service",
+        return_value=mock_repo_provider,
+    )
+
+    bundle_changes = mocker.patch(
+        "shared.bundle_analysis.comparison.BundleAnalysisComparison.bundle_changes"
+    )
+    bundle_changes.return_value = [
+        BundleChange("test-bundle", BundleChange.ChangeType.CHANGED, size_delta=3456),
+    ]
+
+    bundle_report = mocker.patch(
+        "shared.bundle_analysis.report.BundleAnalysisReport.bundle_report"
+    )
+    bundle_report.return_value = MockBundleReport()
+
+    fetch_pr = mocker.patch(
+        "services.bundle_analysis.fetch_and_update_pull_request_information_from_commit"
+    )
+    fetch_pr.return_value = None
+
+    success = await notifier.notify()
+    assert success == False

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -2,6 +2,7 @@ from app import celery_app
 from tasks.ai_pr_review import ai_pr_view_task
 from tasks.backfill_commit_data_to_storage import backfill_commit_data_to_storage_task
 from tasks.brolly_stats_rollup import brolly_stats_rollup_task
+from tasks.bundle_analysis_notify import bundle_analysis_notify_task
 from tasks.bundle_analysis_processor import bundle_analysis_processor_task
 from tasks.commit_update import commit_update_task
 from tasks.compute_comparison import compute_comparison_task

--- a/tasks/bundle_analysis_notify.py
+++ b/tasks/bundle_analysis_notify.py
@@ -1,0 +1,122 @@
+import logging
+from typing import Any, Dict
+
+from shared.celery_config import notify_task_name
+from shared.yaml import UserYaml
+
+from app import celery_app
+from database.enums import ReportType
+from database.models import Commit
+from services.bundle_analysis import Notifier
+from services.lock_manager import LockManager, LockRetry, LockType
+from tasks.base import BaseCodecovTask
+
+log = logging.getLogger(__name__)
+
+bundle_analysis_notify_task_name = "app.tasks.bundle_analysis.BundleAnalysisNotify"
+
+
+class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task_name):
+    async def run_async(
+        self,
+        db_session,
+        # Celery `chain` injects this argument - it's the returned result
+        # from the prior task in the chain
+        previous_result: Dict[str, Any],
+        *,
+        repoid: int,
+        commitid: str,
+        commit_yaml: dict,
+        **kwargs,
+    ):
+        repoid = int(repoid)
+        commit_yaml = UserYaml.from_dict(commit_yaml)
+
+        log.info(
+            "Starting bundle analysis notify",
+            extra=dict(
+                repoid=repoid,
+                commit=commitid,
+                commit_yaml=commit_yaml,
+            ),
+        )
+
+        lock_manager = LockManager(
+            repoid=repoid,
+            commitid=commitid,
+            report_type=ReportType.BUNDLE_ANALYSIS,
+        )
+
+        try:
+            with lock_manager.locked(
+                LockType.BUNDLE_ANALYSIS_NOTIFY,
+                retry_num=self.request.retries,
+            ):
+                return await self.process_async_within_lock(
+                    db_session=db_session,
+                    repoid=repoid,
+                    commitid=commitid,
+                    commit_yaml=commit_yaml,
+                    previous_result=previous_result,
+                    **kwargs,
+                )
+        except LockRetry as retry:
+            self.retry(max_retries=5, countdown=retry.countdown)
+
+    async def process_async_within_lock(
+        self,
+        *,
+        db_session,
+        repoid: int,
+        commitid: str,
+        commit_yaml: UserYaml,
+        previous_result: Dict[str, Any],
+        **kwargs,
+    ):
+        log.info(
+            "Running bundle analysis notify",
+            extra=dict(
+                repoid=repoid,
+                commit=commitid,
+                commit_yaml=commit_yaml,
+                parent_task=self.request.parent_id,
+            ),
+        )
+
+        commit = (
+            db_session.query(Commit).filter_by(repoid=repoid, commitid=commitid).first()
+        )
+        assert commit, "commit not found"
+
+        notify = True
+
+        # these are the task results from prior processor tasks in the chain
+        # (they get accumulated as we execute each task in succession)
+        processing_results = previous_result.get("results", [])
+
+        if all((result["error"] is not None for result in processing_results)):
+            # every processor errored, nothing to notify on
+            notify = False
+
+        success = None
+        if notify:
+            notifier = Notifier(commit, commit_yaml)
+            success = await notifier.notify()
+
+        log.info(
+            "Finished bundle analysis notify",
+            extra=dict(
+                repoid=repoid,
+                commit=commitid,
+                commit_yaml=commit_yaml,
+                parent_task=self.request.parent_id,
+            ),
+        )
+
+        return {"notify_attempted": notify, "notify_succeeded": success}
+
+
+RegisteredBundleAnalysisNotifyTask = celery_app.register_task(
+    BundleAnalysisNotifyTask()
+)
+bundle_analysis_notify_task = celery_app.tasks[RegisteredBundleAnalysisNotifyTask.name]

--- a/tasks/tests/unit/test_bundle_analysis_notify_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_notify_task.py
@@ -1,0 +1,32 @@
+import pytest
+
+from database.tests.factories import CommitFactory
+from tasks.bundle_analysis_notify import BundleAnalysisNotifyTask
+
+
+@pytest.mark.asyncio
+async def test_bundle_analysis_notify_task(
+    mocker,
+    dbsession,
+    celery_app,
+    mock_redis,
+):
+    mocker.patch.object(BundleAnalysisNotifyTask, "app", celery_app)
+
+    commit = CommitFactory.create()
+    dbsession.add(commit)
+    dbsession.flush()
+
+    mocker.patch("services.bundle_analysis.Notifier.notify", return_value=True)
+
+    result = await BundleAnalysisNotifyTask().run_async(
+        dbsession,
+        {"results": [{"error": None}]},
+        repoid=commit.repoid,
+        commitid=commit.commitid,
+        commit_yaml={},
+    )
+    assert result == {
+        "notify_attempted": True,
+        "notify_succeeded": True,
+    }


### PR DESCRIPTION
This is a separate task for now and results in a separate PR comment.  Ideally this would be part of the existing notify task but there's some significant refactoring work that needs to be done first to support that.

This new task runs at the end of the bundle analysis processor chain and posts a PR comment with information regarding the bundle analysis comparison across base/head commits.

Depends on the migration in https://github.com/codecov/codecov-api/pull/320