### PR TITLE
temp fix: disable django models until migration is figured out

### DIFF
--- a/helpers/telemetry.py
+++ b/helpers/telemetry.py
@@ -112,6 +112,7 @@ class MetricContext:
 
         self.populate()
 
+        """
         PgSimpleMetric.objects.create(
             timestamp=timestamp,
             name=name,
@@ -129,6 +130,7 @@ class MetricContext:
             owner_slug=self.owner_slug,
             commit_slug=self.commit_slug,
         )
+        """
 
     @fire_and_forget
     async def attempt_log_simple_metric(self, name: str, value: float):


### PR DESCRIPTION
for reasons i don't understand, the migrations for the timescale model are no-ops when run from worker
```
$ docker exec -it umbrella-hat-worker-1 python manage.py sqlmigrate ts_telemetry 0001_initial
BEGIN;
--
-- Create model SimpleMetric
--
-- (no-op)
--
-- Raw SQL operation
--
-- (no-op)
--
-- Create index telemetry_s_name_498f66_idx on field(s) name, timestamp, repo_slug, owner_slug, commit_slug of model SimpleMetric
--
-- (no-op)
--
-- Raw SQL operation
--
-- (no-op)
COMMIT;
```

but not when run from api:
```
$ docker exec -it umbrella-hat-api-1 python manage.py sqlmigrate ts_telemetry 0001_initial
BEGIN;
--
-- Create model SimpleMetric
--
CREATE TABLE "telemetry_simple" ("timestamp" timestamp with time zone NOT NULL PRIMARY KEY, "repo_slug" text NULL, "owner_slug" text NULL, "commit_slug" text NULL, "name" text NOT NULL, "value" double precision NOT NULL);
--
-- Raw SQL operation
--
ALTER TABLE telemetry_simple DROP CONSTRAINT telemetry_simple_pkey;
--
-- Create index telemetry_s_name_498f66_idx on field(s) name, timestamp, repo_slug, owner_slug, commit_slug of model SimpleMetric
--
CREATE INDEX "telemetry_s_name_498f66_idx" ON "telemetry_simple" ("name", "timestamp", "repo_slug", "owner_slug", "commit_slug");
--
-- Raw SQL operation
--
SELECT create_hypertable('telemetry_simple', 'timestamp');
COMMIT;
```
so let's comment out the model again until i can figure that out

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.