### PR TITLE
chore: Change wording in statuses messages

### DIFF
--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -87,9 +87,7 @@ class StatusChangesMixin(object):
             lpc = len(changes)
             eng = "files have" if lpc > 1 else "file has"
             description = (
-                "{0} {1} unexpected coverage changes not visible in diff".format(
-                    lpc, eng
-                )
+                "{0} {1} indirect coverage changes not visible in diff".format(lpc, eng)
             )
             state = (
                 "success"
@@ -98,7 +96,7 @@ class StatusChangesMixin(object):
             )
             return (state, description)
 
-        description = "No unexpected coverage changes found"
+        description = "No indirect coverage changes found"
         return ("success", description)
 
 
@@ -260,7 +258,7 @@ class StatusProjectMixin(object):
         if coverage == 100.0:
             return (
                 "success",
-                ", passed because patch was fully covered by tests with no unexpected coverage changes",
+                ", passed because patch was fully covered by tests, and no indirect coverage changes",
             )
         return None
 

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -1231,8 +1231,8 @@ class TestChangesChecksNotifier(object):
         expected_result = {
             "state": "success",
             "output": {
-                "title": "No unexpected coverage changes found",
-                "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=h1)\n\nNo unexpected coverage changes found",
+                "title": "No indirect coverage changes found",
+                "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?src=pr&el=h1)\n\nNo indirect coverage changes found",
             },
         }
         result = await notifier.build_payload(sample_comparison)
@@ -1287,8 +1287,8 @@ class TestChangesChecksNotifier(object):
         expected_result = {
             "state": "failure",
             "output": {
-                "title": "3 files have unexpected coverage changes not visible in diff",
-                "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_with_multiple_changes/{comparison_with_multiple_changes.head.commit.repository.name}/pull/{comparison_with_multiple_changes.pull.pullid}?src=pr&el=h1)\n\n3 files have unexpected coverage changes not visible in diff",
+                "title": "3 files have indirect coverage changes not visible in diff",
+                "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_with_multiple_changes/{comparison_with_multiple_changes.head.commit.repository.name}/pull/{comparison_with_multiple_changes.pull.pullid}?src=pr&el=h1)\n\n3 files have indirect coverage changes not visible in diff",
             },
         }
         result = await notifier.build_payload(comparison_with_multiple_changes)

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -1656,7 +1656,7 @@ class TestProjectStatusNotifier(object):
             current_yaml=UserYaml({}),
         )
         expected_result = {
-            "message": "28.57% (target 70.00%), passed because patch was fully covered by tests with no unexpected coverage changes",
+            "message": "28.57% (target 70.00%), passed because patch was fully covered by tests, and no indirect coverage changes",
             "state": "success",
         }
         result = await notifier.build_payload(comparison_100_percent_patch)
@@ -2091,7 +2091,7 @@ class TestChangesStatusNotifier(object):
             current_yaml=UserYaml({}),
         )
         expected_result = {
-            "message": "No unexpected coverage changes found",
+            "message": "No indirect coverage changes found",
             "state": "success",
         }
         result = await notifier.build_payload(sample_comparison)
@@ -2137,7 +2137,7 @@ class TestChangesStatusNotifier(object):
             current_yaml=UserYaml({}),
         )
         expected_result = {
-            "message": "3 files have unexpected coverage changes not visible in diff",
+            "message": "3 files have indirect coverage changes not visible in diff",
             "state": "failure",
         }
         result = await notifier.build_payload(comparison_with_multiple_changes)
@@ -2183,7 +2183,7 @@ class TestChangesStatusNotifier(object):
         )
         base_commit = sample_comparison.project_coverage_base.commit
         expected_result = {
-            "message": "No unexpected coverage changes found",
+            "message": "No indirect coverage changes found",
             "state": "success",
             "url": f"test.example.br/gh/{sample_comparison.head.commit.repository.slug}/pull/{sample_comparison.pull.pullid}",
         }

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -436,7 +436,7 @@ class TestNotifyTask(object):
                         "data_sent": {
                             "title": "codecov/changes",
                             "state": "failure",
-                            "message": "1 file has unexpected coverage changes not visible in diff",
+                            "message": "1 file has indirect coverage changes not visible in diff",
                         },
                         "data_received": {"id": 9333281703},
                     },
@@ -664,7 +664,7 @@ class TestNotifyTask(object):
                         "data_sent": {
                             "title": "codecov/changes",
                             "state": "success",
-                            "message": "No unexpected coverage changes found",
+                            "message": "No indirect coverage changes found",
                         },
                         "data_received": {"id": 9333363801},
                     },
@@ -1039,15 +1039,15 @@ class TestNotifyTask(object):
                     "notifier": "status-changes",
                     "title": "default",
                     "result": {
-                        "notification_attempted": False,
-                        "notification_successful": None,
-                        "explanation": "already_done",
+                        "notification_attempted": True,
+                        "notification_successful": True,
+                        "explanation": None,
                         "data_sent": {
                             "title": "codecov/changes",
                             "state": "success",
-                            "message": "No unexpected coverage changes found",
+                            "message": "No indirect coverage changes found",
                         },
-                        "data_received": None,
+                        "data_received": {"id": 24846000025},
                     },
                 },
                 {


### PR DESCRIPTION
context: codecov/engineering-team#1131

Changes 'unexpected changes' to 'indirect changes' in statuses
sent by the notify task.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.