### PR TITLE
fix: Handle removed bundles in PR comment

### DIFF
--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -10,6 +10,7 @@ from shared.bundle_analysis import (
     BundleAnalysisComparison,
     BundleAnalysisReport,
     BundleAnalysisReportLoader,
+    BundleChange,
 )
 from shared.bundle_analysis.storage import get_bucket_name
 from shared.reports.enums import UploadState
@@ -344,8 +345,11 @@ class Notifier:
         ]
         for bundle_change in bundle_changes:
             bundle_name = bundle_change.bundle_name
-            head_bundle_report = comparison.head_report.bundle_report(bundle_name)
-            size = self._bytes_readable(head_bundle_report.total_size())
+            if bundle_change.change_type == BundleChange.ChangeType.REMOVED:
+                size = "(removed)"
+            else:
+                head_bundle_report = comparison.head_report.bundle_report(bundle_name)
+                size = self._bytes_readable(head_bundle_report.total_size())
 
             change_size = bundle_change.size_delta
             icon = ""

--- a/services/tests/test_bundle_analysis.py
+++ b/services/tests/test_bundle_analysis.py
@@ -11,11 +11,13 @@ from services.repository import EnrichedPull
 
 expected_message_increase = """## Bundle Report
 
-Changes will increase total bundle size by 3.46KB :arrow_up:
+Changes will increase total bundle size by 14.57KB :arrow_up:
 
 | Bundle name | Size | Change |
 | ----------- | ---- | ------ |
-| test-bundle | 123.46KB | 3.46KB :arrow_up: |"""
+| added-bundle | 123.46KB | 12.35KB :arrow_up: |
+| changed-bundle | 123.46KB | 3.46KB :arrow_up: |
+| removed-bundle | (removed) | 1.23KB :arrow_down: |"""
 
 expected_message_decrease = """## Bundle Report
 
@@ -95,7 +97,13 @@ async def test_bundle_analysis_notify(
         "shared.bundle_analysis.comparison.BundleAnalysisComparison.bundle_changes"
     )
     bundle_changes.return_value = [
-        BundleChange("test-bundle", BundleChange.ChangeType.CHANGED, size_delta=3456),
+        BundleChange("added-bundle", BundleChange.ChangeType.ADDED, size_delta=12345),
+        BundleChange(
+            "changed-bundle", BundleChange.ChangeType.CHANGED, size_delta=3456
+        ),
+        BundleChange(
+            "removed-bundle", BundleChange.ChangeType.REMOVED, size_delta=-1234
+        ),
     ]
 
     bundle_report = mocker.patch(


### PR DESCRIPTION
The code would have errored previously when trying to call `head_bundle_report.total_size()` (since `head_bundle_report` would have been `None` if removed)