### PR TITLE
Add test results finisher

### DIFF
--- a/services/lock_manager.py
+++ b/services/lock_manager.py
@@ -16,6 +16,7 @@ log = logging.getLogger(__name__)
 class LockType(Enum):
     BUNDLE_ANALYSIS_PROCESSING = "bundle_analysis_processing"
     BUNDLE_ANALYSIS_NOTIFY = "bundle_analysis_notify"
+    NOTIFICATION = "notify"
     # TODO: port existing task locking to use `LockManager`
 
 

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -216,10 +216,9 @@ class TestResultsNotifier:
         return "\n".join(message)
 
     def insert_breaks(self, table_value):
-        len_of_table_value = len(table_value)
-        for i in range((len_of_table_value) // 70):
-            table_value = (
-                table_value[: (i + 1) * 70] + "<br>" + table_value[(i + 1) * 70 :]
-            )
-
-        return table_value
+        line_size = 70
+        lines = [
+            table_value[i : i + line_size]
+            for i in range(0, len(table_value), line_size)
+        ]
+        return "<br>".join(lines)

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -12,6 +12,7 @@ from services.repository import (
     fetch_and_update_pull_request_information_from_commit,
     get_repo_provider_service,
 )
+from services.urls import get_pull_url
 
 log = logging.getLogger(__name__)
 
@@ -94,3 +95,131 @@ def generate_test_id(repoid, testsuite, name, flags_hash):
             "utf-8"
         )
     ).hexdigest()
+
+
+class TestResultsNotifier:
+    def __init__(self, commit: Commit, commit_yaml, test_instances):
+        self.commit = commit
+        self.commit_yaml = commit_yaml
+        self.test_instances = test_instances
+
+    async def notify(self):
+        commit_report = self.commit.commit_report(report_type=ReportType.TEST_RESULTS)
+        if not commit_report:
+            log.warning(
+                "No test results commit report found for this commit",
+                extra=dict(
+                    commitid=self.commit.commitid,
+                    report_key=commit_report.external_id,
+                ),
+            )
+
+        repo_service = get_repo_provider_service(self.commit.repository, self.commit)
+
+        pull = await fetch_and_update_pull_request_information_from_commit(
+            repo_service, self.commit, self.commit_yaml
+        )
+        pullid = pull.database_pull.pullid
+        if pull is None:
+            log.info(
+                "Not notifying since there is no pull request associated with this commit",
+                extra=dict(
+                    commitid=self.commit.commitid,
+                    report_key=commit_report.external_id,
+                    pullid=pullid,
+                ),
+            )
+
+        pull_url = get_pull_url(pull.database_pull)
+
+        message = self.build_message(pull_url, self.test_instances)
+
+        try:
+            comment_id = pull.database_pull.commentid
+            if comment_id:
+                await repo_service.edit_comment(pullid, comment_id, message)
+            else:
+                res = await repo_service.post_comment(pullid, message)
+                pull.database_pull.commentid = res["id"]
+            return True
+        except TorngitClientError:
+            log.error(
+                "Error creating/updating PR comment",
+                extra=dict(
+                    commitid=self.commit.commitid,
+                    report_key=commit_report.external_id,
+                    pullid=pullid,
+                ),
+            )
+            return False
+
+    def build_message(self, url, test_instances):
+        message = []
+
+        message += [
+            f"##  [Codecov]({url}) Report",
+            "",
+            "**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.",
+            "",
+            "### :x: Failed Test Results: ",
+        ]
+        failed_tests = 0
+        passed_tests = 0
+        skipped_tests = 0
+
+        failures = dict()
+
+        for test_instance in test_instances:
+            if (
+                test_instance.outcome == Outcome.Failure
+                or test_instance.outcome == Outcome.Error
+            ):
+                failed_tests += 1
+                job_code = test_instance.upload.job_code
+                flag_names = sorted(test_instance.upload.flag_names)
+                suffix = ""
+                if job_code or flag_names:
+                    suffix = f"[{''.join(flag_names) or ''} {job_code or ''}]"
+                failures[
+                    f"{test_instance.test.testsuite}::{test_instance.test.name}{suffix}"
+                ] = test_instance.failure_message
+            elif test_instance.outcome == Outcome.Skip:
+                skipped_tests += 1
+            elif test_instance.outcome == Outcome.Pass:
+                passed_tests += 1
+
+        results = f"Completed {len(test_instances)} tests with **`{failed_tests} failed`**, {passed_tests} passed and {skipped_tests} skipped."
+
+        message.append(results)
+
+        details = [
+            "<details><summary>View the full list of failed tests</summary>",
+            "",
+            "| **File path** | **Failure message** |",
+            "| :-- | :-- |",
+        ]
+
+        message += details
+
+        failure_table = [
+            "| {0} | <pre>{1}</pre> |".format(
+                self.insert_breaks(failed_test_name),
+                failure_message.replace("\n", "<br>"),
+            )
+            for failed_test_name, failure_message in sorted(
+                failures.items(), key=lambda failure: failure[0]
+            )
+        ]
+
+        message += failure_table
+
+        return "\n".join(message)
+
+    def insert_breaks(self, table_value):
+        len_of_table_value = len(table_value)
+        for i in range((len_of_table_value) // 70):
+            table_value = (
+                table_value[: (i + 1) * 70] + "<br>" + table_value[(i + 1) * 70 :]
+            )
+
+        return table_value

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -3,10 +3,11 @@ from hashlib import sha256
 from typing import Mapping, Sequence
 
 from shared.torngit.exceptions import TorngitClientError
-from test_results_parser import Outcome, Testrun
+from sqlalchemy import desc
+from test_results_parser import Outcome
 
 from database.enums import ReportType
-from database.models import Commit, CommitReport, RepositoryFlag, Upload
+from database.models import Commit, CommitReport, RepositoryFlag, TestInstance, Upload
 from services.report import BaseReportService
 from services.repository import (
     fetch_and_update_pull_request_information_from_commit,
@@ -170,10 +171,9 @@ class TestResultsNotifier:
         failures = dict()
 
         for test_instance in test_instances:
-            if (
-                test_instance.outcome == Outcome.Failure
-                or test_instance.outcome == Outcome.Error
-            ):
+            if test_instance.outcome == str(
+                Outcome.Failure
+            ) or test_instance.outcome == str(Outcome.Error):
                 failed_tests += 1
                 job_code = test_instance.upload.job_code
                 flag_names = sorted(test_instance.upload.flag_names)
@@ -183,9 +183,9 @@ class TestResultsNotifier:
                 failures[
                     f"{test_instance.test.testsuite}::{test_instance.test.name}{suffix}"
                 ] = test_instance.failure_message
-            elif test_instance.outcome == Outcome.Skip:
+            elif test_instance.outcome == str(Outcome.Skip):
                 skipped_tests += 1
-            elif test_instance.outcome == Outcome.Pass:
+            elif test_instance.outcome == str(Outcome.Pass):
                 passed_tests += 1
 
         results = f"Completed {len(test_instances)} tests with **`{failed_tests} failed`**, {passed_tests} passed and {skipped_tests} skipped."
@@ -222,3 +222,31 @@ class TestResultsNotifier:
             for i in range(0, len(table_value), line_size)
         ]
         return "<br>".join(lines)
+
+
+def latest_test_instances_for_a_given_commit(db_session, commit_id):
+    """
+    This will result in a SQL query that looks something like this:
+
+    SELECT DISTINCT ON (rt.test_id) rt.id, rt.external_id, rt.created_at, rt.updated_at, rt.test_id, rt.duration_seconds, rt.outcome, rt.upload_id, rt.failure_message
+        FROM reports_testinstance rt JOIN reports_upload ru ON ru.id = rt.upload_id JOIN reports_commitreport rc ON rc.id = ru.report_id
+        WHERE rc.commit_id = <commit_id> ORDER BY rt.test_id, ru.created_at desc
+
+    The goal of this query is to return: "the latest test instance for each unique test based on upload creation time"
+
+    The `DISTINCT ON` test_id with the order by test_id, enforces that we are only fetching one test instance for each test
+
+    The ordering of the upload.create_at desc enforces that we get the latest test instance for that unique test
+    """
+    return (
+        db_session.query(TestInstance)
+        .join(Upload)
+        .join(CommitReport)
+        .filter(
+            CommitReport.commit_id == commit_id,
+        )
+        .order_by(TestInstance.test_id)
+        .order_by(desc(Upload.created_at))
+        .distinct(TestInstance.test_id)
+        .all()
+    )

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -91,8 +91,6 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         )
         assert commit, "commit not found"
 
