### PR TITLE
add config to allow disabling upload throttling

### DIFF
--- a/services/decoration.py
+++ b/services/decoration.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+from shared.config import get_config
 from sqlalchemy import func
 
 from conftest import dbsession
@@ -49,6 +50,11 @@ def _is_bot_account(author: Owner) -> bool:
 
 
 def determine_uploads_used(db_session, org: Owner) -> int:
+    # This query takes an absurdly long time to run and in some environments we
+    # would like to disable it
+    if not get_config("setup", "upload_throttling_enabled", default=True):
+        return 0
+
     query = (
         db_session.query(Upload)
         .join(CommitReport)


### PR DESCRIPTION
this query is very costly and we want the ability to disable it in some environments until we optimize it

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.