### PR TITLE
fix: re-enable sql task metrics

### DIFF
--- a/helpers/telemetry.py
+++ b/helpers/telemetry.py
@@ -112,7 +112,6 @@ class MetricContext:
 
         self.populate()
 
-        """
         PgSimpleMetric.objects.create(
             timestamp=timestamp,
             name=name,
@@ -130,7 +129,6 @@ class MetricContext:
             owner_slug=self.owner_slug,
             commit_slug=self.commit_slug,
         )
-        """
 
     @fire_and_forget
     async def attempt_log_simple_metric(self, name: str, value: float):


### PR DESCRIPTION
https://github.com/codecov/worker/pull/289 should fix the problems i saw when i deployed these metrics to staging

enabled in https://github.com/codecov/worker/pull/283, reverted in https://github.com/codecov/worker/pull/286, back on now

sorry for the churn on this. in the future i'll deploy to staging manually to test for things like this before merging

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.