### PR TITLE
fix: use timezone-aware timestamp in MetricsContext

### DIFF
--- a/helpers/telemetry.py
+++ b/helpers/telemetry.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import datetime
 
+import django
 from shared.django_apps.pg_telemetry.models import SimpleMetric as PgSimpleMetric
 from shared.django_apps.ts_telemetry.models import SimpleMetric as TsSimpleMetric
 
@@ -108,7 +109,8 @@ class MetricContext:
         self.populated = True
 
     def log_simple_metric(self, name: str, value: float):
-        timestamp = datetime.now()
+        # Timezone-aware timestamp in UTC
+        timestamp = django.utils.timezone.now()
 
         self.populate()
 


### PR DESCRIPTION
there is a noisy log telling us we shouldn't use naive timestamps when `USE_TZ` is set

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.