### PR TITLE
Attempt to fix adjust base behavior rounding bug

### DIFF
--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -207,7 +207,13 @@ class StatusProjectMixin(object):
                 partials_removed=partials_removed,
             ),
         )
-        if base_adjusted_coverage <= head_coverage:
+        # the head coverage is rounded to five digits after the dot, using shared.helpers.numeric.ratio
+        # so we should round the base adjusted coverage to the same amount of digits after the dot
+        # Decimal.quantize: https://docs.python.org/3/library/decimal.html#decimal.Decimal.quantize
+        quantized_base_adjusted_coverage = base_adjusted_coverage.quantize(
+            Decimal("0.00000")
+        )
+        if quantized_base_adjusted_coverage <= head_coverage:
             rounded_difference = round_number(
                 self.current_yaml, head_coverage - base_adjusted_coverage
             )

--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -196,6 +196,17 @@ class StatusProjectMixin(object):
             * 100
         )
         head_coverage = Decimal(comparison.head.report.totals.coverage)
+        log.info(
+            "Adjust base applied to project status",
+            extra=dict(
+                commit=comparison.head.commit.commitid,
+                base_adjusted_coverage=base_adjusted_coverage,
+                head_coverage=head_coverage,
+                hits_removed=hits_removed,
+                misses_removed=misses_removed,
+                partials_removed=partials_removed,
+            ),
+        )
         if base_adjusted_coverage <= head_coverage:
             rounded_difference = round_number(
                 self.current_yaml, head_coverage - base_adjusted_coverage


### PR DESCRIPTION
This PR creates a log in the `_apply_adjust_base_behavior` function and attempts to fix the following bug.

There's a bug where we compare the base adjusted coverage to the
head coverage. The issue occurs when the base adjusted coverage has more
digits after the decimal point than the head coverage.

The head coverage that we fetch in this function will always have 5
digits after the decimal, but the base adjusted coverage does not have
that same restriction.

The decimal library will not round the number with more digits after
the decimal point when doing a comparison.

Currently, in our code we are basically doing the following:

`Decimal('90.001').quantize('0.00') <= Decimal('90.001')`

which will evaluate to false.

If we are rounding the head coverage to 5 digits after the decimal point
we must do the same for the base adjusted coverage for it to be a fair
comparison.