### PR TITLE
fix(update_branches): commit more often, no more yield_per, no more ownerid

### DIFF
--- a/tasks/update_branches.py
+++ b/tasks/update_branches.py
@@ -26,7 +26,7 @@ class UpdateBranchesTask(BaseCodecovTask, name=update_branches_task_name):
 
         log.info(
             "Doing update branches for branch",
-            extra=dict(branch_name=branch_name),
+            extra=dict(branch_name=branch_name, incorrect_commitid=incorrect_commitid),
         )
 
         branches_to_update = (
@@ -67,14 +67,22 @@ class UpdateBranchesTask(BaseCodecovTask, name=update_branches_task_name):
             for branch in chunk:
                 log.info(
                     "Updating branch on repo",
-                    extra=dict(branch_name=branch_name, repoid=branch.repoid),
+                    extra=dict(
+                        branch_name=branch_name,
+                        repoid=branch.repoid,
+                        incorrect_commitid=incorrect_commitid,
+                    ),
                 )
 
                 latest_commit_on_branch = commit_dict.get(branch.repoid, None)
                 if latest_commit_on_branch is None:
                     log.info(
                         "No existing commits on this branch in this repo",
-                        extra=dict(branch_name=branch_name, repoid=branch.repoid),
+                        extra=dict(
+                            branch_name=branch_name,
+                            repoid=branch.repoid,
+                            incorrect_commitid=incorrect_commitid,
+                        ),
                     )
                     continue
 
@@ -85,6 +93,7 @@ class UpdateBranchesTask(BaseCodecovTask, name=update_branches_task_name):
                         branch_name=branch_name,
                         repoid=branch.repoid,
                         latest_commit=new_branch_head,
+                        incorrect_commitid=incorrect_commitid,
                     ),
                 )
 
@@ -92,7 +101,12 @@ class UpdateBranchesTask(BaseCodecovTask, name=update_branches_task_name):
                     branch.head = new_branch_head
 
             if not dry_run:
-                log.info("flushing and commiting changes to chunk")
+                log.info(
+                    "flushing and commiting changes to chunk",
+                    extra=dict(
+                        branch_name=branch_name, incorrect_commitid=incorrect_commitid
+                    ),
+                )
                 db_session.commit()
 
         return {"successful": True}

--- a/tasks/update_branches.py
+++ b/tasks/update_branches.py
@@ -10,7 +10,13 @@ log = logging.getLogger(__name__)
 
 class UpdateBranchesTask(BaseCodecovTask, name=update_branches_task_name):
     async def run_async(
-        self, db_session, *args, branch_name=None, ownerid=None, dry_run=True, **kwargs
+        self,
+        db_session,
+        *args,
+        branch_name=None,
+        incorrect_commitid=None,
+        dry_run=True,
+        **kwargs
     ):
         if branch_name is None:
             log.warning("No branch name specified, not updating any branches")
@@ -18,95 +24,63 @@ class UpdateBranchesTask(BaseCodecovTask, name=update_branches_task_name):
 
         log.info(
             "Doing update branches for branch",
-            extra=dict(branch_name=branch_name, ownerid=ownerid),
+            extra=dict(branch_name=branch_name),
         )
-        if ownerid is not None:
-            log.info(
-                "Owner id was specified, only updating branches in the repo of that owner",
-                extra=dict(branch_name=branch_name, ownerid=ownerid),
-            )
-            repoids = (
-                db_session.query(Repository.repoid)
-                .filter(Repository.ownerid == ownerid)
-                .all()
-            )
-            log.info(
-                "repo ids we're taking a look at",
-                extra=dict(repoids=repoids, branch_name=branch_name, ownerid=ownerid),
-            )
-            query = (
-                db_session.query(Branch)
-                .filter(Branch.branch == branch_name, Branch.repoid.in_(repoids))
-                .yield_per(10)
-            )
-        else:
-            log.info(
-                "No owner id specified updating for branches in all orgs' repos",
-                extra=dict(branch_name=branch_name, ownerid=ownerid),
-            )
-            query = (
-                db_session.query(Branch)
-                .filter(
-                    Branch.branch == branch_name,
-                )
-                .yield_per(10)
-            )
 
-        for branch in query:
-            log.info(
-                "Updating branch on repo",
-                extra=dict(branch_name=branch_name, repoid=branch.repoid),
+        branches_to_update = (
+            db_session.query(Branch)
+            .filter(
+                Branch.branch == branch_name,
+                Branch.head == incorrect_commitid,
             )
-            existing_commit = (
-                db_session.query(Commit)
-                .filter(Commit.repoid == branch.repoid, Commit.commitid == branch.head)
-                .first()
-            )
-            if existing_commit is not None:
+            .all()
+        )
+
+        chunk_size = 1000
+        chunks = [
+            branches_to_update[i : i + chunk_size]
+            for i in range(len(branches_to_update), chunk_size)
+        ]
+
+        for chunk in chunks:
+            for branch in chunk:
                 log.info(
-                    "Existing commit in the repo already exists, no need to update",
+                    "Updating branch on repo",
+                    extra=dict(branch_name=branch_name, repoid=branch.repoid),
+                )
+
+                latest_commit_on_branch = (
+                    db_session.query(Commit)
+                    .filter(
+                        Commit.branch == branch_name,
+                        Commit.repoid == branch.repoid,
+                    )
+                    .order_by(Commit.updatestamp.desc())
+                    .first()
+                )
+                if latest_commit_on_branch is None:
+                    log.info(
+                        "No existing commits on this branch in this repo",
+                        extra=dict(branch_name=branch_name, repoid=branch.repoid),
+                    )
+                    continue
+
+                new_branch_head = latest_commit_on_branch.commitid
+                log.info(
+                    "Found latest commit on branch and updating branch head to",
                     extra=dict(
                         branch_name=branch_name,
                         repoid=branch.repoid,
-                        existing_commit=existing_commit.commitid,
+                        latest_commit=new_branch_head,
                     ),
                 )
-                continue
 
-            log.info(
-                "No existing commit checking latest commit on branch in repo",
-                extra=dict(branch_name=branch_name, repoid=branch.repoid),
-            )
-
-            latest_commit_on_branch = (
-                db_session.query(Commit)
-                .filter(
-                    Commit.branch == branch_name,
-                    Commit.repoid == branch.repoid,
-                )
-                .order_by(Commit.updatestamp.desc())
-                .first()
-            )
-            if latest_commit_on_branch is None:
-                log.info(
-                    "No existing commits on this branch in this repo",
-                    extra=dict(branch_name=branch_name, repoid=branch.repoid),
-                )
-                continue
-
-            new_branch_head = latest_commit_on_branch.commitid
-            log.info(
-                "Found latest commit on branch and updating branch head to",
-                extra=dict(
-                    branch_name=branch_name,
-                    repoid=branch.repoid,
-                    latest_commit=new_branch_head,
-                ),
-            )
+                if not dry_run:
+                    branch.head = new_branch_head
 
             if not dry_run:
-                branch.head = new_branch_head
-                db_session.flush()
+                log.info("flushing and commiting changes to chunk")
+                db_session.commit()
 
         return {"successful": True}
 


### PR DESCRIPTION
- no more ownerid
- takes in incorrect commitid to help filter branches
- no longer uses yield_per, instead does one query for all the branches then breaks it up into chunks of branches
- commits after updating every chunk