### PR TITLE
Use test result totals in worker

### DIFF
--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -305,12 +305,10 @@ class TestInstance(CodecovBaseModel, MixinBaseClass):
     failure_message = Column(types.Text)
 
 
-class TestResultReportTotals(CodecovBaseModel, AbstractTotals):
+class TestResultReportTotals(CodecovBaseModel, MixinBaseClass):
     __tablename__ = "reports_testresultreporttotals"
-
     report_id = Column(types.Integer, ForeignKey("reports_commitreport.id"))
     report = relationship("CommitReport", foreign_keys=[report_id])
-
     passed = Column(types.Integer)
     skipped = Column(types.Integer)
     failed = Column(types.Integer)

--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -61,6 +61,13 @@ class CommitReport(CodecovBaseModel, MixinBaseClass):
         cascade="all, delete",
         passive_deletes=True,
     )
+    test_result_totals = relationship(
+        "TestResultReportTotals",
+        back_populates="report",
+        uselist=False,
+        cascade="all, delete",
+        passive_deletes=True,
+    )
 
 
 uploadflagmembership = Table(
@@ -149,9 +156,9 @@ class ReportDetails(CodecovBaseModel, MixinBaseClass):
                 "session_totals": SessionTotalsArray.build_from_encoded_data(
                     v.get("session_totals")
                 ),
-                "diff_totals": ReportTotals(*v["diff_totals"])
-                if v["diff_totals"]
-                else None,
+                "diff_totals": (
+                    ReportTotals(*v["diff_totals"]) if v["diff_totals"] else None
+                ),
             }
             for v in json_files_array
         ]
@@ -296,3 +303,14 @@ class TestInstance(CodecovBaseModel, MixinBaseClass):
     upload_id = Column(types.Integer, ForeignKey("reports_upload.id"))
     upload = relationship("Upload", backref=backref("testinstances"))
     failure_message = Column(types.Text)
+
+
+class TestResultReportTotals(CodecovBaseModel, AbstractTotals):
+    __tablename__ = "reports_testresultreporttotals"
+
+    report_id = Column(types.Integer, ForeignKey("reports_commitreport.id"))
+    report = relationship("CommitReport", foreign_keys=[report_id])
+
+    passed = Column(types.Integer)
+    skipped = Column(types.Integer)
+    failed = Column(types.Integer)

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -1,5 +1,4 @@
 import logging
-from collections import defaultdict
 from hashlib import sha256
 from typing import Mapping, Sequence
 
@@ -150,7 +149,7 @@ class TestResultsNotifier:
         self.commit_yaml = commit_yaml
         self.test_instances = test_instances
 
-    async def notify(self):
+    async def notify(self, failures, num_passed, num_skipped, num_failed):
         commit_report = self.commit.commit_report(report_type=ReportType.TEST_RESULTS)
         if not commit_report:
             log.warning(
@@ -178,7 +177,9 @@ class TestResultsNotifier:
 
         pull_url = get_pull_url(pull.database_pull)
 
-        message = self.build_message(pull_url, self.test_instances)
+        message = self.build_message(
+            pull_url, self.test_instances, failures, num_passed, num_skipped, num_failed
+        )
 
         try:
             comment_id = pull.database_pull.commentid
@@ -199,7 +200,9 @@ class TestResultsNotifier:
             )
             return False
 
-    def build_message(self, url, test_instances):
+    def build_message(
+        self, url, test_instances, failures, num_passed, num_skipped, num_failed
+    ):
         message = []
 
         message += [
@@ -207,36 +210,8 @@ class TestResultsNotifier:
             "",
             "### :x: Failed Test Results: ",
         ]
-        failed_tests = 0
-        passed_tests = 0
-        skipped_tests = 0
 
-        failures = defaultdict(lambda: defaultdict(list))
-
-        escaper = StringEscaper(ESCAPE_FAILURE_MESSAGE_DEFN)
-
-        for test_instance in test_instances:
-            if test_instance.outcome == str(
-                Outcome.Failure
-            ) or test_instance.outcome == str(Outcome.Error):
-                failed_tests += 1
-                flag_names = sorted(test_instance.upload.flag_names)
-                suffix = ""
-                if flag_names:
-                    suffix = f"{','.join(flag_names) or ''}"
-                normalized_new_lines = "\n".join(
-                    test_instance.failure_message.splitlines()
-                )
-                formatted_failure_message = escaper.replace(normalized_new_lines)
-                failures[formatted_failure_message][
-                    f"{test_instance.test.testsuite}//////////{test_instance.test.name}"
-                ].append(suffix)
-            elif test_instance.outcome == str(Outcome.Skip):
-                skipped_tests += 1
-            elif test_instance.outcome == str(Outcome.Pass):
-                passed_tests += 1
-
-        results = f"Completed {len(test_instances)} tests with **`{failed_tests} failed`**, {passed_tests} passed and {skipped_tests} skipped."
+        results = f"Completed {len(test_instances)} tests with **`{num_failed} failed`**, {num_passed} passed and {num_skipped} skipped."
 
         message.append(results)
 

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -20,38 +20,6 @@ from services.urls import get_pull_url
 log = logging.getLogger(__name__)
 
 
