### PR TITLE
Improve test result PR comment

### DIFF
--- a/services/test_results.py
+++ b/services/test_results.py
@@ -218,8 +218,13 @@ class TestResultsNotifier:
             "| {0} | <pre>{1}</pre> |".format(
                 (
                     "<br>".join(
-                        self.insert_breaks(f"{test_name}[{','.join(test_env_list)}]")
-                        for test_name, test_env_list in failed_test_to_env_list.items()
+                        self.insert_breaks(
+                            f"{test_name}[{','.join(sorted(test_env_list))}]"
+                        )
+                        for test_name, test_env_list in sorted(
+                            failed_test_to_env_list.items(),
+                            key=lambda failure: failure[0],
+                        )
                     )
                 ),
                 failure_message.replace("\n", "<br>"),

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -188,11 +188,10 @@ class TestResultsNotifier:
                 Outcome.Failure
             ) or test_instance.outcome == str(Outcome.Error):
                 failed_tests += 1
-                job_code = test_instance.upload.job_code
                 flag_names = sorted(test_instance.upload.flag_names)
                 suffix = ""
-                if job_code or flag_names:
-                    suffix = f"{''.join(flag_names) or ''} {job_code or ''}"
+                if flag_names:
+                    suffix = f"{''.join(flag_names) or ''}"
                 failures[test_instance.failure_message][
                     f"{test_instance.test.testsuite}::{test_instance.test.name}"
                 ].append(suffix)

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -229,7 +229,9 @@ class TestResultsNotifier:
                 ),
                 failure_message.replace("\n", "<br>"),
             )
-            for failure_message, failed_test_to_env_list in failures.items()
+            for failure_message, failed_test_to_env_list in sorted(
+                failures.items(), key=lambda x: x[0]
+            )
         ]
 
         message += failure_table

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -212,8 +212,6 @@ class TestResultsNotifier:
         ]
 
         message += details
-        for failure_message, failed_test_to_env_list in failures.items():
-            print(failure_message, failed_test_to_env_list)
         failure_table = [
             "| {0} | <pre>{1}</pre> |".format(
                 (

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -191,7 +191,7 @@ class TestResultsNotifier:
                 flag_names = sorted(test_instance.upload.flag_names)
                 suffix = ""
                 if flag_names:
-                    suffix = f"{''.join(flag_names) or ''}"
+                    suffix = f"({','.join(flag_names) or ''})"
                 failures[test_instance.failure_message][
                     f"{test_instance.test.testsuite}::{test_instance.test.name}"
                 ].append(suffix)

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -221,14 +221,14 @@ class TestResultsNotifier:
                         )
                         for test_name, test_env_list in sorted(
                             failed_test_to_env_list.items(),
-                            key=lambda failure: failure[0],
+                            key=lambda failed_test: failed_test[0],
                         )
                     )
                 ),
                 failure_message.replace("\n", "<br>"),
             )
             for failure_message, failed_test_to_env_list in sorted(
-                failures.items(), key=lambda x: x[0]
+                failures.items(), key=lambda failure: failure[0]
             )
         ]
 

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -155,7 +155,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance4 = TestInstance(
             test_id=test_id2,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="not that bad",
             duration_seconds=2,
             upload_id=upload_id1,
@@ -177,7 +177,7 @@ class TestUploadTestFinisherTask(object):
         expected_result = {"notify_attempted": True, "notify_succeeded": True}
         m.post_comment.assert_called_with(
             pull.pullid,
-            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a] | <pre>okay i guess</pre> |\n| test_testsuite::test_name[b] | <pre>not that bad</pre> |",
+            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[b] | <pre>not that bad</pre> |\n| test_testsuite::test_name[a] | <pre>okay i guess</pre> |",
         )
 
         assert expected_result == result
@@ -216,7 +216,7 @@ class TestUploadTestFinisherTask(object):
         dbsession.flush()
 
         upload2 = UploadFactory.create()
-        upload2.created_at = upload2.created_at + datetime.timedelta(0, 3)
+        upload2.created_at = upload1.created_at + datetime.timedelta(0, 3)
         dbsession.add(upload2)
         dbsession.flush()
 
@@ -299,7 +299,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance1 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="bad",
             duration_seconds=1,
             upload_id=upload_id1,
