### PR TITLE
chore: Change default RCB to adjust_base

### DIFF
--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -103,7 +103,7 @@ class StatusChangesMixin(object):
 
 
 class StatusProjectMixin(object):
-    DEFAULT_REMOVED_CODE_BEHAVIOR = "fully_covered_patch"
+    DEFAULT_REMOVED_CODE_BEHAVIOR = "adjust_base"
 
     async def _apply_removals_only_behavior(
         self, comparison: Union[ComparisonProxy, FilteredComparison]

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -1653,7 +1653,7 @@ class TestProjectChecksNotifier(object):
         notifier = ProjectChecksNotifier(
             repository=sample_comparison_negative_change.head.commit.repository,
             title="default",
-            notifier_yaml_settings={},
+            notifier_yaml_settings={"removed_code_behavior": "removals_only"},
             notifier_site_settings=True,
             current_yaml={"comment": False},
         )


### PR DESCRIPTION
These changes set the default Removed Code Behavior (RCB) to
`adjust_base` (instead of `fully_covered_patch`).

The change in the test is because the status actually passes
via adjust_base. I decided to preserve the outcome of the test,
and changed the rcb configured for the test.

context: codecov/engineering-team#1130

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.