-        notify = True
-
         if self.check_if_no_success(previous_result):
             # every processor errored, nothing to notify on
             return {"notify_attempted": False, "notify_succeeded": False}
@@ -132,7 +130,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             ),
         )
 
-        return {"notify_attempted": notify, "notify_succeeded": success}
+        return {"notify_attempted": True, "notify_succeeded": success}
 
     def check_if_no_success(self, previous_result):
         return all(

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -1,0 +1,153 @@
+import logging
+from typing import Any, Dict
+
+from shared.yaml import UserYaml
+from sqlalchemy import desc
+from test_results_parser import Outcome
+
+from app import celery_app
+from database.enums import ReportType
+from database.models import Commit, CommitReport, Test, TestInstance, Upload
+from services.lock_manager import LockManager, LockRetry, LockType
+from services.test_results import TestResultsNotifier
+from tasks.base import BaseCodecovTask
+from tasks.notify import notify_task_name
+
+log = logging.getLogger(__name__)
+
+test_results_finisher_task_name = "app.tasks.test_results.TestResultsFinisherTask"
+
+
+class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_name):
+    async def run_async(
+        self,
+        db_session,
+        chord_result: Dict[str, Any],
+        *,
+        repoid: int,
+        commitid: str,
+        commit_yaml: dict,
+        **kwargs,
+    ):
+        repoid = int(repoid)
+        commit_yaml = UserYaml.from_dict(commit_yaml)
+
+        log.info(
+            "Starting test results finisher task",
+            extra=dict(
+                repoid=repoid,
+                commit=commitid,
+                commit_yaml=commit_yaml,
+            ),
+        )
+
+        lock_manager = LockManager(
+            repoid=repoid,
+            commitid=commitid,
+            report_type=ReportType.COVERAGE,
+            lock_timeout=max(80, self.hard_time_limit_task),
+        )
+
+        try:
+            # this needs to be the coverage notification lock
+            # since both tests post/edit the same comment
+            with lock_manager.locked(
+                LockType.NOTIFICATION,
+                retry_num=self.request.retries,
+            ):
+                return await self.process_async_within_lock(
+                    db_session=db_session,
+                    repoid=repoid,
+                    commitid=commitid,
+                    commit_yaml=commit_yaml,
+                    previous_result=chord_result,
+                    **kwargs,
+                )
+        except LockRetry as retry:
+            self.retry(max_retries=5, countdown=retry.countdown)
+
+    async def process_async_within_lock(
+        self,
+        *,
+        db_session,
+        repoid: int,
+        commitid: str,
+        commit_yaml: UserYaml,
+        previous_result: Dict[str, Any],
+        **kwargs,
+    ):
+        log.info(
+            "Running test results finishers",
+            extra=dict(
+                repoid=repoid,
+                commit=commitid,
+                commit_yaml=commit_yaml,
+                parent_task=self.request.parent_id,
+            ),
+        )
+
+        commit: Commit = (
+            db_session.query(Commit).filter_by(repoid=repoid, commitid=commitid).first()
+        )
+        assert commit, "commit not found"
+
+        notify = True
+
+        if self.check_if_no_success(previous_result):
+            # every processor errored, nothing to notify on
+            return {"notify_attempted": False, "notify_succeeded": False}
+
+        test_instances = (
+            db_session.query(TestInstance)
+            .join(Upload)
+            .join(CommitReport)
+            .join(Commit)
+            .filter(Commit.id_ == commit.id_)
+            .order_by(TestInstance.test_id)
+            .order_by(desc(Upload.created_at))
+            .distinct(TestInstance.test_id)
+            .all()
+        )
+
+        if self.check_if_no_failures(test_instances):
+            self.app.tasks[notify_task_name].apply_async(
+                args=None,
+                kwargs=dict(
+                    repoid=repoid, commitid=commitid, current_yaml=commit_yaml.to_dict()
+                ),
+            )
+            return {"notify_attempted": False, "notify_succeeded": False}
+
+        success = None
+        notifier = TestResultsNotifier(commit, commit_yaml, test_instances)
+        success = await notifier.notify()
+
+        log.info(
+            "Finished test results notify",
+            extra=dict(
+                repoid=repoid,
+                commit=commitid,
+                commit_yaml=commit_yaml,
+                parent_task=self.request.parent_id,
+            ),
+        )
+
+        return {"notify_attempted": notify, "notify_succeeded": success}
+
+    def check_if_no_success(self, previous_result):
+        return all(
+            (
+                testrun_list["successful"] is False
+                for result in previous_result
+                for testrun_list in result
+            )
+        )
+
+    def check_if_no_failures(self, testrun_list):
+        return all(
+            [instance.outcome != int(Outcome.Failure) for instance in testrun_list]
+        )
+
+
+RegisteredTestResultsFinisherTask = celery_app.register_task(TestResultsFinisherTask())
+test_results_finisher_task = celery_app.tasks[RegisteredTestResultsFinisherTask.name]

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -108,7 +108,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="a",
+            flags_hash="a",
         )
         dbsession.add(test1)
         dbsession.flush()
