### PR TITLE
chore: add commit id to logs

### DIFF
--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -360,10 +360,10 @@ def _adjust_sessions(
                         session_ids_to_partially_delete.append(sess_id)
     actually_fully_deleted_sessions = set()
     if session_ids_to_fully_delete:
-        extra=dict(
-                deleted_sessions=session_ids_to_fully_delete,
-            )
-        if upload:
+        extra = dict(
+            deleted_sessions=session_ids_to_fully_delete,
+        )
+        if upload is not None:
             extra["commit_id"] = commit_id
         log.info(
             "Deleted multiple sessions due to carriedforward overwrite",
@@ -372,10 +372,10 @@ def _adjust_sessions(
         original_report.delete_multiple_sessions(session_ids_to_fully_delete)
         actually_fully_deleted_sessions.update(session_ids_to_fully_delete)
     if session_ids_to_partially_delete:
-        extra=dict(
-                deleted_sessions=session_ids_to_partially_delete,
-            )
-        if upload:
+        extra = dict(
+            deleted_sessions=session_ids_to_partially_delete,
+        )
+        if upload is not None:
             extra["commit_id"] = commit_id
         log.info(
             "Partially deleting sessions due to label carryforward overwrite",
@@ -388,7 +388,7 @@ def _adjust_sessions(
             if not labels_now:
                 log.info(
                     "Session has now no new labels, deleting whole session",
-                    extra=dict(commit_id=commit_id) if upload else dict(),
+                    extra=dict(commit_id=commit_id) if upload is not None else dict(),
                 )
                 actually_fully_deleted_sessions.add(s)
                 original_report.delete_session(s)

--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -336,6 +336,8 @@ def _adjust_sessions(
         for f in flags_under_carryforward_rules
         if f not in to_partially_overwrite_flags
     ]
+    if upload is not None:
+        commit_id = upload.report.commit_id
     if upload is None and to_partially_overwrite_flags:
         log.warning("Upload is None, but there are partial_overwrite_flags present")
     if (
@@ -358,23 +360,36 @@ def _adjust_sessions(
                         session_ids_to_partially_delete.append(sess_id)
     actually_fully_deleted_sessions = set()
     if session_ids_to_fully_delete:
+        extra=dict(
+                deleted_sessions=session_ids_to_fully_delete,
+            )
+        if upload:
+            extra["commit_id"] = commit_id
         log.info(
             "Deleted multiple sessions due to carriedforward overwrite",
-            extra=dict(deleted_sessions=session_ids_to_fully_delete),
+            extra=extra,
         )
         original_report.delete_multiple_sessions(session_ids_to_fully_delete)
         actually_fully_deleted_sessions.update(session_ids_to_fully_delete)
     if session_ids_to_partially_delete:
+        extra=dict(
+                deleted_sessions=session_ids_to_partially_delete,
+            )
+        if upload:
+            extra["commit_id"] = commit_id
         log.info(
             "Partially deleting sessions due to label carryforward overwrite",
-            extra=dict(deleted_sessions=session_ids_to_partially_delete),
+            extra=extra,
         )
         all_labels = get_all_report_labels(to_merge_report)
         original_report.delete_labels(session_ids_to_partially_delete, all_labels)
         for s in session_ids_to_partially_delete:
             labels_now = get_labels_per_session(original_report, s)
             if not labels_now:
-                log.info("Session has now no new labels, deleting whole session")
+                log.info(
+                    "Session has now no new labels, deleting whole session",
+                    extra=dict(commit_id=commit_id) if upload else dict(),
+                )
                 actually_fully_deleted_sessions.add(s)
                 original_report.delete_session(s)
     return SessionAdjustmentResult(


### PR DESCRIPTION
<!-- Describe your PR here. -->

Adds commit_id information from uploaded reports to logs when it is available. Closes #211 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.