-ESCAPE_FAILURE_MESSAGE_DEFN = [
-    Replacement(
-        [
-            "\\",
-            "'",
-            "*",
-            "_",
-            "`",
-            "[",
-            "]",
-            "{",
-            "}",
-            "(",
-            ")",
-            "#",
-            "+",
-            "-",
-            ".",
-            "!",
-            "|",
-            "<",
-            ">",
-            "&",
-            '"',
-        ],
-        "\\",
-        EscapeEnum.PREPEND,
-    ),
-    Replacement(["\n"], "<br>", EscapeEnum.REPLACE),
-]
-
-
 class TestResultsReportService(BaseReportService):
     def __init__(self, current_yaml: UserYaml):
         super().__init__(current_yaml)

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -141,6 +141,8 @@ class TestResultsNotifier:
                     report_key=commit_report.external_id,
                 ),
             )
+            return False
+
         pullid = pull.database_pull.pullid
 
         pull_url = get_pull_url(pull.database_pull)

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -140,15 +140,13 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
         commits_query = db_session.query(Commit).filter(
             Commit.repoid == repoid, Commit.commitid == commitid
         )
-        commit = commits_query.first()
+        commit: Commit = commits_query.first()
 
-        # check if there were any test failures
-        latest_test_instances = latest_test_instances_for_a_given_commit(
-            db_session, commit.id_
-        )
-
-        if any(
-            [test.outcome == str(Outcome.Failure) for test in latest_test_instances]
+        test_result_commit_report = commit.commit_report(ReportType.TEST_RESULTS)
+        if (
+            test_result_commit_report is not None
+            and test_result_commit_report.totals is not None
+            and test_result_commit_report.totals.failed > 0
         ):
             return {
                 "notify_attempted": False,

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -145,8 +145,8 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
         test_result_commit_report = commit.commit_report(ReportType.TEST_RESULTS)
         if (
             test_result_commit_report is not None
-            and test_result_commit_report.totals is not None
-            and test_result_commit_report.totals.failed > 0
+            and test_result_commit_report.test_result_totals is not None
+            and test_result_commit_report.test_result_totals.failed > 0
         ):
             return {
                 "notify_attempted": False,

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from typing import Any, Dict
 
 from sentry_sdk import metrics
@@ -7,7 +8,7 @@ from test_results_parser import Outcome
 
 from app import celery_app
 from database.enums import ReportType
-from database.models import Commit, CommitReport, Test, TestInstance, Upload
+from database.models import Commit, TestResultReportTotals
 from services.lock_manager import LockManager, LockRetry, LockType
 from services.test_results import (
     TestResultsNotifier,
@@ -102,10 +103,45 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             )
             return {"notify_attempted": False, "notify_succeeded": False}
 
+        commit_report = commit.commit_report(ReportType.TEST_RESULTS)
         with metrics.timing("test_results.finisher.fetch_latest_test_instances"):
             test_instances = latest_test_instances_for_a_given_commit(
                 db_session, commit.id_
             )
+
+        failed_tests = 0
+        passed_tests = 0
+        skipped_tests = 0
+
+        failures = defaultdict(lambda: defaultdict(list))
+
+        for test_instance in test_instances:
+            if test_instance.outcome == str(
+                Outcome.Failure
+            ) or test_instance.outcome == str(Outcome.Error):
+                failed_tests += 1
+                flag_names = sorted(test_instance.upload.flag_names)
+                suffix = ""
+                if flag_names:
+                    suffix = f"({','.join(flag_names) or ''})"
+                failures[test_instance.failure_message][
+                    f"{test_instance.test.testsuite}::{test_instance.test.name}"
+                ].append(suffix)
+            elif test_instance.outcome == str(Outcome.Skip):
+                skipped_tests += 1
+            elif test_instance.outcome == str(Outcome.Pass):
+                passed_tests += 1
+
+        totals = commit_report.test_result_totals
+        if totals is None:
+            totals = TestResultReportTotals(
+                report_id=commit_report.id,
+            )
+            db_session.add(totals)
+        totals.passed = passed_tests
+        totals.skipped = skipped_tests
+        totals.failed = failed_tests
+        db_session.flush()
 
         if self.check_if_no_failures(test_instances):
             metrics.incr(
@@ -124,7 +160,9 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
 
         notifier = TestResultsNotifier(commit, commit_yaml, test_instances)
         with metrics.timing("test_results.finisher.notification"):
-            success = await notifier.notify()
+            success = await notifier.notify(
+                failures, passed_tests, skipped_tests, failed_tests
+            )
 
         log.info(
             "Finished test results notify",


### PR DESCRIPTION
The point of this change is to avoid doing the expensive query to fetch the latest test instances for a commit each time we want to do a notify.

We will be generating the test result report totals in the test results finisher task and setting the number of passed skipped and failed tests.

Depends on: https://github.com/codecov/codecov-api/pull/387