@@ -309,7 +309,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance2 = TestInstance(
             test_id=test_id1,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="not that bad",
             duration_seconds=1,
             upload_id=upload_id2,
@@ -319,7 +319,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance3 = TestInstance(
             test_id=test_id2,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="not that bad",
             duration_seconds=2,
             upload_id=upload_id1,
@@ -330,7 +330,7 @@ class TestUploadTestFinisherTask(object):
 
         test_instance4 = TestInstance(
             test_id=test_id3,
-            outcome=int(Outcome.Failure),
+            outcome=str(Outcome.Failure),
             failure_message="not that bad",
             duration_seconds=2,
             upload_id=upload_id1,
@@ -699,7 +699,7 @@ class TestUploadTestFinisherTask(object):
         dbsession.flush()
 
         upload2 = UploadFactory.create()
-        upload2.created_at = upload2.created_at + datetime.timedelta(0, 3)
+        upload2.created_at = upload1.created_at + datetime.timedelta(0, 3)
         dbsession.add(upload2)
         dbsession.flush()
 
@@ -818,7 +818,7 @@ class TestUploadTestFinisherTask(object):
         m.edit_comment.assert_called_with(
             pull.pullid,
             1,
-            "##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/1) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a] | <pre>okay i guess</pre> |\n| test_testsuite::test_name[b] | <pre>not that bad</pre> |",
+            "##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/1) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[b] | <pre>not that bad</pre> |\n| test_testsuite::test_name[a] | <pre>okay i guess</pre> |",
         )
 
         assert expected_result == result

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -177,7 +177,7 @@ class TestUploadTestFinisherTask(object):
         expected_result = {"notify_attempted": True, "notify_succeeded": True}
         m.post_comment.assert_called_with(
             pull.pullid,
-            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a ] | <pre>okay i guess</pre> |\n| test_testsuite::test_name[b ] | <pre>not that bad</pre> |",
+            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a] | <pre>okay i guess</pre> |\n| test_testsuite::test_name[b] | <pre>not that bad</pre> |",
         )
 
         assert expected_result == result
@@ -352,7 +352,7 @@ class TestUploadTestFinisherTask(object):
         expected_result = {"notify_attempted": True, "notify_succeeded": True}
         m.post_comment.assert_called_with(
             pull.pullid,
-            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 3 tests with **`3 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a ,b ]<br>test_testsuite::test_name_2[a ] | <pre>not that bad</pre> |",
+            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 3 tests with **`3 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a,b]<br>test_testsuite::test_name_2[a] | <pre>not that bad</pre> |",
         )
 
         assert expected_result == result
@@ -818,7 +818,7 @@ class TestUploadTestFinisherTask(object):
         m.edit_comment.assert_called_with(
             pull.pullid,
             1,
-            "##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/1) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a ] | <pre>okay i guess</pre> |\n| test_testsuite::test_name[b ] | <pre>not that bad</pre> |",
+            "##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/1) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a] | <pre>okay i guess</pre> |\n| test_testsuite::test_name[b] | <pre>not that bad</pre> |",
         )
 
         assert expected_result == result

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -153,6 +153,17 @@ class TestUploadTestFinisherTask(object):
         dbsession.add(test_instance3)
         dbsession.flush()
 