@@ -117,7 +117,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="b",
+            flags_hash="b",
         )
         dbsession.add(test2)
         dbsession.flush()
@@ -262,7 +262,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="a",
+            flags_hash="a",
         )
         dbsession.add(test1)
         dbsession.flush()
@@ -271,7 +271,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="b",
+            flags_hash="b",
         )
         dbsession.add(test2)
         dbsession.flush()
@@ -420,7 +420,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="a",
+            flags_hash="a",
         )
         dbsession.add(test1)
         dbsession.flush()
@@ -429,7 +429,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="b",
+            flags_hash="b",
         )
         dbsession.add(test2)
         dbsession.flush()
@@ -572,7 +572,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="a",
+            flags_hash="a",
         )
         dbsession.add(test1)
         dbsession.flush()
@@ -581,7 +581,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="b",
+            flags_hash="b",
         )
         dbsession.add(test2)
         dbsession.flush()
@@ -729,7 +729,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="a",
+            flags_hash="a",
         )
         dbsession.add(test1)
         dbsession.flush()
@@ -738,7 +738,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             name="test_name",
             testsuite="test_testsuite",
-            env="b",
+            flags_hash="b",
         )
         dbsession.add(test2)
         dbsession.flush()

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -1,0 +1,789 @@
+import datetime
+from pathlib import Path
+
+import pytest
+from mock import AsyncMock
+from shared.torngit.exceptions import TorngitClientError
+from test_results_parser import Outcome
+
+from database.enums import ReportType
+from database.models import CommitReport, RepositoryFlag, Test, TestInstance
+from database.tests.factories import CommitFactory, PullFactory, UploadFactory
+from services.repository import EnrichedPull
+from services.test_results import generate_test_id
+from tasks.test_results_finisher import TestResultsFinisherTask
+
+here = Path(__file__)
+
+
+class TestUploadTestFinisherTask(object):
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_upload_finisher_task_call(
+        self,
+        mocker,
+        mock_configuration,
+        dbsession,
+        codecov_vcr,
+        mock_storage,
+        mock_redis,
+        celery_app,
+    ):
+        mocked_app = mocker.patch.object(
+            TestResultsFinisherTask,
+            "app",
+            tasks={"app.tasks.notify.Notify": mocker.MagicMock()},
+        )
+
+        commit = CommitFactory.create(
+            message="hello world",
+            commitid="cd76b0821854a780b60012aed85af0a8263004ad",
+            repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
+            repository__owner__username="joseph-sentry",
+            repository__owner__service="github",
+            repository__name="codecov-demo",
+        )
+        dbsession.add(commit)
+        dbsession.flush()
+
+        upload1 = UploadFactory.create()
+        dbsession.add(upload1)
+        dbsession.flush()
+
+        upload2 = UploadFactory.create()
+        upload2.created_at = upload2.created_at + datetime.timedelta(0, 3)
+        dbsession.add(upload2)
+        dbsession.flush()
+
+        current_report_row = CommitReport(
+            commit_id=commit.id_, report_type=ReportType.TEST_RESULTS.value
+        )
+        dbsession.add(current_report_row)
+        dbsession.flush()
+        upload1.report = current_report_row
+        upload2.report = current_report_row
+        dbsession.flush()
+
+        pull = PullFactory.create(repository=commit.repository, head=commit.commitid)
+
+        _ = mocker.patch(
+            "services.test_results.fetch_and_update_pull_request_information_from_commit",
+            return_value=EnrichedPull(
+                database_pull=pull,
+                provider_pull={},
+            ),
+        )
+
+        mocker.patch.object(TestResultsFinisherTask, "hard_time_limit_task", 0)
+
+        m = mocker.MagicMock(
+            edit_comment=AsyncMock(return_value=True),
+            post_comment=AsyncMock(return_value={"id": 1}),
+        )
+        mocked_repo_provider = mocker.patch(
+            "services.test_results.get_repo_provider_service",
+            return_value=m,
+        )
+
+        repoid = upload1.report.commit.repoid
+        upload2.report.commit.repoid = repoid
+        dbsession.flush()
+
+        flag1 = RepositoryFlag(repository_id=repoid, flag_name="a")
+        flag2 = RepositoryFlag(repository_id=repoid, flag_name="b")
+        dbsession.flush()
+
+        upload1.flags = [flag1]
+        upload2.flags = [flag2]
+        dbsession.flush()
+
+        upload_id1 = upload1.id
+        upload_id2 = upload2.id
+
+        test_id1 = generate_test_id(repoid, "test_name", "test_testsuite", "a")
+        test_id2 = generate_test_id(repoid, "test_name", "test_testsuite", "b")
+
+        test1 = Test(
+            id_=test_id1,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="a",
+        )
+        dbsession.add(test1)
+        dbsession.flush()
+        test2 = Test(
+            id_=test_id2,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="b",
+        )
+        dbsession.add(test2)
+        dbsession.flush()
+
+        test_instance1 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Failure),
+            failure_message="bad",
+            duration_seconds=1,
+            upload_id=upload_id1,
+        )
+        dbsession.add(test_instance1)
+        dbsession.flush()
+
+        test_instance2 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Failure),
+            failure_message="not that bad",
+            duration_seconds=1,
+            upload_id=upload_id2,
+        )
+        dbsession.add(test_instance2)
+        dbsession.flush()
+
+        test_instance3 = TestInstance(
+            test_id=test_id2,
+            outcome=int(Outcome.Failure),
+            failure_message="okay i guess",
+            duration_seconds=2,
+            upload_id=upload_id1,
+        )
+
+        dbsession.add(test_instance3)
+        dbsession.flush()
+
+        result = await TestResultsFinisherTask().run_async(
+            dbsession,
+            [
+                [{"successful": True}],
+            ],
+            repoid=repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": False}},
+        )
+
+        expected_result = {"notify_attempted": True, "notify_succeeded": True}
+        m.post_comment.assert_called_with(
+            pull.pullid,
+            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a ] | <pre>okay i guess</pre> |\n| test_testsuite::test_name[b ] | <pre>not that bad</pre> |",
+        )
+
+        assert expected_result == result
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_upload_finisher_task_call_no_failures(
+        self,
+        mocker,
+        mock_configuration,
+        dbsession,
+        codecov_vcr,
+        mock_storage,
+        mock_redis,
+        celery_app,
+    ):
+        mocked_app = mocker.patch.object(
+            TestResultsFinisherTask,
+            "app",
+            tasks={"app.tasks.notify.Notify": mocker.MagicMock()},
+        )
+
+        commit = CommitFactory.create(
+            message="hello world",
+            commitid="cd76b0821854a780b60012aed85af0a8263004ad",
+            repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
+            repository__owner__username="joseph-sentry",
+            repository__owner__service="github",
+            repository__name="codecov-demo",
+        )
+        dbsession.add(commit)
+        dbsession.flush()
+
+        upload1 = UploadFactory.create()
+        dbsession.add(upload1)
+        dbsession.flush()
+
+        upload2 = UploadFactory.create()
+        upload2.created_at = upload2.created_at + datetime.timedelta(0, 3)
+        dbsession.add(upload2)
+        dbsession.flush()
+
+        current_report_row = CommitReport(
+            commit_id=commit.id_, report_type=ReportType.TEST_RESULTS.value
+        )
+        dbsession.add(current_report_row)
+        dbsession.flush()
+        upload1.report = current_report_row
+        upload2.report = current_report_row
+        dbsession.flush()
+
+        pull = PullFactory.create(repository=commit.repository, head=commit.commitid)
+
+        _ = mocker.patch(
+            "services.test_results.fetch_and_update_pull_request_information_from_commit",
+            return_value=EnrichedPull(
+                database_pull=pull,
+                provider_pull={},
+            ),
+        )
+
+        mocker.patch.object(TestResultsFinisherTask, "hard_time_limit_task", 0)
+
+        m = mocker.MagicMock(
+            edit_comment=AsyncMock(return_value=True),
+            post_comment=AsyncMock(return_value={"id": 1}),
+        )
+        mocked_repo_provider = mocker.patch(
+            "services.test_results.get_repo_provider_service",
+            return_value=m,
+        )
+
+        repoid = upload1.report.commit.repoid
+        upload2.report.commit.repoid = repoid
+        dbsession.flush()
+
+        flag1 = RepositoryFlag(repository_id=repoid, flag_name="a")
+        flag2 = RepositoryFlag(repository_id=repoid, flag_name="b")
+        dbsession.flush()
+
+        upload1.flags = [flag1]
+        upload2.flags = [flag2]
+        dbsession.flush()
+
+        upload_id1 = upload1.id
+        upload_id2 = upload2.id
+
+        test_id1 = generate_test_id(repoid, "test_name", "test_testsuite", "a")
+        test_id2 = generate_test_id(repoid, "test_name", "test_testsuite", "b")
+
+        test1 = Test(
+            id_=test_id1,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="a",
+        )
+        dbsession.add(test1)
+        dbsession.flush()
+        test2 = Test(
+            id_=test_id2,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="b",
+        )
+        dbsession.add(test2)
+        dbsession.flush()
+
+        test_instance1 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Pass),
+            failure_message="bad",
+            duration_seconds=1,
+            upload_id=upload_id1,
+        )
+        dbsession.add(test_instance1)
+        dbsession.flush()
+
+        test_instance2 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Pass),
+            failure_message="not that bad",
+            duration_seconds=1,
+            upload_id=upload_id2,
+        )
+        dbsession.add(test_instance2)
+        dbsession.flush()
+
+        test_instance3 = TestInstance(
+            test_id=test_id2,
+            outcome=int(Outcome.Pass),
+            failure_message="okay i guess",
+            duration_seconds=2,
+            upload_id=upload_id1,
+        )
+
+        dbsession.add(test_instance3)
+        dbsession.flush()
+
+        result = await TestResultsFinisherTask().run_async(
+            dbsession,
+            [
+                [{"successful": True}],
+            ],
+            repoid=repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": False}},
+        )
+
+        expected_result = {"notify_attempted": False, "notify_succeeded": False}
+        mocked_app.tasks["app.tasks.notify.Notify"].apply_async.assert_called_with(
+            args=None,
+            kwargs={
+                "commitid": commit.commitid,
+                "current_yaml": {"codecov": {"max_report_age": False}},
+                "repoid": commit.repoid,
+            },
+        )
+
+        assert expected_result == result
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_upload_finisher_task_call_no_success(
+        self,
+        mocker,
+        mock_configuration,
+        dbsession,
+        codecov_vcr,
+        mock_storage,
+        mock_redis,
+        celery_app,
+    ):
+        mocked_app = mocker.patch.object(
+            TestResultsFinisherTask,
+            "app",
+            tasks={"app.tasks.notify.Notify": mocker.MagicMock()},
+        )
+
+        commit = CommitFactory.create(
+            message="hello world",
+            commitid="cd76b0821854a780b60012aed85af0a8263004ad",
+            repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
+            repository__owner__username="joseph-sentry",
+            repository__owner__service="github",
+            repository__name="codecov-demo",
+        )
+        dbsession.add(commit)
+        dbsession.flush()
+
+        upload1 = UploadFactory.create()
+        dbsession.add(upload1)
+        dbsession.flush()
+
+        upload2 = UploadFactory.create()
+        upload2.created_at = upload2.created_at + datetime.timedelta(0, 3)
+        dbsession.add(upload2)
+        dbsession.flush()
+
+        current_report_row = CommitReport(
+            commit_id=commit.id_, report_type=ReportType.TEST_RESULTS.value
+        )
+        dbsession.add(current_report_row)
+        dbsession.flush()
+        upload1.report = current_report_row
+        upload2.report = current_report_row
+        dbsession.flush()
+
+        pull = PullFactory.create(repository=commit.repository, head=commit.commitid)
+
+        _ = mocker.patch(
+            "services.test_results.fetch_and_update_pull_request_information_from_commit",
+            return_value=EnrichedPull(
+                database_pull=pull,
+                provider_pull={},
+            ),
+        )
+
+        mocker.patch.object(TestResultsFinisherTask, "hard_time_limit_task", 0)
+
+        m = mocker.MagicMock(
+            edit_comment=AsyncMock(return_value=True),
+            post_comment=AsyncMock(return_value={"id": 1}),
+        )
+        mocked_repo_provider = mocker.patch(
+            "services.test_results.get_repo_provider_service",
+            return_value=m,
+        )
+
+        repoid = upload1.report.commit.repoid
+        upload2.report.commit.repoid = repoid
+        dbsession.flush()
+
+        flag1 = RepositoryFlag(repository_id=repoid, flag_name="a")
+        flag2 = RepositoryFlag(repository_id=repoid, flag_name="b")
+        dbsession.flush()
+
+        upload1.flags = [flag1]
+        upload2.flags = [flag2]
+        dbsession.flush()
+
+        upload_id1 = upload1.id
+        upload_id2 = upload2.id
+
+        test_id1 = generate_test_id(repoid, "test_name", "test_testsuite", "a")
+        test_id2 = generate_test_id(repoid, "test_name", "test_testsuite", "b")
+
+        test1 = Test(
+            id_=test_id1,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="a",
+        )
+        dbsession.add(test1)
+        dbsession.flush()
+        test2 = Test(
+            id_=test_id2,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="b",
+        )
+        dbsession.add(test2)
+        dbsession.flush()
+
+        test_instance1 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Pass),
+            failure_message="bad",
+            duration_seconds=1,
+            upload_id=upload_id1,
+        )
+        dbsession.add(test_instance1)
+        dbsession.flush()
+
+        test_instance2 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Pass),
+            failure_message="not that bad",
+            duration_seconds=1,
+            upload_id=upload_id2,
+        )
+        dbsession.add(test_instance2)
+        dbsession.flush()
+
+        test_instance3 = TestInstance(
+            test_id=test_id2,
+            outcome=int(Outcome.Pass),
+            failure_message="okay i guess",
+            duration_seconds=2,
+            upload_id=upload_id1,
+        )
+
+        dbsession.add(test_instance3)
+        dbsession.flush()
+
+        result = await TestResultsFinisherTask().run_async(
+            dbsession,
+            [
+                [{"successful": False}],
+            ],
+            repoid=repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": False}},
+        )
+
+        expected_result = {"notify_attempted": False, "notify_succeeded": False}
+
+        assert expected_result == result
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_upload_finisher_task_call_existing_comment(
+        self,
+        mocker,
+        mock_configuration,
+        dbsession,
+        codecov_vcr,
+        mock_storage,
+        mock_redis,
+        celery_app,
+    ):
+        mocked_app = mocker.patch.object(
+            TestResultsFinisherTask,
+            "app",
+            tasks={"app.tasks.notify.Notify": mocker.MagicMock()},
+        )
+
+        commit = CommitFactory.create(
+            message="hello world",
+            commitid="cd76b0821854a780b60012aed85af0a8263004ad",
+            repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
+            repository__owner__username="joseph-sentry",
+            repository__owner__service="github",
+            repository__name="codecov-demo",
+        )
+        dbsession.add(commit)
+        dbsession.flush()
+
+        upload1 = UploadFactory.create()
+        dbsession.add(upload1)
+        dbsession.flush()
+
+        upload2 = UploadFactory.create()
+        upload2.created_at = upload2.created_at + datetime.timedelta(0, 3)
+        dbsession.add(upload2)
+        dbsession.flush()
+
+        current_report_row = CommitReport(
+            commit_id=commit.id_, report_type=ReportType.TEST_RESULTS.value
+        )
+        dbsession.add(current_report_row)
+        dbsession.flush()
+        upload1.report = current_report_row
+        upload2.report = current_report_row
+        dbsession.flush()
+
+        pull = PullFactory.create(
+            repository=commit.repository, head=commit.commitid, commentid=1, pullid=1
+        )
+
+        _ = mocker.patch(
+            "services.test_results.fetch_and_update_pull_request_information_from_commit",
+            return_value=EnrichedPull(
+                database_pull=pull,
+                provider_pull={},
+            ),
+        )
+
+        mocker.patch.object(TestResultsFinisherTask, "hard_time_limit_task", 0)
+
+        m = mocker.MagicMock(
+            edit_comment=AsyncMock(return_value=True),
+            post_comment=AsyncMock(return_value={"id": 1}),
+        )
+        mocked_repo_provider = mocker.patch(
+            "services.test_results.get_repo_provider_service",
+            return_value=m,
+        )
+
+        repoid = upload1.report.commit.repoid
+        upload2.report.commit.repoid = repoid
+        dbsession.flush()
+
+        flag1 = RepositoryFlag(repository_id=repoid, flag_name="a")
+        flag2 = RepositoryFlag(repository_id=repoid, flag_name="b")
+        dbsession.flush()
+
+        upload1.flags = [flag1]
+        upload2.flags = [flag2]
+        dbsession.flush()
+
+        upload_id1 = upload1.id
+        upload_id2 = upload2.id
+
+        test_id1 = generate_test_id(repoid, "test_name", "test_testsuite", "a")
+        test_id2 = generate_test_id(repoid, "test_name", "test_testsuite", "b")
+
+        test1 = Test(
+            id_=test_id1,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="a",
+        )
+        dbsession.add(test1)
+        dbsession.flush()
+        test2 = Test(
+            id_=test_id2,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="b",
+        )
+        dbsession.add(test2)
+        dbsession.flush()
+
+        test_instance1 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Failure),
+            failure_message="bad",
+            duration_seconds=1,
+            upload_id=upload_id1,
+        )
+        dbsession.add(test_instance1)
+        dbsession.flush()
+
+        test_instance2 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Failure),
+            failure_message="not that bad",
+            duration_seconds=1,
+            upload_id=upload_id2,
+        )
+        dbsession.add(test_instance2)
+        dbsession.flush()
+
+        test_instance3 = TestInstance(
+            test_id=test_id2,
+            outcome=int(Outcome.Failure),
+            failure_message="okay i guess",
+            duration_seconds=2,
+            upload_id=upload_id1,
+        )
+
+        dbsession.add(test_instance3)
+        dbsession.flush()
+
+        result = await TestResultsFinisherTask().run_async(
+            dbsession,
+            [
+                [{"successful": True}],
+            ],
+            repoid=repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": False}},
+        )
+
+        expected_result = {"notify_attempted": True, "notify_succeeded": True}
+
+        m.edit_comment.assert_called_with(
+            pull.pullid,
+            1,
+            "##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/1) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a ] | <pre>okay i guess</pre> |\n| test_testsuite::test_name[b ] | <pre>not that bad</pre> |",
+        )
+
+        assert expected_result == result
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_upload_finisher_task_call_comment_fails(
+        self,
+        mocker,
+        mock_configuration,
+        dbsession,
+        codecov_vcr,
+        mock_storage,
+        mock_redis,
+        celery_app,
+    ):
+        mocked_app = mocker.patch.object(
+            TestResultsFinisherTask,
+            "app",
+            tasks={"app.tasks.notify.Notify": mocker.MagicMock()},
+        )
+
+        commit = CommitFactory.create(
+            message="hello world",
+            commitid="cd76b0821854a780b60012aed85af0a8263004ad",
+            repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
+            repository__owner__username="joseph-sentry",
+            repository__owner__service="github",
+            repository__name="codecov-demo",
+        )
+        dbsession.add(commit)
+        dbsession.flush()
+
+        upload1 = UploadFactory.create()
+        dbsession.add(upload1)
+        dbsession.flush()
+
+        upload2 = UploadFactory.create()
+        upload2.created_at = upload2.created_at + datetime.timedelta(0, 3)
+        dbsession.add(upload2)
+        dbsession.flush()
+
+        current_report_row = CommitReport(
+            commit_id=commit.id_, report_type=ReportType.TEST_RESULTS.value
+        )
+        dbsession.add(current_report_row)
+        dbsession.flush()
+        upload1.report = current_report_row
+        upload2.report = current_report_row
+        dbsession.flush()
+
+        pull = PullFactory.create(repository=commit.repository, head=commit.commitid)
+
+        _ = mocker.patch(
+            "services.test_results.fetch_and_update_pull_request_information_from_commit",
+            return_value=EnrichedPull(
+                database_pull=pull,
+                provider_pull={},
+            ),
+        )
+
+        mocker.patch.object(TestResultsFinisherTask, "hard_time_limit_task", 0)
+
+        m = mocker.MagicMock(
+            edit_comment=AsyncMock(return_value=True),
+            post_comment=AsyncMock(side_effect=TorngitClientError),
+        )
+
+        mocked_repo_provider = mocker.patch(
+            "services.test_results.get_repo_provider_service",
+            return_value=m,
+        )
+
+        repoid = upload1.report.commit.repoid
+        upload2.report.commit.repoid = repoid
+        dbsession.flush()
+
+        flag1 = RepositoryFlag(repository_id=repoid, flag_name="a")
+        flag2 = RepositoryFlag(repository_id=repoid, flag_name="b")
+        dbsession.flush()
+
+        upload1.flags = [flag1]
+        upload2.flags = [flag2]
+        dbsession.flush()
+
+        upload_id1 = upload1.id
+        upload_id2 = upload2.id
+
+        test_id1 = generate_test_id(repoid, "test_name", "test_testsuite", "a")
+        test_id2 = generate_test_id(repoid, "test_name", "test_testsuite", "b")
+
+        test1 = Test(
+            id_=test_id1,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="a",
+        )
+        dbsession.add(test1)
+        dbsession.flush()
+        test2 = Test(
+            id_=test_id2,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            env="b",
+        )
+        dbsession.add(test2)
+        dbsession.flush()
+
+        test_instance1 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Failure),
+            failure_message="bad",
+            duration_seconds=1,
+            upload_id=upload_id1,
+        )
+        dbsession.add(test_instance1)
+        dbsession.flush()
+
+        test_instance2 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Failure),
+            failure_message="not that bad",
+            duration_seconds=1,
+            upload_id=upload_id2,
+        )
+        dbsession.add(test_instance2)
+        dbsession.flush()
+
+        test_instance3 = TestInstance(
+            test_id=test_id2,
+            outcome=int(Outcome.Failure),
+            failure_message="okay i guess",
+            duration_seconds=2,
+            upload_id=upload_id1,
+        )
+
+        dbsession.add(test_instance3)
+        dbsession.flush()
+
+        result = await TestResultsFinisherTask().run_async(
+            dbsession,
+            [
+                [{"successful": True}],
+            ],
+            repoid=repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": False}},
+        )
+
+        expected_result = {"notify_attempted": True, "notify_succeeded": False}
+
+        assert expected_result == result

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -51,7 +51,7 @@ class TestUploadTestFinisherTask(object):
         dbsession.flush()
 
         upload2 = UploadFactory.create()
