### PR TITLE
fix: commit after running worker migrations

### DIFF
--- a/django_scaffold/management/commands/migrate.py
+++ b/django_scaffold/management/commands/migrate.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.core.management.commands.migrate import Command as MigrateCommand
 from django.db import connections
+from django.db import transaction as django_transaction
 from django.db.utils import IntegrityError, ProgrammingError
 
 from services.redis import get_redis_connection
@@ -71,6 +72,9 @@ class Command(MigrateCommand):
 
         try:
             super().handle(*args, **options)
+
+            # Autocommit is disabled in worker
+            django_transaction.commit(database)
         except:
             log.info("Codecov migrations failed.")
             raise

--- a/django_scaffold/settings.py
+++ b/django_scaffold/settings.py
@@ -24,10 +24,12 @@ INSTALLED_APPS = [
 TELEMETRY_VANILLA_DB = "default"
 TELEMETRY_TIMESCALE_DB = "timeseries"
 
-# DATABASE_ROUTERS = [
-#    "database.TelemetryDatabaseRouter",
-#    "shared.django_apps.db_routers.MultiDatabaseRouter",
-# ]
+DATABASE_ROUTERS = [
+    "shared.django_apps.db_routers.TelemetryDatabaseRouter",
+    "shared.django_apps.db_routers.MultiDatabaseRouter",
+]
+
+SKIP_RISKY_MIGRATION_STEPS = get_config("migrations", "skip_risky_steps", default=False)
 
 MIDDLEWARE = []
 


### PR DESCRIPTION
whoops. autocommit is turned off in worker and this also applies to the migrate command apparently :)

also re-enable the database routers and add a setting i missed that actually causes risky migrations to be skipped

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.