### PR TITLE
revamp sync_repos task

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -334,7 +334,9 @@ requests==2.31.0
 respx==0.20.2
     # via -r requirements.in
 rfc3986[idna2008]==1.4.0
-    # via httpx
+    # via
+    #   httpx
+    #   rfc3986
 rsa==4.7.2
     # via google-auth
 s3transfer==0.3.4

--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -124,7 +124,7 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
     ):
         repoids_added = []
         # Casting to str in case celery interprets the service ID as a integer for some reason
-        # As that as coused issues testing locally before
+        # As that has caused issues with testing locally
         service_ids = set(str(x[0]) for x in repository_service_ids)
         # Check what repos we already have in the DB
         existing_repos = set(

--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -123,7 +123,9 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
         repository_service_ids: Optional[List[Tuple[str, str]]],
     ):
         repoids_added = []
-        service_ids = set(x[0] for x in repository_service_ids)
+        # Casting to str in case celery interprets the service ID as a integer for some reason
+        # As that as coused issues testing locally before
+        service_ids = set(str(x[0]) for x in repository_service_ids)
         # Check what repos we already have in the DB
         existing_repos = set(
             map(

--- a/tasks/tests/unit/test_sync_repos_task.py
+++ b/tasks/tests/unit/test_sync_repos_task.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import MagicMock, call
 
 import httpx
 import pytest
@@ -997,3 +998,156 @@ class TestSyncReposTaskUnit(object):
         mocked_app.tasks[sync_repo_languages_task_name].apply_async.assert_any_call(
             kwargs={"repoid": new_repo_list[0].repoid, "manual_trigger": False}
         )
+
+    @pytest.mark.asyncio
+    async def test_sync_repos_usgin_integration_affected_repos_known(
+        self,
+        mocker,
+        dbsession,
+        mock_owner_provider,
+        mock_redis,
+    ):
+
+        user = OwnerFactory.create(
+            organizations=[],
+            service="github",
+            username="1nf1n1t3l00p",
+            unencrypted_oauth_token="sometesttoken",
+            permission=[],
+            service_id="45343385",
+        )
+        dbsession.add(user)
+
+        mocked_app = mocker.patch.object(
+            SyncReposTask,
+            "app",
+            tasks={
+                sync_repo_languages_task_name: mocker.MagicMock(),
+            },
+        )
+        repository_service_ids = [
+            ("460565350", "R_kgDOG3OrZg"),
+            ("665728948", "R_kgDOJ643tA"),
+            ("553624697", "R_kgDOIP-keQ"),
+            ("631985885", "R_kgDOJatW3Q"),  # preseeded
+            ("623359086", "R_kgDOJSe0bg"),  # preseeded
+        ]
+        service_ids = [x[0] for x in repository_service_ids]
+        service_ids_to_add = service_ids[:3]
+
+        def repo_obj(service_id, name, language, private, branch, using_integration):
+            return {
+                "owner": {
+                    "service_id": "test-owner-service-id",
+                    "username": "test-owner-username",
+                },
+                "repo": {
+                    "service_id": service_id,
+                    "name": name,
+                    "language": language,
+                    "private": private,
+                    "branch": branch,
+                },
+                "_using_integration": using_integration,
+            }
+
+        preseeded_repos = [
+            repo_obj("631985885", "example-python", "python", False, "main", True),
+            repo_obj("623359086", "sentry", "python", False, "main", True),
+        ]
+
+        for repo in preseeded_repos:
+            new_repo = RepositoryFactory.create(
+                private=repo["repo"]["private"],
+                name=repo["repo"]["name"],
+                using_integration=repo["_using_integration"],
+                service_id=repo["repo"]["service_id"],
+                owner=user,
+            )
+            dbsession.add(new_repo)
+        dbsession.flush()
+
+        # These are the repos we're supposed to query from the service provider
+        async def side_effect(*args, **kwargs):
+            results = [
+                {
+                    "branch": "main",
+                    "language": "python",
+                    "name": "codecov-cli",
+                    "owner": {
+                        "is_expected_owner": False,
+                        "node_id": "MDEyOk9yZ2FuaXphdGlvbjgyMjYyMDU=",
+                        "service_id": "8226205",
+                        "username": "codecov",
+                    },
+                    "service_id": "460565350",
+                    "private": False,
+                },
+                {
+                    "branch": "main",
+                    "language": "python",
+                    "name": "worker",
+                    "owner": {
+                        "is_expected_owner": False,
+                        "node_id": "MDEyOk9yZ2FuaXphdGlvbjgyMjYyMDU=",
+                        "service_id": "8226205",
+                        "username": "codecov",
+                    },
+                    "service_id": "665728948",
+                    "private": False,
+                },
+                {
+                    "branch": "main",
+                    "language": "python",
+                    "name": "components-demo",
+                    "owner": {
+                        "is_expected_owner": True,
+                        "node_id": "U_kgDOBfIxWg",
+                        "username": "giovanni-guidini",
+                    },
+                    "service_id": "553624697",
+                    "private": False,
+                },
+            ]
+            for r in results:
+                yield r
+
+        mock_owner_provider.get_repos_from_nodeids_generator.side_effect = side_effect
+        mock_owner_provider.service = "github"
+
+        await SyncReposTask().run_async(
+            dbsession,
+            ownerid=user.ownerid,
+            using_integration=True,
+            repository_service_ids=repository_service_ids,
+        )
+        dbsession.commit()
+
+        mock_owner_provider.get_repos_from_nodeids_generator.assert_called_with(
+            ["R_kgDOG3OrZg", "R_kgDOJ643tA", "R_kgDOIP-keQ"], user.username
+        )
+
+        repos = (
+            dbsession.query(Repository)
+            .filter(Repository.service_id.in_(service_ids))
+            .all()
+        )
+        repos_added = list(
+            filter(lambda repo: repo.service_id in service_ids_to_add, repos)
+        )
+        assert len(repos) == 5
+
+        mocked_app.tasks[sync_repo_languages_task_name].apply_async.calls(
+            [
+                call(kwargs={"repoid": repo.repoid, "manual_trigger": False})
+                for repo in repos_added
+            ]
+        )
+
+        upserted_owner = (
+            dbsession.query(Owner)
+            .filter(Owner.service == "github", Owner.service_id == "8226205")
+            .first()
+        )
+        assert upserted_owner is not None
+        assert upserted_owner.username == "codecov"


### PR DESCRIPTION
Adds a new flow for sync_repos task in which the caller
already knows what repos we should check. This happens
in INSTALLATION webhooks by GitHub, that include a list of affected repos.

The new flow makes use of github graphQL api via torngit to get info
directly on the repos affected.