-        upload2.created_at = upload2.created_at + datetime.timedelta(0, 3)
+        upload2.created_at = upload1.created_at + datetime.timedelta(0, 3)
         dbsession.add(upload2)
         dbsession.flush()
 
@@ -124,7 +124,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance1 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="bad",
             duration_seconds=1,
             upload_id=upload_id1,
@@ -134,7 +134,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance2 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="not that bad",
             duration_seconds=1,
             upload_id=upload_id2,
@@ -144,7 +144,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance3 = TestInstance(
             test_id=test_id2,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="okay i guess",
             duration_seconds=2,
             upload_id=upload_id1,
@@ -278,7 +278,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance1 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Pass),
+            outcome=str(Outcome.Pass),
             failure_message="bad",
             duration_seconds=1,
             upload_id=upload_id1,
@@ -288,7 +288,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance2 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Pass),
+            outcome=str(Outcome.Pass),
             failure_message="not that bad",
             duration_seconds=1,
             upload_id=upload_id2,
@@ -298,7 +298,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance3 = TestInstance(
             test_id=test_id2,
-            outcome=int(Outcome.Pass),
+            outcome=str(Outcome.Pass),
             failure_message="okay i guess",
             duration_seconds=2,
             upload_id=upload_id1,
@@ -436,7 +436,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance1 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Pass),
+            outcome=str(Outcome.Pass),
             failure_message="bad",
             duration_seconds=1,
             upload_id=upload_id1,
