### PR TITLE
Fix test result PR comment

### DIFF
--- a/helpers/string.py
+++ b/helpers/string.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from enum import Enum
 from typing import List
 
@@ -8,11 +9,11 @@ class EscapeEnum(Enum):
     REPLACE = "replace"
 
 
+@dataclass
 class Replacement:
-    def __init__(self, chars: str, output: str, method: EscapeEnum):
-        self.chars = chars
-        self.output = output
-        self.method = method
+    chars: str
+    output: str
+    method: EscapeEnum
 
 
 class StringEscaper:
@@ -29,14 +30,16 @@ class StringEscaper:
 
         for example:
             escape_def = [
-                Replacement(chars="<>", output="\\", method=EscapeEnum.PREPEND),
-                Replacement(chars="pre", output="div", method=EscapeEnum.REPLACE)
+                Replacement("1", "2", EscapeEnum.APPEND),
+                Replacement("3", "4", EscapeEnum.PREPEND),
+                Replacement("5", "6", EscapeEnum.REPLACE),
             ]
-            StringEscaper(escape_def)
 
-            replace("<pre></pre>")
+            escaper = StringEscaper(escape_def)
 
-            will give: \<div\>\</div\>
+            escaper.replace("123456")
+
+            will give: "12243466"
     """
 
     def __init__(self, escape_def: List[Replacement]):

--- a/helpers/string.py
+++ b/helpers/string.py
@@ -1,0 +1,54 @@
+from enum import Enum
+from typing import List
+
+
+class EscapeEnum(Enum):
+    APPEND = "append"
+    PREPEND = "prepend"
+    REPLACE = "replace"
+
+
+class Replacement:
+    def __init__(self, chars: str, output: str, method: EscapeEnum):
+        self.chars = chars
+        self.output = output
+        self.method = method
+
+
+class StringEscaper:
+    """
+    Class to use to escape strings using format defined
+    through a dict.
+
+    Args:
+        escape_def: list of Replacement that defines how to escape
+        characters
+
+        string is escaped by applying method in each Replacement
+        to each char in Replacement.chars using the char in output
+
+        for example:
+            escape_def = [
+                Replacement(chars="<>", output="\\", method=EscapeEnum.PREPEND),
+                Replacement(chars="pre", output="div", method=EscapeEnum.REPLACE)
+            ]
+            StringEscaper(escape_def)
+
+            replace("<pre></pre>")
+
+            will give: \<div\>\</div\>
+    """
+
+    def __init__(self, escape_def: List[Replacement]):
+        self.escape_def = escape_def
+
+    def replace(self, string):
+        for replacement in self.escape_def:
+            for char in replacement.chars:
+                if replacement.method == EscapeEnum.PREPEND:
+                    string = string.replace(char, f"{replacement.output}{char}")
+                elif replacement.method == EscapeEnum.APPEND:
+                    string = string.replace(char, f"{char}{replacement.output}")
+                elif replacement.method == EscapeEnum.REPLACE:
+                    string = string.replace(char, replacement.output)
+        return string

--- a/helpers/tests/unit/test_string.py
+++ b/helpers/tests/unit/test_string.py
@@ -1,0 +1,13 @@
+from helpers.string import EscapeEnum, Replacement, StringEscaper
+
+
+def test_string_escaper():
+    escape_def = [
+        Replacement("1", "2", EscapeEnum.APPEND),
+        Replacement("3", "4", EscapeEnum.PREPEND),
+        Replacement("5", "6", EscapeEnum.REPLACE),
+    ]
+
+    escaper = StringEscaper(escape_def)
+
+    assert escaper.replace("123456") == "12243466"

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -133,16 +133,15 @@ class TestResultsNotifier:
         pull = await fetch_and_update_pull_request_information_from_commit(
             repo_service, self.commit, self.commit_yaml
         )
-        pullid = pull.database_pull.pullid
         if pull is None:
             log.info(
                 "Not notifying since there is no pull request associated with this commit",
                 extra=dict(
                     commitid=self.commit.commitid,
                     report_key=commit_report.external_id,
-                    pullid=pullid,
                 ),
             )
+        pullid = pull.database_pull.pullid
 
         pull_url = get_pull_url(pull.database_pull)
 
@@ -225,7 +224,7 @@ class TestResultsNotifier:
                         )
                     )
                 ),
-                failure_message.replace("\n", "<br>"),
+                failure_message.replace("\r", "").replace("\n", "<br>"),
             )
             for failure_message, failed_test_to_env_list in sorted(
                 failures.items(), key=lambda failure: failure[0]

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -21,11 +21,11 @@ from services.urls import get_pull_url
 log = logging.getLogger(__name__)
 
 
-ESCAPE_FAILURE_MESSAGE_DEFN = {
+ESCAPE_FAILURE_MESSAGE_DEFN = [
     Replacement(r"\'*_`[]{}()#+-.!|<>&", "\\", EscapeEnum.PREPEND),
     Replacement("\r", "", EscapeEnum.REPLACE),
     Replacement("\n", "<br>", EscapeEnum.REPLACE),
-}
+]
 
 
 class TestResultsReportService(BaseReportService):

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -139,7 +139,7 @@ class TestUploadTestFinisherTask(object):
         test_instance2 = TestInstance(
             test_id=test_id1,
             outcome=str(Outcome.Failure),
-            failure_message="not that bad",
+            failure_message="<pre>not that bad</pre> | hello | goodbye |",
             duration_seconds=1,
             upload_id=upload_id2,
         )
@@ -160,7 +160,7 @@ class TestUploadTestFinisherTask(object):
         test_instance4 = TestInstance(
             test_id=test_id2,
             outcome=str(Outcome.Failure),
-            failure_message="not that bad",
+            failure_message="<pre>not that bad</pre> | hello | goodbye |",
             duration_seconds=2,
             upload_id=upload_id1,
         )
@@ -181,7 +181,7 @@ class TestUploadTestFinisherTask(object):
         expected_result = {"notify_attempted": True, "notify_succeeded": True}
         m.post_comment.assert_called_with(
             pull.pullid,
-            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| <pre>test_testsuite::test_name[(b)]</pre> | <pre>not that bad</pre> |\n| <pre>test_testsuite::test_name[(a)]</pre> | <pre>okay i guess</pre> |",
+            f"##  [Codecov](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/{pull.pullid}) Report\n\n**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 2 tests with **`2 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **File path** | **Failure message** |\n| :-- | :-- |\n| <pre>test_testsuite::test_name[(b)]</pre> | <pre>\\<pre\\>not that bad\\</pre\\> \\| hello \\| goodbye \\|</pre> |\n| <pre>test_testsuite::test_name[(a)]</pre> | <pre>okay i guess</pre> |",
         )
 
         assert expected_result == result


### PR DESCRIPTION
This PR adds escaping for certain characters when making the test result PR comment.

We have to do this to properly display the failure message table.