### PR TITLE
fix: handle scientific notation when parsing hit count in lcov reports

### DIFF
--- a/services/report/languages/tests/unit/test_lcov.py
+++ b/services/report/languages/tests/unit/test_lcov.py
@@ -51,6 +51,7 @@ DA:0,skipped
 DA:null,skipped
 DA:1,0
 DA:=,=
+DA:2,1e+0
 BRDA:0,0,0,0
 BRDA:1,1,1,1
 end_of_record
@@ -64,13 +65,16 @@ SF:file.cpp
 FN:2,not_hit
 FN:3,_Zalkfjeo
 FN:4,_Gsabebra
+FN:78,_Zalkfjeo2
 FNDA:1,_ln1_is_skipped
 FNDA:,not_hit
 FNDA:2,ignored
 FNDA:3,ignored
 FNDA:4,ignored
+FNDA:78,1+e0
 DA:1,1
 DA:77,0
+DA:78,1
 BRDA:2,1,0,1
 BRDA:2,1,1,-
 BRDA:2,1,3,0
@@ -138,10 +142,21 @@ class TestLcov(BaseTestCase):
                     [[0, "0/4", ["3:0", "3:1", "4:0", "4:1"], None, None]],
                     None,
                     None,
-                )
+                ),
+                (
+                    78,
+                    1,
+                    None,
+                    [[0, 1, None, None, None]],
+                    None,
+                    None,
+                ),
                 # TODO (Thiago): This is out f order compared to the original, verify what happened
             ],
-            "file.js": [(1, 1, None, [[0, 1, None, None, None]], None, None)],
+            "file.js": [
+                (1, 1, None, [[0, 1, None, None, None]], None, None),
+                (2, 1, None, [[0, 1, None, None, None]], None, None),
+            ],
             "file.ts": [(2, 1, None, [[0, 1, None, None, None]], None, None)],
         }
 


### PR DESCRIPTION
surprisingly, we encountered a report where a line was executed >2**64 times and the lcov tool emitted the hit count with scientific notation. this commit handles that

i mocked up lcov data that uses scientific notation and ran the upload through my local instance of codecov and it worked: https://github.com/matt-codecov/test-lcov-sci-notation

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.