+        test_instance4 = TestInstance(
+            test_id=test_id2,
+            outcome=int(Outcome.Failure),
+            failure_message="not that bad",
+            duration_seconds=2,
+            upload_id=upload_id1,
+        )
+
+        dbsession.add(test_instance4)
+        dbsession.flush()
+
         result = await TestResultsFinisherTask().run_async(
             dbsession,
             [
@@ -167,6 +178,181 @@ class TestUploadTestFinisherTask(object):
         m.post_comment.assert_called_with(
             pull.pullid,
             f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a ] | <pre>okay i guess</pre> |\n| test_testsuite::test_name[b ] | <pre>not that bad</pre> |",
+        )
+
+        assert expected_result == result
+
+    @pytest.mark.asyncio
+    @pytest.mark.integration
+    async def test_upload_finisher_task_call_multi_env_fail(
+        self,
+        mocker,
+        mock_configuration,
+        dbsession,
+        codecov_vcr,
+        mock_storage,
+        mock_redis,
+        celery_app,
+    ):
+        mocked_app = mocker.patch.object(
+            TestResultsFinisherTask,
+            "app",
+            tasks={"app.tasks.notify.Notify": mocker.MagicMock()},
+        )
+
+        commit = CommitFactory.create(
+            message="hello world",
+            commitid="cd76b0821854a780b60012aed85af0a8263004ad",
+            repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
+            repository__owner__username="joseph-sentry",
+            repository__owner__service="github",
+            repository__name="codecov-demo",
+        )
+        dbsession.add(commit)
+        dbsession.flush()
+
+        upload1 = UploadFactory.create()
+        dbsession.add(upload1)
+        dbsession.flush()
+
+        upload2 = UploadFactory.create()
+        upload2.created_at = upload2.created_at + datetime.timedelta(0, 3)
+        dbsession.add(upload2)
+        dbsession.flush()
+
+        current_report_row = CommitReport(
+            commit_id=commit.id_, report_type=ReportType.TEST_RESULTS.value
+        )
+        dbsession.add(current_report_row)
+        dbsession.flush()
+        upload1.report = current_report_row
+        upload2.report = current_report_row
+        dbsession.flush()
+
+        pull = PullFactory.create(repository=commit.repository, head=commit.commitid)
+
+        _ = mocker.patch(
+            "services.test_results.fetch_and_update_pull_request_information_from_commit",
+            return_value=EnrichedPull(
+                database_pull=pull,
+                provider_pull={},
+            ),
+        )
+
+        mocker.patch.object(TestResultsFinisherTask, "hard_time_limit_task", 0)
+
+        m = mocker.MagicMock(
+            edit_comment=AsyncMock(return_value=True),
+            post_comment=AsyncMock(return_value={"id": 1}),
+        )
+        mocked_repo_provider = mocker.patch(
+            "services.test_results.get_repo_provider_service",
+            return_value=m,
+        )
+
+        repoid = upload1.report.commit.repoid
+        upload2.report.commit.repoid = repoid
+        dbsession.flush()
+
+        flag1 = RepositoryFlag(repository_id=repoid, flag_name="a")
+        flag2 = RepositoryFlag(repository_id=repoid, flag_name="b")
+        dbsession.flush()
+
+        upload1.flags = [flag1]
+        upload2.flags = [flag2]
+        dbsession.flush()
+
+        upload_id1 = upload1.id
+        upload_id2 = upload2.id
+
+        test_id1 = generate_test_id(repoid, "test_name", "test_testsuite", "a")
+        test_id2 = generate_test_id(repoid, "test_name", "test_testsuite", "b")
+        test_id3 = generate_test_id(repoid, "test_name_2", "test_testsuite", "a")
+
+        test1 = Test(
+            id_=test_id1,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            flags_hash="a",
+        )
+        dbsession.add(test1)
+        dbsession.flush()
+        test2 = Test(
+            id_=test_id2,
+            repoid=repoid,
+            name="test_name",
+            testsuite="test_testsuite",
+            flags_hash="b",
+        )
+        dbsession.add(test2)
+        dbsession.flush()
+        test3 = Test(
+            id_=test_id3,
+            repoid=repoid,
+            name="test_name_2",
+            testsuite="test_testsuite",
+            flags_hash="a",
+        )
+        dbsession.add(test3)
+        dbsession.flush()
+
+        test_instance1 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Failure),
+            failure_message="bad",
+            duration_seconds=1,
+            upload_id=upload_id1,
+        )
+        dbsession.add(test_instance1)
+        dbsession.flush()
+
+        test_instance2 = TestInstance(
+            test_id=test_id1,
+            outcome=int(Outcome.Failure),
+            failure_message="not that bad",
+            duration_seconds=1,
+            upload_id=upload_id2,
+        )
+        dbsession.add(test_instance2)
+        dbsession.flush()
+
+        test_instance3 = TestInstance(
+            test_id=test_id2,
+            outcome=int(Outcome.Failure),
+            failure_message="not that bad",
+            duration_seconds=2,
+            upload_id=upload_id1,
+        )
+
+        dbsession.add(test_instance3)
+        dbsession.flush()
+
+        test_instance4 = TestInstance(
+            test_id=test_id3,
+            outcome=int(Outcome.Failure),
+            failure_message="not that bad",
+            duration_seconds=2,
+            upload_id=upload_id1,
+        )
+
+        dbsession.add(test_instance4)
+        dbsession.flush()
+
+        result = await TestResultsFinisherTask().run_async(
+            dbsession,
+            [
+                [{"successful": True}],
+            ],
+            repoid=repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": False}},
+        )
+
+        expected_result = {"notify_attempted": True, "notify_succeeded": True}
+        m.post_comment.assert_called_with(
+            pull.pullid,
+            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 3 tests with **`3 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a ,b ]<br>test_testsuite::test_name_2[a ] | <pre>not that bad</pre> |",
         )
 
         assert expected_result == result

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -177,7 +177,7 @@ class TestUploadTestFinisherTask(object):
         expected_result = {"notify_attempted": True, "notify_succeeded": True}
         m.post_comment.assert_called_with(
             pull.pullid,
-            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[b] | <pre>not that bad</pre> |\n| test_testsuite::test_name[a] | <pre>okay i guess</pre> |",
+            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[(b)] | <pre>not that bad</pre> |\n| test_testsuite::test_name[(a)] | <pre>okay i guess</pre> |",
         )
 
         assert expected_result == result
@@ -352,7 +352,7 @@ class TestUploadTestFinisherTask(object):
         expected_result = {"notify_attempted": True, "notify_succeeded": True}
         m.post_comment.assert_called_with(
             pull.pullid,
-            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 3 tests with **`3 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[a,b]<br>test_testsuite::test_name_2[a] | <pre>not that bad</pre> |",
+            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 3 tests with **`3 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[(a),(b)]<br>test_testsuite::test_name_2[(a)] | <pre>not that bad</pre> |",
         )
 
         assert expected_result == result
@@ -818,7 +818,7 @@ class TestUploadTestFinisherTask(object):
         m.edit_comment.assert_called_with(
             pull.pullid,
             1,
-            "##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/1) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[b] | <pre>not that bad</pre> |\n| test_testsuite::test_name[a] | <pre>okay i guess</pre> |",
+            "##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/1) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| test_testsuite::test_name[(b)] | <pre>not that bad</pre> |\n| test_testsuite::test_name[(a)] | <pre>okay i guess</pre> |",
         )
 
         assert expected_result == result


### PR DESCRIPTION
This changes the PR comment to organize rows such that tests with the same failure message will be displayed in the same row. Also, if a test has multiple flags with the same failure message, it will display them in the same line.