### PR TITLE
fix: Rewrite report in readable format in error

### DIFF
--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -223,6 +223,9 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                     )
                     upload_obj.state_id = UploadState.ERROR.db_id
                     upload_obj.state = "error"
+                    self._attempt_rewrite_raw_report_readable_error_case(
+                        report_service, commit, upload_obj
+                    )
                     raise
                 if individual_info.get("successful"):
                     report = individual_info.pop("report")
@@ -346,6 +349,24 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 archive_service.delete_file(archive_url)
                 return True
         return False
+
+    def _attempt_rewrite_raw_report_readable_error_case(
+        self, report_service: ReportService, commit: Commit, upload: Upload
+    ):
+        log.info(
+            "Attempting to rewrite raw upload in readable format for debugging purposes (processing already failed)"
+        )
+        try:
+            raw_report = report_service.parse_raw_report_from_storage(
+                commit.repository, upload
+            )
+            self._rewrite_raw_report_readable(
+                processing_result={"raw_report": raw_report, "upload_object": upload},
+                report_service=report_service,
+                commit=commit,
+            )
+        except FileNotFoundError:
+            log.exception("Failed to rewrite raw report in readable format")
 
     def _rewrite_raw_report_readable(
         self,

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -354,7 +354,8 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         self, report_service: ReportService, commit: Commit, upload: Upload
     ):
         log.info(
-            "Attempting to rewrite raw upload in readable format for debugging purposes (processing already failed)"
+            "Attempting to rewrite raw upload in readable format for debugging purposes (processing already failed)",
+            extra=dict(commit=commit.commitid, upload=upload.external_id),
         )
         try:
             raw_report = report_service.parse_raw_report_from_storage(
@@ -366,7 +367,10 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 commit=commit,
             )
         except FileNotFoundError:
-            log.exception("Failed to rewrite raw report in readable format")
+            log.exception(
+                "Failed to rewrite raw report in readable format",
+                extra=dict(commit=commit.commitid, upload=upload.external_id),
+            )
 
     def _rewrite_raw_report_readable(
         self,


### PR DESCRIPTION
context: codecov/engineering-team#1112

Attempts to rewrite a report in readable format if the processing failed.
This is meant to aid in debugging errors - that likely come from the report
content - in case of processing failure.

Particularly the reports uploaded by the CLI are done so encoded and
compressed. If we rewrite in readable format users can download them in
the commits page of the UI and actually see what's inside.

Important details:
* This only applies if the processing failed with an exception.
* If we were to try processing the re-writen report the processing would
fail. (but we won't do that because processing failed with exception)
* If the error was an internal one the report won't be changed either.
Particularly for `SoftLimitTimeout` error it would be dangerous to
try and rewrite the report.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.