### PR TITLE
chore: use debian base images instead of alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ test_env.install_cli:
 	pip install --no-cache-dir codecov-cli==$(CODECOV_CLI_VERSION)
 
 test_env.container_prepare:
-	apk add -U curl git build-base jq
+	apt-get install -y git build-essential netcat-traditional
 	make test_env.install_cli
 	git config --global --add safe.directory /worker
 

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ test_env.run_mutation:
 	docker-compose exec worker make test_env.container_mutation
 
 test_env.container_mutation:
-	apk add git
+	apt-get install -y git
 	git diff origin/main ${full_sha} > data.patch
 	pip install mutmut[patch]
 	mutmut run --use-patch-file data.patch || true

--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -1,24 +1,26 @@
 # syntax=docker/dockerfile:1.4
-ARG PYTHON_IMAGE=python:3.10.13-alpine3.18
+ARG PYTHON_IMAGE=python:3.10.13-slim-bookworm
+
 # BUILD STAGE
 FROM $PYTHON_IMAGE as build
 
-RUN apk add --upgrade --no-cache apk-tools && \
-    apk add --update --no-cache \
-    git \
-    openssh \
-    postgresql-dev \
-    musl-dev \
-    libxslt-dev \
-    python3-dev \
+# Pinning a specific nightly version so that builds don't suddenly break if a
+# "this feature is now stabilized" warning is promoted to an error or something.
+# We would like to keep up with nightly if we can.
+ARG RUST_VERSION=nightly-2023-02-22
+ENV RUST_VERSION=${RUST_VERSION}
+
+RUN apt-get update
+RUN apt-get install -y \
+    build-essential \
     libffi-dev \
-    gcc \
-    libcurl \
-    build-base \
-    curl-dev \
-    rust \
-    cargo \
-    && pip install --upgrade pip
+    libpq-dev \
+    curl
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+    | bash -s -- -y --default-toolchain $RUST_VERSION
+ENV PATH="/root/.cargo/bin:$PATH"
 
 COPY requirements.txt /
 WORKDIR /pip-packages/
@@ -27,16 +29,17 @@ ENV PYCURL_SSL_LIBRARY=openssl
 RUN pip wheel --no-cache-dir -r /requirements.txt
 RUN rm -rf /pip-packages/src
 
-
 # RUNTIME STAGE - Copy packages from build stage and install runtime dependencies
 FROM $PYTHON_IMAGE
 
-RUN apk add --upgrade --no-cache apk-tools busybox expat libretls postgresql-libs gcc libxslt-dev curl make
+RUN apt-get update
+RUN apt-get install -y \
+    libpq-dev
 
 WORKDIR /pip-packages/
 COPY --from=build /pip-packages/ /pip-packages/
 
-
 RUN pip install --no-deps --no-index --find-links=/pip-packages/ /pip-packages/*
 
-RUN addgroup -S application && adduser -S codecov -G application
+RUN addgroup --system application \
+    && adduser --system codecov --ingroup application --home /home/codecov

--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -34,7 +34,8 @@ FROM $PYTHON_IMAGE
 
 RUN apt-get update
 RUN apt-get install -y \
-    libpq-dev
+    libpq-dev \
+    make
 
 WORKDIR /pip-packages/
 COPY --from=build /pip-packages/ /pip-packages/

--- a/worker.sh
+++ b/worker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -n "$PROMETHEUS_MULTIPROC_DIR" ]; then
     rm -r "$PROMETHEUS_MULTIPROC_DIR" 2> /dev/null


### PR DESCRIPTION
fixes https://github.com/codecov/engineering-team/issues/1242

with an alpine/musl image we have to build more packages from source. grpcio takes an eternity to build for example

also apparently alpine/musl images have DNS resolution problems

this uses an official "slim" python image based on debian stable. from a quick glance at uncompressed image sizes on my local machine, this is actually 300mb smaller:
<img width="876" alt="Screenshot 2024-02-23 at 7 46 49 PM" src="https://github.com/codecov/worker/assets/137832199/d38bac82-374e-45a7-b04c-234a84823954">
<img width="863" alt="Screenshot 2024-02-23 at 7 47 03 PM" src="https://github.com/codecov/worker/assets/137832199/3b15bacd-679b-48c8-952a-0c5ffae50453">

i have not rigorously tested this but it seems okay

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.