### PR TITLE
feat: some per-customer ats metrics

### DIFF
--- a/tasks/label_analysis.py
+++ b/tasks/label_analysis.py
@@ -419,10 +419,10 @@ class LabelAnalysisRequestProcessingTask(
                 commit=commit_sha,
             ),
         )
-        self.metrics_context.log_simple_metric(
+        self.metrics_context.attempt_log_simple_metric(
             "label_analysis.tests_saved_count", len(all_report_labels)
         )
-        self.metrics_context.log_simple_metric(
+        self.metrics_context.attempt_log_simple_metric(
             "label_analysis.requests_with_requested_labels",
             float(requested_labels is not None),
         )
@@ -436,10 +436,10 @@ class LabelAnalysisRequestProcessingTask(
                 "absent_labels": sorted(requested_labels - all_report_labels),
                 "global_level_labels": sorted(global_level_labels & requested_labels),
             }
-            self.metrics_context.log_simple_metric(
+            self.metrics_context.attempt_log_simple_metric(
                 "label_analysis.requested_labels_count", len(requested_labels)
             )
-            self.metrics_context.log_simple_metric(
+            self.metrics_context.attempt_log_simple_metric(
                 "label_analysis.tests_to_run_count",
                 len(
                     ans["present_diff_labels"]
@@ -448,7 +448,7 @@ class LabelAnalysisRequestProcessingTask(
                 ),
             )
             return ans
-        self.metrics_context.log_simple_metric(
+        self.metrics_context.attempt_log_simple_metric(
             "label_analysis.tests_to_run_count",
             len(executable_lines_labels | global_level_labels),
         )

--- a/tasks/tests/unit/test_label_analysis.py
+++ b/tasks/tests/unit/test_label_analysis.py
@@ -512,13 +512,13 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     mock_metrics_context.assert_called_with(
         repo_id=repository.repoid, commit_id=larf.head_commit.id
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 0.0
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 6
     )
     dbsession.flush()
@@ -556,16 +556,16 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     mock_metrics.incr.assert_called_with(
         "label_analysis_task.already_calculated.new_result"
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 1.0
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.requested_labels_count", 4
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 3
     )
 
@@ -620,13 +620,13 @@ async def test_simple_call_with_requested_labels(
     mock_metrics_context.assert_called_with(
         repo_id=larf.head_commit.repository.repoid, commit_id=larf.head_commit.id
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 1.0
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 3
     )
 

--- a/tasks/tests/unit/test_label_analysis_encoded_labels.py
+++ b/tasks/tests/unit/test_label_analysis_encoded_labels.py
@@ -528,13 +528,13 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     mock_metrics_context.assert_called_with(
         repo_id=repository.repoid, commit_id=larf.head_commit.id
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 0.0
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 6
     )
     # It's zero because the report has the _labels_index already
@@ -576,16 +576,16 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     mock_metrics.incr.assert_called_with(
         "label_analysis_task.already_calculated.new_result"
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 1.0
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.requested_labels_count", 4
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 3
     )
 
@@ -642,13 +642,13 @@ async def test_simple_call_with_requested_labels(
     mock_metrics_context.assert_called_with(
         repo_id=larf.head_commit.repository.repoid, commit_id=larf.head_commit.id
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 1.0
     )
-    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 3
     )
 

--- a/tasks/tests/unit/test_label_analysis_encoded_labels.py
+++ b/tasks/tests/unit/test_label_analysis_encoded_labels.py
@@ -438,6 +438,7 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
+    mock_metrics_context = mocker.patch("tasks.label_analysis.MetricContext")
     mocker.patch.object(
         LabelAnalysisRequestProcessingTask,
         "_get_lines_relevant_to_diff",
@@ -524,6 +525,18 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     }
     assert res == expected_result
     mock_metrics.incr.assert_called_with("label_analysis_task.success")
+    mock_metrics_context.assert_called_with(
+        repo_id=repository.repoid, commit_id=larf.head_commit.id
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.tests_saved_count", 9
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.requests_with_requested_labels", 0.0
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.tests_to_run_count", 6
+    )
     # It's zero because the report has the _labels_index already
     dbsession.flush()
     dbsession.refresh(larf)
@@ -560,6 +573,21 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     mock_metrics.incr.assert_called_with(
         "label_analysis_task.already_calculated.new_result"
     )
+    mock_metrics.incr.assert_called_with(
+        "label_analysis_task.already_calculated.new_result"
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.tests_saved_count", 9
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.requests_with_requested_labels", 1.0
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.requested_labels_count", 4
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.tests_to_run_count", 3
+    )
 
 
 @pytest.mark.asyncio
@@ -567,6 +595,7 @@ async def test_simple_call_with_requested_labels(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
+    mock_metrics_context = mocker.patch("tasks.label_analysis.MetricContext")
     mocker.patch.object(
         LabelAnalysisRequestProcessingTask,
         "_get_lines_relevant_to_diff",
@@ -609,6 +638,19 @@ async def test_simple_call_with_requested_labels(
         "global_level_labels": [],
     }
     mock_metrics.incr.assert_called_with("label_analysis_task.success")
+    mock_metrics.incr.assert_called_with("label_analysis_task.success")
+    mock_metrics_context.assert_called_with(
+        repo_id=larf.head_commit.repository.repoid, commit_id=larf.head_commit.id
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.tests_saved_count", 9
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.requests_with_requested_labels", 1.0
+    )
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
+        "label_analysis.tests_to_run_count", 3
+    )
 
 
 def test_get_requested_labels(dbsession, mocker):


### PR DESCRIPTION
context: codecov/engineering-team#526

Adds some basic per-customer ats metrics.
Actually because the `MetricsContext` usage is disabled this
just sets up the metrics once that's done.

Makes use of `MetricsContext` to annotate metrics per customer
(repo, commit, owner).

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.