@@ -446,7 +446,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance2 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Pass),
+            outcome=str(Outcome.Pass),
             failure_message="not that bad",
             duration_seconds=1,
             upload_id=upload_id2,
@@ -456,7 +456,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance3 = TestInstance(
             test_id=test_id2,
-            outcome=int(Outcome.Pass),
+            outcome=str(Outcome.Pass),
             failure_message="okay i guess",
             duration_seconds=2,
             upload_id=upload_id1,
@@ -588,7 +588,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance1 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="bad",
             duration_seconds=1,
             upload_id=upload_id1,
@@ -598,7 +598,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance2 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="not that bad",
             duration_seconds=1,
             upload_id=upload_id2,
@@ -608,7 +608,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance3 = TestInstance(
             test_id=test_id2,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="okay i guess",
             duration_seconds=2,
             upload_id=upload_id1,
@@ -745,7 +745,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance1 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="bad",
             duration_seconds=1,
             upload_id=upload_id1,
@@ -755,7 +755,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance2 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="not that bad",
             duration_seconds=1,
             upload_id=upload_id2,
@@ -765,7 +765,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance3 = TestInstance(
             test_id=test_id2,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="okay i guess",
             duration_seconds=2,
             upload_id=upload_id1,


### PR DESCRIPTION
Depends on: #197 

## Summary
This PR adds functionality for the test results PR comment feature, and contains the necessary improvements to the test result processor task to achieve this.

The first change to the processor is that it's no longer writing to the db anymore. This is because the processor tasks run concurrently, and concurrent writes to the DB were making it difficult to ensure that there multiple Test objects weren't being created at the same time. The writes to the DB to persist `Test` and `TestInstance` objects were moved to the finisher. 

The second change to the processor is that it now returns a processed list of "Testrun dicts", which contains some metadata (`env` and `run_number`) and a list of "testruns" which the finisher will use to decide what `Test` and `TestInstance` objects to create.

The `TestResultsFinisher` task is created in this PR. This task is responsible for gathering the results of the processing step, adding new `Test` and `TestInstance` objects, updating existing `TestInstance` objects that need to be updated, and finally either writing the test results PR comment or triggering the notify task to write the coverage PR comment.

The upload task was updated to use a chord to run the processor tasks concurrently and to pass their results to the finisher task that will run when all the processor tasks are completed.

The notify task now checks if there are any failed tests that exist on a report attached to the commit it is trying to notify for, if there exist failed tests, it will no longer notify.

## Edge cases
### CI Re-run 
This is the edge case where a user might not make any changes to the code, but re-runs the CI. This may happen if there is a flaky test that sometimes fails. We must handle this because when this happens we want to update the outcomes of the tests that ran previously.  The `run_number` metadata field that the processor passes to the finisher is used to handle this edge case. The `run_number` corresponds to the `build_code` in the upload. This helps us distinguish between different runs of the same workflow. The `run_number` tells the finisher that if a `TestInstance` exists on the current commit and maps to the same `Test` as the one we are currently examining, we should look at the `run_number` to determine which one should be used. The notify task being called if there are no failures in the test result finisher, is also part of the solution to this edge case, because of the case where during the re run, the coverage notifier runs before the test result finisher 

### Same test, different env
This is a case where a user may be running the same test in the same CI run multiple times under a different environment eg. running a tests under multiple python versions. We need to be able to distinguish between these tests. We do this by adding the `env` field to the `Test` object which comprises a hash of the `flag_names` and the `job_code` of upload where the `Test` was first created. The uniqueness constraint on `Test` objects includes the `testsuite`, `name`, `repoid` and `env` fields which means there can only be one `Test` with the same name, testsuite and env for each repo.  
Subsequent uploads that contain the same test being run with the same env will map to the existing `Test` object in the DB.

## Possible improvements
- Checkpoint logger integration
- Addition of metrics on top of the checkpoint logger
- Streaming parsing improvements mentioned here: https://github.com/codecov/worker/pull/197#pullrequestreview-1812283749
- Adding a roll up of the test result data for a given CommitReport (similar to `ReportLevelTotals`)
- Moving `TestInstance` data to GCS in sqlite files