### PR TITLE
remove most of the spurious async/awaits from worker tasks

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,7 +26,6 @@ def pytest_configure(config):
     file after command line options have been parsed.
     """
     os.environ["CURRENT_ENVIRONMENT"] = "local"
-    os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
     _get_cached_current_env.cache_clear()
     initialize_logging()
 

--- a/main.py
+++ b/main.py
@@ -62,27 +62,6 @@ def setup_worker():
         log.info(f"External dependencies folder configured to {external_deps_folder}")
         sys.path.append(external_deps_folder)
 
-    # ALERT ALERT ALERT! This is not to be done lightly!
-    # Django's ORM raises errors if run from within an asyncio event loop. Our
-    # base celery task runs all task implementations via asyncio.run(), so when
-    # we use Django's ORM in most of worker it'll get steamed. However, the base
-    # task use of asyncio is actually superfluous. Consider the following:
-    #
-    #    async def run_async():
-    #        await foo()
-    #        await bar()
-    #        await baz()
-    #    asyncio.run(run_async())
-    #
-    # `run_async()` is effectively running `foo()`, `bar()`, and `baz()`
-    # synchronously. When we `await foo()`, there's nothing else running in the
-    # event loop that we could resume, and we can't start `bar()` until `foo()`
-    # has completed. So... there's nothing to do but wait.
-    #
-    # With that in mind, we should be able to safely disable Django's
-    # protections with this environment variable.
-    os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
-
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_scaffold.settings")
     django.setup()
 

--- a/tasks/README.md
+++ b/tasks/README.md
@@ -74,7 +74,7 @@ When adding a new task, you will already have a ton you need to do. But be sure 
 3. Don't start scheduling things to it right away (see point above about the system being asychronous)
 4. Make sure celery displays it when spinning up the system on your local machine
 
-You should be able to copy-paste any of the tasks when creating your own, but the important entrypoint of the task is the `run_async` function.
+You should be able to copy-paste any of the tasks when creating your own, but the important entrypoint of the task is the `run_impl` function.
 
 It needs to have
 
@@ -86,7 +86,7 @@ It needs to have
 * In the end, your function signature should look a bit like this:
 
 ```
-    async def run_async(
+    def run_impl(
         self,
         db_session: Session,
         *,

--- a/tasks/ai_pr_review.py
+++ b/tasks/ai_pr_review.py
@@ -1,5 +1,6 @@
 import logging
 
+from asgiref.sync import async_to_sync
 from celery.exceptions import SoftTimeLimitExceeded
 from openai import AsyncOpenAI
 from shared.config import get_config
@@ -36,7 +37,7 @@ class AiPrReviewTask(BaseCodecovTask, name="app.tasks.ai_pr_review.AiPrReview"):
             return {"successful": False, "error": "not_github"}
 
         try:
-            await perform_review(repository, pullid)
+            async_to_sync(perform_review)(repository, pullid)
             return {"successful": True}
         except RepositoryWithoutValidBotError:
             log.warning(

--- a/tasks/ai_pr_review.py
+++ b/tasks/ai_pr_review.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 class AiPrReviewTask(BaseCodecovTask, name="app.tasks.ai_pr_review.AiPrReview"):
     throws = (SoftTimeLimitExceeded,)
 
-    async def run_async(
+    def run_impl(
         self,
         db_session: Session,
         *,

--- a/tasks/backfill_commit_data_to_storage.py
+++ b/tasks/backfill_commit_data_to_storage.py
@@ -30,7 +30,7 @@ class BackfillCommitDataToStorageTask(
     BaseCodecovTask,
     name=f"app.tasks.{TaskConfigGroup.archive.value}.BackfillCommitDataToStorage",
 ):
-    async def run_async(
+    def run_impl(
         self,
         db_session: Session,
         *,

--- a/tasks/backfill_gh_app_installations.py
+++ b/tasks/backfill_gh_app_installations.py
@@ -2,6 +2,7 @@ import logging
 from typing import List, Optional
 
 import shared.torngit as torngit
+from asgiref.sync import async_to_sync
 from sqlalchemy.orm.session import Session
 
 from app import celery_app
@@ -17,14 +18,14 @@ class BackfillGHAppInstallationsTask(
     BaseCodecovTask, name=backfill_gh_app_installations
 ):
     # Looping and adding all repositories in the installation app
-    async def add_repos_service_ids_from_provider(
+    def add_repos_service_ids_from_provider(
         self,
         db_session: Session,
         ownerid: int,
         owner_service: torngit.base.TorngitBaseAdapter,
         gh_app_installation: GithubAppInstallation,
     ):
-        repos = await owner_service.list_repos_using_installation()
+        repos = async_to_sync(owner_service.list_repos_using_installation)()
 
         if repos:
             # Fetching all repos service ids we have for that owner in the DB
@@ -53,7 +54,7 @@ class BackfillGHAppInstallationsTask(
             gh_app_installation.repository_service_ids = new_repo_service_ids
             db_session.commit()
 
-    async def backfill_existing_gh_apps(
+    def backfill_existing_gh_apps(
         self, db_session: Session, owner_ids: List[int] = None
     ):
         # Get owners that have installations, and installations queries
@@ -92,9 +93,9 @@ class BackfillGHAppInstallationsTask(
                 owner=owner, using_integration=True
             )
 
-            remote_gh_app_installation = await owner_service.get_gh_app_installation(
-                installation_id=installation_id
-            )
+            remote_gh_app_installation = async_to_sync(
+                owner_service.get_gh_app_installation
+            )(installation_id=installation_id)
             repository_selection = remote_gh_app_installation.get(
                 "repository_selection", ""
             )
@@ -107,7 +108,7 @@ class BackfillGHAppInstallationsTask(
                 )
             else:
                 # Find and add all repos the gh app has access to
-                await self.add_repos_service_ids_from_provider(
+                self.add_repos_service_ids_from_provider(
                     db_session=db_session,
                     ownerid=ownerid,
                     owner_service=owner_service,
@@ -115,7 +116,7 @@ class BackfillGHAppInstallationsTask(
                 )
                 log.info("Successful backfill", extra=dict(ownerid=ownerid))
 
-    async def backfill_owners_with_integration_without_gh_app(
+    def backfill_owners_with_integration_without_gh_app(
         self, db_session: Session, owner_ids: List[int] = None
     ):
         owners_with_integration_id_without_gh_app_query = (
@@ -158,7 +159,7 @@ class BackfillGHAppInstallationsTask(
             db_session.commit()
 
             # Find and add all repos the gh app has access to
-            await self.add_repos_service_ids_from_provider(
+            self.add_repos_service_ids_from_provider(
                 db_session=db_session,
                 ownerid=ownerid,
                 owner_service=owner_service,
@@ -174,10 +175,10 @@ class BackfillGHAppInstallationsTask(
         **kwargs
     ):
         # Backfill gh apps we already have
-        await self.backfill_existing_gh_apps(db_session=db_session, owner_ids=owner_ids)
+        self.backfill_existing_gh_apps(db_session=db_session, owner_ids=owner_ids)
 
         # Backfill owners with legacy integration + adding new gh app
-        await self.backfill_owners_with_integration_without_gh_app(
+        self.backfill_owners_with_integration_without_gh_app(
             db_session=db_session, owner_ids=owner_ids
         )
 

--- a/tasks/backfill_gh_app_installations.py
+++ b/tasks/backfill_gh_app_installations.py
@@ -166,7 +166,7 @@ class BackfillGHAppInstallationsTask(
             )
             log.info("Successful backfill", extra=dict(ownerid=ownerid))
 
-    async def run_async(
+    def run_impl(
         self,
         db_session: Session,
         owner_ids: Optional[List[int]] = None,

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 from datetime import datetime
 
@@ -271,9 +270,7 @@ class BaseCodecovTask(celery_app.Task):
                         ):
                             with self.task_core_runtime.time():  # Timer isn't tested
                                 with metrics.timer(f"{self.metrics_prefix}.run"):
-                                    return asyncio.run(
-                                        self.run_async(db_session, *args, **kwargs)
-                                    )
+                                    return self.run_impl(db_session, *args, **kwargs)
                     except (DataError, IntegrityError):
                         log.exception(
                             "Errors related to the constraints of database happened",

--- a/tasks/brolly_stats_rollup.py
+++ b/tasks/brolly_stats_rollup.py
@@ -79,7 +79,7 @@ class BrollyStatsRollupTask(CodecovCronTask, name=brolly_stats_rollup_task_name)
         """
         return get_config("setup", "telemetry", "admin_email", default=None)
 
-    async def run_cron_task(self, db_session, *args, **kwargs):
+    def run_cron_task(self, db_session, *args, **kwargs):
         # We shouldn't even schedule this task if it's not enabled, but
         # let's double-check that we're supposed to collect stats.
         if not get_config("setup", "telemetry", "enabled", default=True):
@@ -105,7 +105,7 @@ class BrollyStatsRollupTask(CodecovCronTask, name=brolly_stats_rollup_task_name)
             "Accept": "application/json",
             "Content-Type": "application/json",
         }
-        res = await httpx.AsyncClient().post(
+        res = httpx.Client().post(
             url=brolly_endpoint,
             content=json.dumps(payload),
             headers=headers,

--- a/tasks/bundle_analysis_notify.py
+++ b/tasks/bundle_analysis_notify.py
@@ -17,7 +17,7 @@ bundle_analysis_notify_task_name = "app.tasks.bundle_analysis.BundleAnalysisNoti
 
 
 class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task_name):
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         # Celery `chain` injects this argument - it's the returned result

--- a/tasks/bundle_analysis_notify.py
+++ b/tasks/bundle_analysis_notify.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Any, Dict
 
+from asgiref.sync import async_to_sync
 from shared.celery_config import notify_task_name
 from shared.yaml import UserYaml
 
@@ -52,7 +53,7 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
                 LockType.BUNDLE_ANALYSIS_NOTIFY,
                 retry_num=self.request.retries,
             ):
-                return await self.process_async_within_lock(
+                return self.process_impl_within_lock(
                     db_session=db_session,
                     repoid=repoid,
                     commitid=commitid,
@@ -63,7 +64,7 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
         except LockRetry as retry:
             self.retry(max_retries=5, countdown=retry.countdown)
 
-    async def process_async_within_lock(
+    def process_impl_within_lock(
         self,
         *,
         db_session,
@@ -101,7 +102,7 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
         success = None
         if notify:
             notifier = Notifier(commit, commit_yaml)
-            success = await notifier.notify()
+            success = async_to_sync(notifier.notify)()
 
         log.info(
             "Finished bundle analysis notify",

--- a/tasks/bundle_analysis_processor.py
+++ b/tasks/bundle_analysis_processor.py
@@ -61,7 +61,7 @@ class BundleAnalysisProcessorTask(
                 LockType.BUNDLE_ANALYSIS_PROCESSING,
                 retry_num=self.request.retries,
             ):
-                return await self.process_async_within_lock(
+                return self.process_impl_within_lock(
                     db_session=db_session,
                     repoid=repoid,
                     commitid=commitid,
@@ -73,7 +73,7 @@ class BundleAnalysisProcessorTask(
         except LockRetry as retry:
             self.retry(max_retries=5, countdown=retry.countdown)
 
-    async def process_async_within_lock(
+    def process_impl_within_lock(
         self,
         *,
         db_session,

--- a/tasks/bundle_analysis_processor.py
+++ b/tasks/bundle_analysis_processor.py
@@ -24,7 +24,7 @@ bundle_analysis_processor_task_name = (
 class BundleAnalysisProcessorTask(
     BaseCodecovTask, name=bundle_analysis_processor_task_name
 ):
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         # Celery `chain` injects this argument - it's the returned result

--- a/tasks/commit_update.py
+++ b/tasks/commit_update.py
@@ -1,5 +1,6 @@
 import logging
 
+from asgiref.sync import async_to_sync
 from shared.celery_config import commit_update_task_name
 from shared.torngit.exceptions import (
     TorngitClientError,
@@ -39,7 +40,7 @@ class CommitUpdateTask(BaseCodecovTask, name=commit_update_task_name):
         was_updated = False
         try:
             repository_service = get_repo_provider_service(repository, commit)
-            was_updated = await possibly_update_commit_from_provider_info(
+            was_updated = async_to_sync(possibly_update_commit_from_provider_info)(
                 commit, repository_service
             )
         except RepositoryWithoutValidBotError:

--- a/tasks/commit_update.py
+++ b/tasks/commit_update.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 
 
 class CommitUpdateTask(BaseCodecovTask, name=commit_update_task_name):
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         repoid: int,

--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 
 
 class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
-    async def run_async(self, db_session, comparison_id, *args, **kwargs):
+    def run_impl(self, db_session, comparison_id, *args, **kwargs):
         comparison = db_session.query(CompareCommit).get(comparison_id)
         repo = comparison.compare_commit.repository
         log_extra = dict(comparison_id=comparison_id, repoid=repo.repoid)

--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -1,6 +1,7 @@
 import logging
 from typing import List, Mapping
 
+from asgiref.sync import async_to_sync
 from shared.celery_config import compute_comparison_task_name
 from shared.components import Component
 from shared.helpers.flag import Flag
@@ -33,7 +34,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
         current_yaml = self.get_yaml_commit(comparison.compare_commit)
 
         with metrics.timer(f"{self.metrics_prefix}.get_comparison_proxy"):
-            comparison_proxy = await self.get_comparison_proxy(comparison, current_yaml)
+            comparison_proxy = self.get_comparison_proxy(comparison, current_yaml)
         if not comparison_proxy.has_project_coverage_base_report():
             comparison.error = CompareCommitError.missing_base_report.value
         elif not comparison_proxy.has_head_report():
@@ -47,7 +48,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
             return {"successful": False}
         try:
             with metrics.timer(f"{self.metrics_prefix}.serialize_impacted_files") as tm:
-                impacted_files = await self.serialize_impacted_files(comparison_proxy)
+                impacted_files = self.serialize_impacted_files(comparison_proxy)
         except TorngitRateLimitError:
             log.warning(
                 "Unable to compute comparison due to rate limit error",
@@ -68,29 +69,27 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
         log.info("Computing comparison successful", extra=log_extra)
         db_session.commit()
 
-        await self.compute_flag_comparison(db_session, comparison, comparison_proxy)
+        self.compute_flag_comparison(db_session, comparison, comparison_proxy)
         db_session.commit()
-        await self.compute_component_comparisons(
-            db_session, comparison, comparison_proxy
-        )
+        self.compute_component_comparisons(db_session, comparison, comparison_proxy)
         db_session.commit()
         return {"successful": True}
 
-    async def compute_flag_comparison(self, db_session, comparison, comparison_proxy):
+    def compute_flag_comparison(self, db_session, comparison, comparison_proxy):
         log_extra = dict(comparison_id=comparison.id)
         log.info("Computing flag comparisons", extra=log_extra)
         head_report_flags = comparison_proxy.comparison.head.report.flags
         if not head_report_flags:
             log.info("Head report does not have any flags", extra=log_extra)
             return
-        await self.create_or_update_flag_comparisons(
+        self.create_or_update_flag_comparisons(
             db_session,
             head_report_flags,
             comparison,
             comparison_proxy,
         )
 
-    async def create_or_update_flag_comparisons(
+    def create_or_update_flag_comparisons(
         self,
         db_session,
         head_report_flags: List[Flag],
@@ -99,7 +98,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
     ):
         repository_id = comparison.compare_commit.repository.repoid
         for flag_name, _ in head_report_flags.items():
-            totals = await self.get_flag_comparison_totals(flag_name, comparison_proxy)
+            totals = self.get_flag_comparison_totals(flag_name, comparison_proxy)
             repositoryflag = (
                 db_session.query(RepositoryFlag)
                 .filter_by(
@@ -150,7 +149,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
             extra=dict(number_stored=len(head_report_flags)),
         )
 
-    async def get_flag_comparison_totals(
+    def get_flag_comparison_totals(
         self,
         flag_name: str,
         comparison_proxy: ComparisonProxy,
@@ -166,7 +165,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
         totals = dict(
             head_totals=head_totals, base_totals=base_totals, patch_totals=None
         )
-        diff = await comparison_proxy.get_diff()
+        diff = async_to_sync(comparison_proxy.get_diff)()
         if diff:
             patch_totals = flag_head_report.apply_diff(diff)
             if patch_totals:
@@ -190,11 +189,11 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
         db_session.add(flag_comparison)
         db_session.flush()
 
-    async def compute_component_comparisons(
+    def compute_component_comparisons(
         self, db_session, comparison: CompareCommit, comparison_proxy: ComparisonProxy
     ):
         head_commit = comparison_proxy.comparison.head.commit
-        yaml: UserYaml = await get_current_yaml(
+        yaml: UserYaml = async_to_sync(get_current_yaml)(
             head_commit, comparison_proxy.repository_service
         )
         components = yaml.get_components()
@@ -206,11 +205,11 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
             ),
         )
         for component in components:
-            await self.compute_component_comparison(
+            self.compute_component_comparison(
                 db_session, comparison, comparison_proxy, component
             )
 
-    async def compute_component_comparison(
+    def compute_component_comparison(
         self,
         db_session,
         comparison: CompareCommit,
@@ -243,7 +242,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
             filtered.project_coverage_base.report.totals.asdict()
         )
         component_comparison.head_totals = filtered.head.report.totals.asdict()
-        diff = await comparison_proxy.get_diff()
+        diff = async_to_sync(comparison_proxy.get_diff)()
         if diff:
             patch_totals = filtered.head.report.apply_diff(diff)
             if patch_totals:
@@ -255,7 +254,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
     def get_yaml_commit(self, commit):
         return get_repo_yaml(commit.repository)
 
-    async def get_comparison_proxy(self, comparison, current_yaml):
+    def get_comparison_proxy(self, comparison, current_yaml):
         compare_commit = comparison.compare_commit
         base_commit = comparison.base_commit
         report_service = ReportService(current_yaml)
@@ -279,8 +278,8 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
             )
         )
 
-    async def serialize_impacted_files(self, comparison_proxy):
-        return await comparison_proxy.get_impacted_files()
+    def serialize_impacted_files(self, comparison_proxy):
+        return async_to_sync(comparison_proxy.get_impacted_files)()
 
     def store_results(self, comparison, impacted_files):
         repository = comparison.compare_commit.repository

--- a/tasks/crontasks.py
+++ b/tasks/crontasks.py
@@ -32,9 +32,7 @@ class CodecovCronTask(BaseCodecovTask):
         """
         raise NotImplementedError()
 
-    async def run_async(
-        self, db_session, *args, cron_task_generation_time_iso, **kwargs
-    ):
+    def run_impl(self, db_session, *args, cron_task_generation_time_iso, **kwargs):
         lock_name = f"worker.executionlock.{self.name}"
         redis_connection = get_redis_connection()
         generation_time = datetime.fromisoformat(cron_task_generation_time_iso)

--- a/tasks/crontasks.py
+++ b/tasks/crontasks.py
@@ -58,7 +58,7 @@ class CodecovCronTask(BaseCodecovTask):
                     last_executed_key, min_seconds_interval, generation_time.timestamp()
                 )
                 log.info("Executing cron task")
-                result = await self.run_cron_task(db_session, *args, **kwargs)
+                result = self.run_cron_task(db_session, *args, **kwargs)
                 return {"executed": True, "result": result}
         except LockError:
             log.info("Not executing cron task since another one is already running it")

--- a/tasks/delete_owner.py
+++ b/tasks/delete_owner.py
@@ -20,7 +20,7 @@ class DeleteOwnerTask(BaseCodecovTask, name=delete_owner_task_name):
     - Cascading deletes of repos, pulls, and branches for the owner
     """
 
-    async def run_async(self, db_session, ownerid):
+    def run_impl(self, db_session, ownerid):
         log.info("Delete owner", extra=dict(ownerid=ownerid))
         owner = db_session.query(Owner).filter(Owner.ownerid == ownerid).first()
 

--- a/tasks/flush_repo.py
+++ b/tasks/flush_repo.py
@@ -171,7 +171,7 @@ class FlushRepoTask(BaseCodecovTask, name="app.tasks.flush_repo.FlushRepo"):
         return deleted_pulls
 
     @sentry_sdk.trace
-    async def run_async(
+    def run_impl(
         self, db_session: Session, *, repoid: int, **kwargs
     ) -> FlushRepoTaskReturnType:
         log.info("Deleting repo contents", extra=dict(repoid=repoid))

--- a/tasks/github_marketplace.py
+++ b/tasks/github_marketplace.py
@@ -19,7 +19,7 @@ class SyncPlansTask(BaseCodecovTask, name=ghm_sync_plans_task_name):
     Sync GitHub marketplace plans
     """
 
-    async def run_async(self, db_session, sender=None, account=None, action=None):
+    def run_impl(self, db_session, sender=None, account=None, action=None):
         """
         Sender: The person who took the action that triggered the webhook. Ex:
         { "login":"username", "id":3877742, "type":"User", ...,  "email":"username@email.com" }

--- a/tasks/health_check.py
+++ b/tasks/health_check.py
@@ -47,7 +47,7 @@ class HealthCheckTask(CodecovCronTask, name=health_check_task_name):
         else:
             return redis_service.get_redis_connection()
 
-    async def run_cron_task(self, db_session, *args, **kwargs):
+    def run_cron_task(self, db_session, *args, **kwargs):
         queue_names = self._get_all_queue_names_from_config()
         redis = self._get_correct_redis_connection()
         for q in queue_names:

--- a/tasks/hourly_check.py
+++ b/tasks/hourly_check.py
@@ -13,7 +13,7 @@ class HourlyCheckTask(CodecovCronTask, name=hourly_check_task_name):
     def get_min_seconds_interval_between_executions(cls):
         return 3300  # 55 minutes
 
-    async def run_cron_task(self, db_session, *args, **kwargs):
+    def run_cron_task(self, db_session, *args, **kwargs):
         log.info("Doing hourly check")
         metrics.incr(f"{self.metrics_prefix}.checks")
         return {"checked": True}

--- a/tasks/http_request.py
+++ b/tasks/http_request.py
@@ -14,7 +14,7 @@ class HTTPRequestTask(BaseCodecovTask, name="app.tasks.http_request.HTTPRequest"
     Task for making generic HTTP requests.
     """
 
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         url,

--- a/tasks/http_request.py
+++ b/tasks/http_request.py
@@ -39,8 +39,8 @@ class HTTPRequestTask(BaseCodecovTask, name="app.tasks.http_request.HTTPRequest"
         log.info("HTTP request", extra=params)
 
         try:
-            async with httpx.AsyncClient() as client:
-                res = await client.request(**params)
+            with httpx.Client() as client:
+                res = client.request(**params)
 
             if res.status_code >= 500:
                 # server error, we can retry later

--- a/tasks/label_analysis.py
+++ b/tasks/label_analysis.py
@@ -80,7 +80,7 @@ class LabelAnalysisRequestProcessingTask(
         self.dbsession = None
         self.metrics_context = None
 
-    async def run_async(self, db_session, request_id, *args, **kwargs):
+    def run_impl(self, db_session, request_id, *args, **kwargs):
         self.errors = []
         self.dbsession = db_session
         label_analysis_request = (

--- a/tasks/manual_trigger.py
+++ b/tasks/manual_trigger.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 class ManualTriggerTask(
     BaseCodecovTask, name=manual_upload_completion_trigger_task_name
 ):
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         *,

--- a/tasks/manual_trigger.py
+++ b/tasks/manual_trigger.py
@@ -48,7 +48,7 @@ class ManualTriggerTask(
                 timeout=60 * 5,
                 blocking_timeout=5,
             ):
-                return await self.process_async_within_lock(
+                return self.process_impl_within_lock(
                     db_session=db_session,
                     repoid=repoid,
                     commitid=commitid,
@@ -68,7 +68,7 @@ class ManualTriggerTask(
             )
             return {"notifications_called": False, "message": "Unable to acquire lock"}
 
-    async def process_async_within_lock(
+    def process_impl_within_lock(
         self,
         *,
         db_session,

--- a/tasks/mutation_test_upload.py
+++ b/tasks/mutation_test_upload.py
@@ -7,7 +7,7 @@ from tasks.base import BaseCodecovTask
 
 # TODO: Move task name to shared
 class MutationTestUploadTask(BaseCodecovTask, name="app.tasks.mutation_test.upload"):
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         *,

--- a/tasks/new_user_activated.py
+++ b/tasks/new_user_activated.py
@@ -33,7 +33,7 @@ class NewUserActivatedTask(BaseCodecovTask, name=new_user_activated_task_name):
             "upgrade" decoration
     """
 
-    async def run_async(self, db_session, org_ownerid, user_ownerid, *args, **kwargs):
+    def run_impl(self, db_session, org_ownerid, user_ownerid, *args, **kwargs):
         log.info(
             "New user activated",
             extra=dict(org_ownerid=org_ownerid, user_ownerid=user_ownerid),

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -48,7 +48,7 @@ log = logging.getLogger(__name__)
 class NotifyTask(BaseCodecovTask, name=notify_task_name):
     throws = (SoftTimeLimitExceeded,)
 
-    async def run_async(
+    def run_impl(
         self,
         db_session: Session,
         *,
@@ -86,7 +86,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 lock_type=LockType.NOTIFICATION, retry_num=self.request.retries
             ):
                 lock_acquired = True
-                return await self.run_async_within_lock(
+                return await self.run_impl_within_lock(
                     db_session,
                     repoid=repoid,
                     commitid=commitid,
@@ -125,7 +125,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
         if checkpoints.data:
             checkpoints.log(checkpoint)
 
-    async def run_async_within_lock(
+    def run_impl_within_lock(
         self,
         db_session: Session,
         *,

--- a/tasks/plan_manager_task.py
+++ b/tasks/plan_manager_task.py
@@ -24,7 +24,7 @@ class DailyPlanManagerTask(CodecovCronTask, name=daily_plan_manager_task_name):
     def get_min_seconds_interval_between_executions(cls):
         return 86100  # 1 day - 5 minutes
 
-    async def run_cron_task(self, db_session: Session, *args, **kwargs):
+    def run_cron_task(self, db_session: Session, *args, **kwargs):
         # Query all org-wide tokens
         tokens_to_delete = (
             db_session.query(OrganizationLevelToken.id_)

--- a/tasks/preprocess_upload.py
+++ b/tasks/preprocess_upload.py
@@ -1,5 +1,6 @@
 import logging
 
+from asgiref.sync import async_to_sync
 from redis.exceptions import LockError
 from shared.torngit.exceptions import TorngitClientError, TorngitRepoNotFoundError
 from shared.validation.exceptions import InvalidYamlException
@@ -52,7 +53,7 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
                 timeout=60 * 5,
                 blocking_timeout=5,
             ):
-                return await self.process_async_within_lock(
+                return self.process_impl_within_lock(
                     db_session=db_session,
                     repoid=repoid,
                     commitid=commitid,
@@ -71,7 +72,7 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
             )
             return {"preprocessed_upload": False}
 
-    async def process_async_within_lock(
+    def process_impl_within_lock(
         self,
         *,
         db_session,
@@ -90,11 +91,11 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
         repository_service = self.get_repo_service(commit)
         # Makes sure that we can properly carry forward reports
         # By populating the commit info (if needed)
-        updated_commit = await possibly_update_commit_from_provider_info(
+        updated_commit = async_to_sync(possibly_update_commit_from_provider_info)(
             commit=commit, repository_service=repository_service
         )
         if repository_service:
-            commit_yaml = await self.fetch_commit_yaml_and_possibly_store(
+            commit_yaml = self.fetch_commit_yaml_and_possibly_store(
                 commit, repository_service
             )
         else:
@@ -105,7 +106,7 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
                 ownerid=repository.owner.ownerid,
             )
         report_service = ReportService(commit_yaml)
-        commit_report = await report_service.initialize_and_save_report(
+        commit_report = async_to_sync(report_service.initialize_and_save_report)(
             commit, report_code
         )
         return {
@@ -144,14 +145,14 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
 
         return repository_service
 
-    async def fetch_commit_yaml_and_possibly_store(self, commit, repository_service):
+    def fetch_commit_yaml_and_possibly_store(self, commit, repository_service):
         repository = commit.repository
         try:
             log.info(
                 "Fetching commit yaml from provider for commit",
                 extra=dict(repoid=commit.repoid, commit=commit.commitid),
             )
-            commit_yaml = await fetch_commit_yaml_from_provider(
+            commit_yaml = async_to_sync(fetch_commit_yaml_from_provider)(
                 commit, repository_service
             )
             save_repo_yaml_to_database_if_needed(commit, commit_yaml)

--- a/tasks/preprocess_upload.py
+++ b/tasks/preprocess_upload.py
@@ -31,7 +31,7 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
     uploading a report to codecov
     """
 
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         *,

--- a/tasks/profiling_collection.py
+++ b/tasks/profiling_collection.py
@@ -23,7 +23,7 @@ log = logging.getLogger(__name__)
 
 
 class ProfilingCollectionTask(BaseCodecovTask, name=profiling_collection_task_name):
-    async def run_async(self, db_session: Session, *, profiling_id: int, **kwargs):
+    def run_impl(self, db_session: Session, *, profiling_id: int, **kwargs):
         redis_connection = get_redis_connection()
         try:
             with redis_connection.lock(

--- a/tasks/profiling_find_uncollected.py
+++ b/tasks/profiling_find_uncollected.py
@@ -17,7 +17,7 @@ class FindUncollectedProfilingsTask(CodecovCronTask, name=profiling_finding_task
     def get_min_seconds_interval_between_executions(cls):
         return 800
 
-    async def run_cron_task(self, db_session, *args, **kwargs):
+    def run_cron_task(self, db_session, *args, **kwargs):
         min_interval_profilings = timedelta(hours=MIN_INTERVAL_PROFILINGS_HOURS)
         now = get_utc_now()
         query = (

--- a/tasks/profiling_normalizer.py
+++ b/tasks/profiling_normalizer.py
@@ -24,9 +24,7 @@ log = logging.getLogger(__name__)
 
 
 class ProfilingNormalizerTask(BaseCodecovTask, name=profiling_normalization_task_name):
-    async def run_async(
-        self, db_session: Session, *, profiling_upload_id: int, **kwargs
-    ):
+    def run_impl(self, db_session: Session, *, profiling_upload_id: int, **kwargs):
         profiling_upload = (
             db_session.query(ProfilingUpload).filter_by(id=profiling_upload_id).first()
         )

--- a/tasks/profiling_summarization.py
+++ b/tasks/profiling_summarization.py
@@ -18,7 +18,7 @@ log = logging.getLogger(__name__)
 class ProfilingSummarizationTask(
     BaseCodecovTask, name=profiling_summarization_task_name
 ):
-    async def run_async(self, db_session: Session, *, profiling_id: int, **kwargs):
+    def run_impl(self, db_session: Session, *, profiling_id: int, **kwargs):
         profiling = db_session.query(ProfilingCommit).filter_by(id=profiling_id).first()
         try:
             joined_execution_counts = json.loads(

--- a/tasks/save_commit_measurements.py
+++ b/tasks/save_commit_measurements.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 class SaveCommitMeasurementsTask(
     BaseCodecovTask, name=timeseries_save_commit_measurements_task_name
 ):
-    async def run_async(
+    def run_impl(
         self,
         db_session: Session,
         commitid: str,

--- a/tasks/save_report_results.py
+++ b/tasks/save_report_results.py
@@ -25,7 +25,7 @@ log = logging.getLogger(__name__)
 class SaveReportResultsTask(
     BaseCodecovTask, name="app.tasks.reports.save_report_results"
 ):
-    async def run_async(
+    def run_impl(
         self, db_session, *, repoid, commitid, report_code, current_yaml, **kwargs
     ):
         commit = self.fetch_commit(db_session, repoid, commitid)

--- a/tasks/save_report_results.py
+++ b/tasks/save_report_results.py
@@ -1,5 +1,6 @@
 import logging
 
+from asgiref.sync import async_to_sync
 from shared.reports.readonly import ReadOnlyReport
 from shared.yaml import UserYaml
 
@@ -38,12 +39,10 @@ class SaveReportResultsTask(
                 "reason": "repository without valid bot",
             }
 
-        current_yaml = await self.fetch_yaml_dict(
-            current_yaml, commit, repository_service
-        )
-        enriched_pull = await fetch_and_update_pull_request_information_from_commit(
-            repository_service, commit, current_yaml
-        )
+        current_yaml = self.fetch_yaml_dict(current_yaml, commit, repository_service)
+        enriched_pull = async_to_sync(
+            fetch_and_update_pull_request_information_from_commit
+        )(repository_service, commit, current_yaml)
         base_commit = self.fetch_base_commit(commit, enriched_pull)
         base_report, head_report = self.fetch_base_and_head_reports(
             current_yaml, commit, base_commit, report_code
@@ -79,7 +78,7 @@ class SaveReportResultsTask(
             notifier_site_settings=True,
             current_yaml=current_yaml,
         )
-        result = await notifier.build_payload(comparison)
+        result = async_to_sync(notifier.build_payload)(comparison)
         report = self.fetch_report(commit, report_code)
         log.info(
             "Saving report results into the db",
@@ -113,9 +112,9 @@ class SaveReportResultsTask(
             base_commit = self.fetch_parent(commit)
         return base_commit
 
-    async def fetch_yaml_dict(self, current_yaml, commit, repository_service):
+    def fetch_yaml_dict(self, current_yaml, commit, repository_service):
         if current_yaml is None:
-            current_yaml = await get_current_yaml(commit, repository_service)
+            current_yaml = async_to_sync(get_current_yaml)(commit, repository_service)
         else:
             current_yaml = UserYaml.from_dict(current_yaml)
         return current_yaml

--- a/tasks/send_email.py
+++ b/tasks/send_email.py
@@ -14,7 +14,7 @@ log = logging.getLogger(__name__)
 
 
 class SendEmailTask(BaseCodecovTask, name=send_email_task_name):
-    async def run_async(
+    def run_impl(
         self, db_session, ownerid, template_name, from_addr, subject, **kwargs
     ):
         with metrics.timer("worker.tasks.send_email"):

--- a/tasks/static_analysis_suite_check.py
+++ b/tasks/static_analysis_suite_check.py
@@ -68,10 +68,10 @@ class StaticAnalysisSuiteCheckTask(BaseCodecovTask, name=static_analysis_task_na
                 )
 
         db_session.commit()
-        metrics_context.attempt_log_simple_metric(
+        metrics_context.log_simple_metric(
             "static_analysis.data_sent_for_commit", float(True)
         )
-        metrics_context.attempt_log_simple_metric(
+        metrics_context.log_simple_metric(
             "static_analysis.files_changed", changed_count
         )
         return {"successful": True, "changed_count": changed_count}

--- a/tasks/static_analysis_suite_check.py
+++ b/tasks/static_analysis_suite_check.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 
 
 class StaticAnalysisSuiteCheckTask(BaseCodecovTask, name=static_analysis_task_name):
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         *,

--- a/tasks/status_set_error.py
+++ b/tasks/status_set_error.py
@@ -1,5 +1,6 @@
 import logging
 
+from asgiref.sync import async_to_sync
 from shared.celery_config import status_set_error_task_name
 from shared.helpers.yaml import default_if_true
 from shared.utils.urls import make_url
@@ -34,13 +35,13 @@ class StatusSetErrorTask(BaseCodecovTask, name=status_set_error_task_name):
         commit = commits.first()
         assert commit, "Commit not found in database."
         repo_service = get_repo_provider_service(commit.repository)
-        current_yaml = await get_current_yaml(commit, repo_service)
+        current_yaml = async_to_sync(get_current_yaml)(commit, repo_service)
         settings = read_yaml_field(current_yaml, ("coverage", "status"))
 
         status_set = False
 
         if settings and any(settings.values()):
-            statuses = await repo_service.get_commit_statuses(commitid)
+            statuses = async_to_sync(repo_service.get_commit_statuses)(commitid)
             url = make_url(repo_service, "commit", commitid)
             for context in ("project", "patch", "changes"):
                 if settings.get(context):
@@ -58,7 +59,7 @@ class StatusSetErrorTask(BaseCodecovTask, name=status_set_error_task_name):
                             message or "Coverage not measured fully because CI failed"
                         )
                         if context in statuses:
-                            await repo_service.set_commit_status(
+                            async_to_sync(repo_service.set_commit_status)(
                                 commit=commitid,
                                 status=state,
                                 context=context,

--- a/tasks/status_set_error.py
+++ b/tasks/status_set_error.py
@@ -59,13 +59,18 @@ class StatusSetErrorTask(BaseCodecovTask, name=status_set_error_task_name):
                             message or "Coverage not measured fully because CI failed"
                         )
                         if context in statuses:
-                            async_to_sync(repo_service.set_commit_status)(
-                                commit=commitid,
-                                status=state,
-                                context=context,
-                                description=message,
-                                url=url,
-                            )
+                            # async_to_sync has its own "context" argument so we
+                            # have to hide ours in a wrapper
+                            async def wrapper():
+                                await repo_service.set_commit_status(
+                                    commit=commitid,
+                                    status=state,
+                                    context=context,
+                                    description=message,
+                                    url=url,
+                                )
+
+                            async_to_sync(wrapper)()
                             status_set = True
                             log.info(
                                 "Status set",

--- a/tasks/status_set_error.py
+++ b/tasks/status_set_error.py
@@ -19,7 +19,7 @@ class StatusSetErrorTask(BaseCodecovTask, name=status_set_error_task_name):
     Set commit status upon error
     """
 
-    async def run_async(self, db_session, repoid, commitid, *, message=None, **kwargs):
+    def run_impl(self, db_session, repoid, commitid, *, message=None, **kwargs):
         log.info(
             "Set error",
             extra=dict(repoid=repoid, commitid=commitid, description=message),

--- a/tasks/status_set_pending.py
+++ b/tasks/status_set_pending.py
@@ -82,13 +82,18 @@ class StatusSetPendingTask(BaseCodecovTask, name=status_set_pending_task_name):
                             ), "Pending status disabled in YAML"
                             assert title not in statuses, "Pending status already set"
 
-                            async_to_sync(repo_service.set_commit_status)(
-                                commit=commitid,
-                                status="pending",
-                                context=title,
-                                description="Collecting reports and waiting for CI to complete",
-                                url=url,
-                            )
+                            # async_to_sync has its own "context" argument so we
+                            # have to hide ours in a wrapper
+                            async def wrapper():
+                                await repo_service.set_commit_status(
+                                    commit=commitid,
+                                    status="pending",
+                                    context=title,
+                                    description="Collecting reports and waiting for CI to complete",
+                                    url=url,
+                                )
+
+                            async_to_sync(wrapper)()
                             status_set = True
                             log.info(
                                 "Status set", extra=dict(context=title, state="pending")

--- a/tasks/status_set_pending.py
+++ b/tasks/status_set_pending.py
@@ -23,7 +23,7 @@ class StatusSetPendingTask(BaseCodecovTask, name=status_set_pending_task_name):
 
     throws = (AssertionError,)
 
-    async def run_async(
+    def run_impl(
         self, db_session, repoid, commitid, branch, on_a_pull_request, *args, **kwargs
     ):
         log.info(

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -167,14 +168,12 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         commits = None
         db_session.commit()
         try:
-            commits_future = repository_service.get_pull_request_commits(pull.pullid)
-            base_ancestors_tree_future = repository_service.get_ancestors_tree(
+            commits = async_to_sync(repository_service.get_pull_request_commits)(
+                pull.pullid
+            )
+            base_ancestors_tree = async_to_sync(repository_service.get_ancestors_tree)(
                 enriched_pull.provider_pull["base"]["branch"]
             )
-            commits, base_ancestors_tree = async_to_sync(
-                asyncio.gather(commits_future, base_ancestors_tree_future)
-            )
-
             commit_updates_done = self.update_pull_commits(
                 enriched_pull, commits, base_ancestors_tree
             )

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -49,7 +49,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         At the end we call the notify task to do notifications with the new information we have
     """
 
-    async def run_async(
+    def run_impl(
         self,
         db_session: sqlalchemy.orm.Session,
         *,
@@ -64,7 +64,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         lock_name = f"pullsync_{repoid}_{pullid}"
         try:
             with redis_connection.lock(lock_name, timeout=60 * 5, blocking_timeout=5):
-                return await self.run_async_within_lock(
+                return await self.run_impl_within_lock(
                     db_session,
                     redis_connection,
                     repoid=repoid,
@@ -84,7 +84,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                 "reason": "unable_fetch_lock",
             }
 
-    async def run_async_within_lock(
+    def run_impl_within_lock(
         self,
         db_session: sqlalchemy.orm.Session,
         redis_connection,

--- a/tasks/sync_repo_languages.py
+++ b/tasks/sync_repo_languages.py
@@ -21,7 +21,7 @@ REPOSITORY_LANGUAGE_SYNC_THRESHOLD = 7
 
 
 class SyncRepoLanguagesTask(BaseCodecovTask, name=sync_repo_languages_task_name):
-    async def run_async(
+    def run_impl(
         self, db_session: Session, repoid: String, manual_trigger=False, *args, **kwargs
     ):
         repository = db_session.query(Repository).get(repoid)

--- a/tasks/sync_repo_languages.py
+++ b/tasks/sync_repo_languages.py
@@ -1,5 +1,6 @@
 import logging
 
+from asgiref.sync import async_to_sync
 from shared.celery_config import sync_repo_languages_task_name
 from shared.torngit.exceptions import TorngitError
 from sqlalchemy import String
@@ -58,11 +59,11 @@ class SyncRepoLanguagesTask(BaseCodecovTask, name=sync_repo_languages_task_name)
                     or repository.owner.service == "bitbucket_server"
                 )
                 if is_bitbucket_call:
-                    languages = await repository_service.get_repo_languages(
+                    languages = async_to_sync(repository_service.get_repo_languages)(
                         token=None, language=repository.language
                     )
                 else:
-                    languages = await repository_service.get_repo_languages()
+                    languages = async_to_sync(repository_service.get_repo_languages)()
                 repository.languages = languages
                 repository.languages_last_updated = now
                 db_session.flush()

--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -51,7 +51,7 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
 
     ignore_result = False
 
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         # `previous_results`` is added by celery if the task is chained.

--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -144,7 +144,7 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
         repos_to_search = [
             x[1] for x in repository_service_ids if x[0] in missing_repo_service_ids
         ]
-        async for repo_data in git.get_repos_from_nodeids_generator(
+        for repo_data in git.get_repos_from_nodeids_generator(
             repos_to_search, owner.username
         ):
             # Insert those repos
@@ -238,7 +238,7 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
         if repository_service_ids:
             # This flow is different from the ones below because the API already informed us the repos affected
             # So we can update those values directly
-            repoids_added = self.sync_repos_affected_repos_known(
+            repoids_added = await self.sync_repos_affected_repos_known(
                 db_session, git, owner, repository_service_ids
             )
             repoids = repoids_added

--- a/tasks/sync_teams.py
+++ b/tasks/sync_teams.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 
+from asgiref.sync import async_to_sync
 from shared.celery_config import sync_teams_task_name
 from sqlalchemy.dialects.postgresql import insert
 
@@ -29,7 +30,7 @@ class SyncTeamsTask(BaseCodecovTask, name=sync_teams_task_name):
         )
 
         # get list of teams with username, name, email, id (service_id), etc
-        teams = await git.list_teams()
+        teams = async_to_sync(git.list_teams)()
 
         updated_teams = []
 

--- a/tasks/sync_teams.py
+++ b/tasks/sync_teams.py
@@ -17,7 +17,7 @@ class SyncTeamsTask(BaseCodecovTask, name=sync_teams_task_name):
 
     ignore_result = False
 
-    async def run_async(self, db_session, ownerid, *, username=None, **kwargs):
+    def run_impl(self, db_session, ownerid, *, username=None, **kwargs):
         log.info("Sync teams", extra=dict(ownerid=ownerid, username=username))
         owner = db_session.query(Owner).filter(Owner.ownerid == ownerid).first()
 

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -22,7 +22,7 @@ test_results_finisher_task_name = "app.tasks.test_results.TestResultsFinisherTas
 
 
 class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_name):
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         chord_result: Dict[str, Any],

--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -43,7 +43,7 @@ class ParserNotSupportedError(Exception):
 class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task_name):
     __test__ = False
 
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         *,

--- a/tasks/tests/integration/test_ai_pr_review.py
+++ b/tasks/tests/integration/test_ai_pr_review.py
@@ -5,8 +5,7 @@ from tasks.ai_pr_review import AiPrReviewTask
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_ai_pr_review_task(
+def test_ai_pr_review_task(
     mocker,
     dbsession,
 ):

--- a/tasks/tests/integration/test_ai_pr_review.py
+++ b/tasks/tests/integration/test_ai_pr_review.py
@@ -20,7 +20,7 @@ async def test_ai_pr_review_task(
 
     task = AiPrReviewTask()
 
-    result = await task.run_async(
+    result = task.run_impl(
         dbsession,
         repoid=repository.repoid,
         pullid=123,

--- a/tasks/tests/integration/test_ghm_sync_plans.py
+++ b/tasks/tests/integration/test_ghm_sync_plans.py
@@ -62,9 +62,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         action = "purchased"
 
         task = SyncPlansTask()
-        result = await task.run_async(
-            dbsession, sender=sender, account=account, action=action
-        )
+        result = task.run_impl(dbsession, sender=sender, account=account, action=action)
         assert result["plan_type_synced"] == "paid"
 
         assert owner.plan == "users"
@@ -95,9 +93,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         action = "purchased"
 
         task = SyncPlansTask()
-        result = await task.run_async(
-            dbsession, sender=sender, account=account, action=action
-        )
+        result = task.run_impl(dbsession, sender=sender, account=account, action=action)
         assert result["plan_type_synced"] == "paid"
 
         owner = (
@@ -136,9 +132,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         action = "purchased"
 
         task = SyncPlansTask()
-        result = await task.run_async(
-            dbsession, sender=sender, account=account, action=action
-        )
+        result = task.run_impl(dbsession, sender=sender, account=account, action=action)
         assert result["plan_type_synced"] == "free"
 
         owner = (
@@ -214,9 +208,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         action = "cancelled"
 
         task = SyncPlansTask()
-        result = await task.run_async(
-            dbsession, sender=sender, account=account, action=action
-        )
+        result = task.run_impl(dbsession, sender=sender, account=account, action=action)
         assert result["plan_type_synced"] == "free"
 
         dbsession.commit()

--- a/tasks/tests/integration/test_ghm_sync_plans.py
+++ b/tasks/tests/integration/test_ghm_sync_plans.py
@@ -27,8 +27,7 @@ C/tY+lZIEO1Gg/FxSMB+hwwhwfSuE3WohZfEcSy+R48=
 
 @pytest.mark.integration
 class TestGHMarketplaceSyncPlansTask(object):
-    @pytest.mark.asyncio
-    async def test_purchase_by_existing_owner(
+    def test_purchase_by_existing_owner(
         self, dbsession, mocker, mock_configuration, codecov_vcr
     ):
         mock_configuration.loaded_files[
@@ -70,8 +69,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         assert owner.plan_auto_activate is True
         assert owner.plan_user_count == 10
 
-    @pytest.mark.asyncio
-    async def test_purchase_new_owner(
+    def test_purchase_new_owner(
         self, dbsession, mocker, mock_configuration, codecov_vcr
     ):
         mock_configuration.loaded_files[
@@ -109,8 +107,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         assert owner.plan_auto_activate is True
         assert owner.plan_user_count == 10
 
-    @pytest.mark.asyncio
-    async def test_purchase_listing_not_found(
+    def test_purchase_listing_not_found(
         self, dbsession, mocker, mock_configuration, codecov_vcr
     ):
         mock_configuration.loaded_files[
@@ -148,8 +145,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         assert owner.plan_user_count == 1
         assert owner.plan_activated_users is None
 
-    @pytest.mark.asyncio
-    async def test_cancelled(self, dbsession, mocker, mock_configuration, codecov_vcr):
+    def test_cancelled(self, dbsession, mocker, mock_configuration, codecov_vcr):
         mock_configuration.loaded_files[
             ("github", "integration", "pem")
         ] = fake_private_key
@@ -233,10 +229,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         for repo in repos:
             assert repo.activated is False
 
-    @pytest.mark.asyncio
-    async def test_sync_all_plans(
-        self, dbsession, mocker, mock_configuration, codecov_vcr
-    ):
+    def test_sync_all_plans(self, dbsession, mocker, mock_configuration, codecov_vcr):
         mock_configuration.loaded_files[
             ("github", "integration", "pem")
         ] = fake_private_key

--- a/tasks/tests/integration/test_http_request_task.py
+++ b/tasks/tests/integration/test_http_request_task.py
@@ -7,9 +7,8 @@ from tasks.http_request import HTTPRequestTask
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
 class TestHTTPRequestTask:
-    async def test_http_request_run_impl_200(self, dbsession, codecov_vcr):
+    def test_http_request_run_impl_200(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         res = task.run_impl(
             dbsession,
@@ -23,7 +22,7 @@ class TestHTTPRequestTask:
         )
         assert res == {"response": "ok", "status_code": 200, "successful": True}
 
-    async def test_http_request_run_impl_400(self, dbsession, codecov_vcr):
+    def test_http_request_run_impl_400(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         res = task.run_impl(
             dbsession,
@@ -41,7 +40,7 @@ class TestHTTPRequestTask:
             "successful": False,
         }
 
-    async def test_http_request_run_impl_500(self, dbsession, codecov_vcr):
+    def test_http_request_run_impl_500(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         with pytest.raises(Retry):
             task.run_impl(
@@ -55,7 +54,7 @@ class TestHTTPRequestTask:
                 data=json.dumps({"testing": 123}),
             )
 
-    async def test_http_request_run_impl_connection_error(self, dbsession, codecov_vcr):
+    def test_http_request_run_impl_connection_error(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         with pytest.raises(Retry):
             task.run_impl(

--- a/tasks/tests/integration/test_http_request_task.py
+++ b/tasks/tests/integration/test_http_request_task.py
@@ -8,7 +8,7 @@ from tasks.http_request import HTTPRequestTask
 
 @pytest.mark.integration
 class TestHTTPRequestTask:
-    def test_http_request_run_impl_200(self, dbsession, codecov_vcr):
+    def test_http_request_run_async_200(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         res = task.run_impl(
             dbsession,
@@ -22,7 +22,7 @@ class TestHTTPRequestTask:
         )
         assert res == {"response": "ok", "status_code": 200, "successful": True}
 
-    def test_http_request_run_impl_400(self, dbsession, codecov_vcr):
+    def test_http_request_run_async_400(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         res = task.run_impl(
             dbsession,
@@ -40,7 +40,7 @@ class TestHTTPRequestTask:
             "successful": False,
         }
 
-    def test_http_request_run_impl_500(self, dbsession, codecov_vcr):
+    def test_http_request_run_async_500(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         with pytest.raises(Retry):
             task.run_impl(
@@ -54,7 +54,7 @@ class TestHTTPRequestTask:
                 data=json.dumps({"testing": 123}),
             )
 
-    def test_http_request_run_impl_connection_error(self, dbsession, codecov_vcr):
+    def test_http_request_run_async_connection_error(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         with pytest.raises(Retry):
             task.run_impl(

--- a/tasks/tests/integration/test_http_request_task.py
+++ b/tasks/tests/integration/test_http_request_task.py
@@ -9,9 +9,9 @@ from tasks.http_request import HTTPRequestTask
 @pytest.mark.integration
 @pytest.mark.asyncio
 class TestHTTPRequestTask:
-    async def test_http_request_run_async_200(self, dbsession, codecov_vcr):
+    async def test_http_request_run_impl_200(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
-        res = await task.run_async(
+        res = task.run_impl(
             dbsession,
             url="http://mockbin.org/bin/a1316495-ee65-4eab-b8e3-d5cb7cfc7519?foo=bar&foo=baz",
             method="POST",
@@ -23,9 +23,9 @@ class TestHTTPRequestTask:
         )
         assert res == {"response": "ok", "status_code": 200, "successful": True}
 
-    async def test_http_request_run_async_400(self, dbsession, codecov_vcr):
+    async def test_http_request_run_impl_400(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
-        res = await task.run_async(
+        res = task.run_impl(
             dbsession,
             url="http://mockbin.org/bin/e4e9db83-b7b9-4a50-b929-d672bcc8d075?foo=bar&foo=baz",
             method="POST",
@@ -41,10 +41,10 @@ class TestHTTPRequestTask:
             "successful": False,
         }
 
-    async def test_http_request_run_async_500(self, dbsession, codecov_vcr):
+    async def test_http_request_run_impl_500(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         with pytest.raises(Retry):
-            await task.run_async(
+            task.run_impl(
                 dbsession,
                 url="http://mockbin.org/bin/c0052243-3391-4a30-bed7-066e4cd04074?foo=bar&foo=baz",
                 method="POST",
@@ -55,12 +55,10 @@ class TestHTTPRequestTask:
                 data=json.dumps({"testing": 123}),
             )
 
-    async def test_http_request_run_async_connection_error(
-        self, dbsession, codecov_vcr
-    ):
+    async def test_http_request_run_impl_connection_error(self, dbsession, codecov_vcr):
         task = HTTPRequestTask()
         with pytest.raises(Retry):
-            await task.run_async(
+            task.run_impl(
                 dbsession,
                 url="http://probablynotavaliddomain.com",
                 method="POST",

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -196,7 +196,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -383,7 +383,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -611,7 +611,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -831,7 +831,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -1277,7 +1277,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -71,7 +71,7 @@ class TestNotifyTask(object):
             )
             mock_storage.write_file("archive", master_chunks_url, content)
         task = NotifyTask()
-        result = await task.run_async(
+        result = task.run_impl(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml={}
         )
         expected_result = {
@@ -196,7 +196,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -383,7 +383,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -611,7 +611,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -831,7 +831,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -1277,7 +1277,7 @@ class TestNotifyTask(object):
                 f"v4/repos/{archive_hash}/commits/{master_commit.commitid}/chunks.txt"
             )
             mock_storage.write_file("archive", master_chunks_url, content)
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -15,8 +15,7 @@ sample_token = "ghp_test6ldgmyaglf73gcnbi0kprz7dyjz6nzgn"
 @pytest.mark.integration
 class TestNotifyTask(object):
     @patch("requests.post")
-    @pytest.mark.asyncio
-    async def test_simple_call_no_notifiers(
+    def test_simple_call_no_notifiers(
         self,
         mock_requests_post,
         dbsession,
@@ -142,8 +141,7 @@ class TestNotifyTask(object):
         assert result == expected_result
 
     @patch("requests.post")
-    @pytest.mark.asyncio
-    async def test_simple_call_only_status_notifiers(
+    def test_simple_call_only_status_notifiers(
         self,
         mock_post_request,
         dbsession,
@@ -328,8 +326,7 @@ class TestNotifyTask(object):
         assert result == expected_result
 
     @patch("requests.post")
-    @pytest.mark.asyncio
-    async def test_simple_call_only_status_notifiers_no_pull_request(
+    def test_simple_call_only_status_notifiers_no_pull_request(
         self,
         mock_post_request,
         dbsession,
@@ -555,8 +552,7 @@ class TestNotifyTask(object):
         assert result == expected_result
 
     @patch("requests.post")
-    @pytest.mark.asyncio
-    async def test_simple_call_only_status_notifiers_with_pull_request(
+    def test_simple_call_only_status_notifiers_with_pull_request(
         self,
         mock_post_request,
         dbsession,
@@ -771,8 +767,7 @@ class TestNotifyTask(object):
         assert result == expected_result
 
     @patch("requests.post")
-    @pytest.mark.asyncio
-    async def test_simple_call_status_and_notifiers(
+    def test_simple_call_status_and_notifiers(
         self,
         mock_post_request,
         dbsession,
@@ -1234,8 +1229,7 @@ class TestNotifyTask(object):
         )
         assert result == expected_result
 
-    @pytest.mark.asyncio
-    async def test_notifier_call_no_head_commit_report(
+    def test_notifier_call_no_head_commit_report(
         self, dbsession, mocker, codecov_vcr, mock_storage, mock_configuration
     ):
         mock_configuration.params["setup"][

--- a/tasks/tests/integration/test_send_email_task.py
+++ b/tasks/tests/integration/test_send_email_task.py
@@ -13,8 +13,7 @@ username = "test_username"
 
 @pytest.mark.integration
 class TestSendEmailTask:
-    @pytest.mark.asyncio
-    async def test_send_email_integration(
+    def test_send_email_integration(
         self,
         mocker,
         dbsession,

--- a/tasks/tests/integration/test_send_email_task.py
+++ b/tasks/tests/integration/test_send_email_task.py
@@ -38,7 +38,7 @@ class TestSendEmailTask:
 
         assert res.status_code == 200
 
-        result = await task.run_async(
+        result = task.run_impl(
             dbsession,
             owner.ownerid,
             "test",

--- a/tasks/tests/integration/test_status_set_error_task.py
+++ b/tasks/tests/integration/test_status_set_error_task.py
@@ -7,8 +7,7 @@ from tasks.status_set_error import StatusSetErrorTask
 
 @pytest.mark.integration
 class TestStatusSetErrorTask(object):
-    @pytest.mark.asyncio
-    async def test_set_error(self, dbsession, mocker, mock_configuration, codecov_vcr):
+    def test_set_error(self, dbsession, mocker, mock_configuration, codecov_vcr):
         repository = RepositoryFactory.create(
             owner__username="ThiagoCodecov",
             owner__service="github",

--- a/tasks/tests/integration/test_status_set_error_task.py
+++ b/tasks/tests/integration/test_status_set_error_task.py
@@ -28,7 +28,7 @@ class TestStatusSetErrorTask(object):
         dbsession.add(commit)
 
         task = StatusSetErrorTask()
-        result = await task.run_async(
+        result = task.run_impl(
             dbsession, repository.repoid, commit.commitid, message="Test err message"
         )
         expected_result = {"status_set": True}

--- a/tasks/tests/integration/test_status_set_pending_task.py
+++ b/tasks/tests/integration/test_status_set_pending_task.py
@@ -7,8 +7,7 @@ from tasks.status_set_pending import StatusSetPendingTask
 
 @pytest.mark.integration
 class TestStatusSetPendingTask(object):
-    @pytest.mark.asyncio
-    async def test_set_pending(
+    def test_set_pending(
         self, dbsession, mocker, mock_configuration, codecov_vcr, mock_redis
     ):
         repository = RepositoryFactory.create(

--- a/tasks/tests/integration/test_status_set_pending_task.py
+++ b/tasks/tests/integration/test_status_set_pending_task.py
@@ -32,7 +32,7 @@ class TestStatusSetPendingTask(object):
         mock_redis.sismember.side_effect = [True]
 
         task = StatusSetPendingTask()
-        result = await task.run_async(
+        result = task.run_impl(
             dbsession, repository.repoid, commit.commitid, commit.branch, True
         )
         expected_result = {"status_set": True}

--- a/tasks/tests/integration/test_sync_pull.py
+++ b/tasks/tests/integration/test_sync_pull.py
@@ -88,7 +88,7 @@ class TestPullSyncTask(object):
         dbsession.add(head_commit)
         dbsession.add(pull)
         dbsession.flush()
-        res = await task.run_async(dbsession, repoid=pull.repoid, pullid=pull.pullid)
+        res = task.run_impl(dbsession, repoid=pull.repoid, pullid=pull.pullid)
         assert {
             "notifier_called": True,
             "commit_updates_done": {"merged_count": 0, "soft_deleted_count": 0},

--- a/tasks/tests/integration/test_sync_pull.py
+++ b/tasks/tests/integration/test_sync_pull.py
@@ -10,10 +10,7 @@ here = Path(__file__)
 
 
 class TestPullSyncTask(object):
-    @pytest.mark.asyncio
-    async def test_call_task(
-        self, dbsession, codecov_vcr, mock_storage, mocker, mock_redis
-    ):
+    def test_call_task(self, dbsession, codecov_vcr, mock_storage, mocker, mock_redis):
         mocker.patch.object(PullSyncTask, "app")
         task = PullSyncTask()
         repository = RepositoryFactory.create(

--- a/tasks/tests/integration/test_timeseries_backfill.py
+++ b/tasks/tests/integration/test_timeseries_backfill.py
@@ -10,7 +10,7 @@ from tasks.timeseries_backfill import TimeseriesBackfillCommitsTask
 
 @pytest.mark.integration
 @pytest.mark.asyncio
-async def test_backfill_dataset_run_async(dbsession, mocker, mock_storage):
+async def test_backfill_dataset_run_impl(dbsession, mocker, mock_storage):
     mocker.patch("services.timeseries.timeseries_enabled", return_value=True)
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=True)
     mocked_app = mocker.patch.object(
@@ -55,7 +55,7 @@ async def test_backfill_dataset_run_async(dbsession, mocker, mock_storage):
         MeasurementName.coverage.value,
         MeasurementName.flag_coverage.value,
     ]
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         commit_ids=[commit.id_],
         dataset_names=dataset_names,

--- a/tasks/tests/integration/test_timeseries_backfill.py
+++ b/tasks/tests/integration/test_timeseries_backfill.py
@@ -9,8 +9,7 @@ from tasks.timeseries_backfill import TimeseriesBackfillCommitsTask
 
 
 @pytest.mark.integration
-@pytest.mark.asyncio
-async def test_backfill_dataset_run_impl(dbsession, mocker, mock_storage):
+def test_backfill_dataset_run_impl(dbsession, mocker, mock_storage):
     mocker.patch("services.timeseries.timeseries_enabled", return_value=True)
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=True)
     mocked_app = mocker.patch.object(

--- a/tasks/tests/unit/test_backfill_commit_data_to_storage_task.py
+++ b/tasks/tests/unit/test_backfill_commit_data_to_storage_task.py
@@ -251,10 +251,7 @@ class TestBackfillCommitDataToStorageTask(object):
     @patch(
         "tasks.backfill_commit_data_to_storage.BackfillCommitDataToStorageTask.handle_all_report_rows"
     )
-    @pytest.mark.asyncio
-    async def test_run(
-        self, mock_handle_all_report_rows, mock_handle_report_json, dbsession
-    ):
+    def test_run(self, mock_handle_all_report_rows, mock_handle_report_json, dbsession):
         commit = CommitFactory()
         dbsession.add(commit)
         dbsession.flush()
@@ -276,8 +273,7 @@ class TestBackfillCommitDataToStorageTask(object):
     @patch(
         "tasks.backfill_commit_data_to_storage.BackfillCommitDataToStorageTask.handle_all_report_rows"
     )
-    @pytest.mark.asyncio
-    async def test_run_missing_commit(
+    def test_run_missing_commit(
         self, mock_handle_all_report_rows, mock_handle_report_json, dbsession
     ):
         mock_handle_all_report_rows.return_value = {"success": True, "errors": []}

--- a/tasks/tests/unit/test_backfill_commit_data_to_storage_task.py
+++ b/tasks/tests/unit/test_backfill_commit_data_to_storage_task.py
@@ -267,7 +267,7 @@ class TestBackfillCommitDataToStorageTask(object):
 
         assert dbsession.query(Commit).get(commit.id_) is not None
         task = BackfillCommitDataToStorageTask()
-        result = await task.run_async(dbsession, commitid=commit.id_)
+        result = task.run_impl(dbsession, commitid=commit.id_)
         assert result == {"success": False, "errors": ["missing_data"]}
 
     @patch(
@@ -288,5 +288,5 @@ class TestBackfillCommitDataToStorageTask(object):
 
         assert dbsession.query(Commit).get(-1) is None
         task = BackfillCommitDataToStorageTask()
-        result = await task.run_async(dbsession, commitid=-1)
+        result = task.run_impl(dbsession, commitid=-1)
         assert result == {"success": False, "errors": ["commit_not_found"]}

--- a/tasks/tests/unit/test_backfill_gh_app_installations.py
+++ b/tasks/tests/unit/test_backfill_gh_app_installations.py
@@ -28,8 +28,7 @@ def repo_obj(service_id, name, language, private, branch, using_integration):
 
 
 class TestBackfillWithPreviousGHAppInstallation(object):
-    @pytest.mark.asyncio
-    async def test_gh_app_with_selection_all(
+    def test_gh_app_with_selection_all(
         self, mocker, mock_repo_provider, dbsession: Session
     ):
         owner = OwnerFactory(service="github", integration_id=12345)
@@ -66,8 +65,7 @@ class TestBackfillWithPreviousGHAppInstallation(object):
         assert gh_app_installation.owner == owner
         assert gh_app_installation.repository_service_ids == None
 
-    @pytest.mark.asyncio
-    async def test_gh_app_with_specific_owner_ids(
+    def test_gh_app_with_specific_owner_ids(
         self, mocker, mock_repo_provider, dbsession: Session
     ):
         owner = OwnerFactory(service="github", integration_id=123)
@@ -126,8 +124,7 @@ class TestBackfillWithPreviousGHAppInstallation(object):
             == gh_app_installation_two.repository_service_ids
         )
 
-    @pytest.mark.asyncio
-    async def test_gh_app_without_all_repo_selection(
+    def test_gh_app_without_all_repo_selection(
         self, mocker, mock_repo_provider, dbsession: Session
     ):
         owner = OwnerFactory(service="github", integration_id=12345)
@@ -189,8 +186,7 @@ class TestBackfillWithPreviousGHAppInstallation(object):
 
 
 class TestBackfillOwnersWithIntegrationWithoutGHApp(object):
-    @pytest.mark.asyncio
-    async def test_no_previous_app_existing_repos_only(
+    def test_no_previous_app_existing_repos_only(
         self, mocker, mock_repo_provider, dbsession: Session
     ):
         owner = OwnerFactory(service="github", integration_id=12345)
@@ -243,8 +239,7 @@ class TestBackfillOwnersWithIntegrationWithoutGHApp(object):
                 in new_gh_app_installation.repository_service_ids
             )
 
-    @pytest.mark.asyncio
-    async def test_no_previous_app_some_existing_repos(
+    def test_no_previous_app_some_existing_repos(
         self, mocker, mock_repo_provider, dbsession: Session
     ):
         owner = OwnerFactory(service="github", integration_id=12345)
@@ -290,8 +285,7 @@ class TestBackfillOwnersWithIntegrationWithoutGHApp(object):
 
 
 class TestBackfillBothTypesOfOwners(object):
-    @pytest.mark.asyncio
-    async def test_backfill_with_both_types_of_owners(
+    def test_backfill_with_both_types_of_owners(
         self, mocker, mock_repo_provider, dbsession: Session
     ):
         owner = OwnerFactory(service="github", integration_id=12345)

--- a/tasks/tests/unit/test_backfill_gh_app_installations.py
+++ b/tasks/tests/unit/test_backfill_gh_app_installations.py
@@ -53,7 +53,7 @@ class TestBackfillWithPreviousGHAppInstallation(object):
         )
 
         task = BackfillGHAppInstallationsTask()
-        assert await task.run_async(dbsession, owner_ids=None) == {
+        assert task.run_impl(dbsession, owner_ids=None) == {
             "successful": True,
             "reason": "backfill task finished",
         }
@@ -101,7 +101,7 @@ class TestBackfillWithPreviousGHAppInstallation(object):
         )
 
         task = BackfillGHAppInstallationsTask()
-        assert await task.run_async(dbsession, owner_ids=[owner.ownerid]) == {
+        assert task.run_impl(dbsession, owner_ids=[owner.ownerid]) == {
             "successful": True,
             "reason": "backfill task finished",
         }
@@ -169,7 +169,7 @@ class TestBackfillWithPreviousGHAppInstallation(object):
         )
 
         task = BackfillGHAppInstallationsTask()
-        assert await task.run_async(dbsession, owner_ids=None) == {
+        assert task.run_impl(dbsession, owner_ids=None) == {
             "successful": True,
             "reason": "backfill task finished",
         }
@@ -223,7 +223,7 @@ class TestBackfillOwnersWithIntegrationWithoutGHApp(object):
         )
 
         task = BackfillGHAppInstallationsTask()
-        assert await task.run_async(dbsession, owner_ids=[owner.ownerid]) == {
+        assert task.run_impl(dbsession, owner_ids=[owner.ownerid]) == {
             "successful": True,
             "reason": "backfill task finished",
         }
@@ -272,7 +272,7 @@ class TestBackfillOwnersWithIntegrationWithoutGHApp(object):
         )
 
         task = BackfillGHAppInstallationsTask()
-        assert await task.run_async(dbsession, owner_ids=None) == {
+        assert task.run_impl(dbsession, owner_ids=None) == {
             "successful": True,
             "reason": "backfill task finished",
         }
@@ -331,7 +331,7 @@ class TestBackfillBothTypesOfOwners(object):
         )
 
         task = BackfillGHAppInstallationsTask()
-        assert await task.run_async(dbsession, owner_ids=None) == {
+        assert task.run_impl(dbsession, owner_ids=None) == {
             "successful": True,
             "reason": "backfill task finished",
         }

--- a/tasks/tests/unit/test_base.py
+++ b/tasks/tests/unit/test_base.py
@@ -41,7 +41,7 @@ class MockDateTime(datetime):
 
 
 class SampleTask(BaseCodecovTask, name="test.SampleTask"):
-    async def run_async(self, dbsession):
+    def run_impl(self, dbsession):
         return {"unusual": "return", "value": ["There"]}
 
 
@@ -51,7 +51,7 @@ class SampleTaskWithArbitraryError(
     def __init__(self, error):
         self.error = error
 
-    async def run_async(self, dbsession):
+    def run_impl(self, dbsession):
         raise self.error
 
     def retry(self):
@@ -65,7 +65,7 @@ class SampleTaskWithArbitraryPostgresError(
     def __init__(self, error):
         self.error = error
 
-    async def run_async(self, dbsession):
+    def run_impl(self, dbsession):
         raise DBAPIError("statement", "params", self.error)
 
     def retry(self):
@@ -74,12 +74,12 @@ class SampleTaskWithArbitraryPostgresError(
 
 
 class SampleTaskWithSoftTimeout(BaseCodecovTask, name="test.SampleTaskWithSoftTimeout"):
-    async def run_async(self, dbsession):
+    def run_impl(self, dbsession):
         raise SoftTimeLimitExceeded()
 
 
 class FailureSampleTask(BaseCodecovTask, name="test.FailureSampleTask"):
-    async def run_async(self, *args, **kwargs):
+    def run_impl(self, *args, **kwargs):
         raise Exception("Whhhhyyyyyyy")
 
 
@@ -331,7 +331,7 @@ class TestBaseCodecovTask(object):
 class TestBaseCodecovTaskHooks(object):
     def test_sample_task_success(self, celery_app, mocker):
         class SampleTask(BaseCodecovTask, name="test.SampleTask"):
-            async def run_async(self, dbsession):
+            def run_impl(self, dbsession):
                 return {"unusual": "return", "value": ["There"]}
 
         mock_metrics = mocker.patch("tasks.base.metrics.incr")
@@ -360,7 +360,7 @@ class TestBaseCodecovTaskHooks(object):
 
     def test_sample_task_failure(self, celery_app, mocker):
         class FailureSampleTask(BaseCodecovTask, name="test.FailureSampleTask"):
-            async def run_async(self, *args, **kwargs):
+            def run_impl(self, *args, **kwargs):
                 raise Exception("Whhhhyyyyyyy")
 
         mock_metrics = mocker.patch("tasks.base.metrics.incr")

--- a/tasks/tests/unit/test_brolly_stats_rollup.py
+++ b/tasks/tests/unit/test_brolly_stats_rollup.py
@@ -3,7 +3,6 @@ import datetime
 import uuid
 
 import httpx
-import pytest
 import respx
 from mock import Mock, patch
 
@@ -29,8 +28,7 @@ def _mock_response():
 
 
 class TestBrollyStatsRollupTask(object):
-    @pytest.mark.asyncio
-    async def test_get_min_seconds_interval_between_executions(self, dbsession):
+    def test_get_min_seconds_interval_between_executions(self, dbsession):
         assert isinstance(
             BrollyStatsRollupTask.get_min_seconds_interval_between_executions(),
             int,
@@ -39,9 +37,8 @@ class TestBrollyStatsRollupTask(object):
             BrollyStatsRollupTask.get_min_seconds_interval_between_executions() == 72000
         )
 
-    @pytest.mark.asyncio
     @patch("tasks.brolly_stats_rollup.get_config", return_value=False)
-    async def test_run_cron_task_while_disabled(self, mocker, dbsession):
+    def test_run_cron_task_while_disabled(self, mocker, dbsession):
         task = BrollyStatsRollupTask()
 
         result = await BrollyStatsRollupTask().run_cron_task(dbsession)
@@ -50,9 +47,8 @@ class TestBrollyStatsRollupTask(object):
             "reason": "telemetry disabled in codecov.yml",
         }
 
-    @pytest.mark.asyncio
     @respx.mock
-    async def test_run_cron_task_http_ok(self, mocker, dbsession):
+    def test_run_cron_task_http_ok(self, mocker, dbsession):
         users = [UserFactory.create(name=name) for name in ("foo", "bar", "baz")]
         for user in users:
             dbsession.add(user)
@@ -120,9 +116,8 @@ class TestBrollyStatsRollupTask(object):
             },
         }
 
-    @pytest.mark.asyncio
     @respx.mock
-    async def test_run_cron_task_not_ok(self, mocker, dbsession):
+    def test_run_cron_task_not_ok(self, mocker, dbsession):
         mock_request = respx.post(DEFAULT_BROLLY_ENDPOINT).mock(
             return_value=httpx.Response(500)
         )
@@ -150,11 +145,8 @@ class TestBrollyStatsRollupTask(object):
             },
         }
 
-    @pytest.mark.asyncio
     @respx.mock
-    async def test_run_cron_task_include_admin_email_if_populated(
-        self, mocker, dbsession
-    ):
+    def test_run_cron_task_include_admin_email_if_populated(self, mocker, dbsession):
         mock_request = respx.post(DEFAULT_BROLLY_ENDPOINT).mock(
             return_value=httpx.Response(200)
         )

--- a/tasks/tests/unit/test_brolly_stats_rollup.py
+++ b/tasks/tests/unit/test_brolly_stats_rollup.py
@@ -41,7 +41,7 @@ class TestBrollyStatsRollupTask(object):
     def test_run_cron_task_while_disabled(self, mocker, dbsession):
         task = BrollyStatsRollupTask()
 
-        result = await BrollyStatsRollupTask().run_cron_task(dbsession)
+        result = BrollyStatsRollupTask().run_cron_task(dbsession)
         assert result == {
             "uploaded": False,
             "reason": "telemetry disabled in codecov.yml",
@@ -100,7 +100,7 @@ class TestBrollyStatsRollupTask(object):
         )
 
         task = BrollyStatsRollupTask()
-        result = await task.run_cron_task(dbsession)
+        result = task.run_cron_task(dbsession)
 
         assert mock_request.called
         assert result == {
@@ -130,7 +130,7 @@ class TestBrollyStatsRollupTask(object):
         dbsession.flush()
 
         task = BrollyStatsRollupTask()
-        result = await task.run_cron_task(dbsession)
+        result = task.run_cron_task(dbsession)
         assert mock_request.called
         assert result == {
             "uploaded": False,
@@ -163,7 +163,7 @@ class TestBrollyStatsRollupTask(object):
         dbsession.flush()
 
         task = BrollyStatsRollupTask()
-        result = await task.run_cron_task(dbsession)
+        result = task.run_cron_task(dbsession)
         assert mock_request.called
         assert result == {
             "uploaded": True,

--- a/tasks/tests/unit/test_bundle_analysis_notify_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_notify_task.py
@@ -19,7 +19,7 @@ async def test_bundle_analysis_notify_task(
 
     mocker.patch("services.bundle_analysis.Notifier.notify", return_value=True)
 
-    result = await BundleAnalysisNotifyTask().run_async(
+    result = BundleAnalysisNotifyTask().run_impl(
         dbsession,
         {"results": [{"error": None}]},
         repoid=commit.repoid,

--- a/tasks/tests/unit/test_bundle_analysis_notify_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_notify_task.py
@@ -4,8 +4,7 @@ from database.tests.factories import CommitFactory
 from tasks.bundle_analysis_notify import BundleAnalysisNotifyTask
 
 
-@pytest.mark.asyncio
-async def test_bundle_analysis_notify_task(
+def test_bundle_analysis_notify_task(
     mocker,
     dbsession,
     celery_app,

--- a/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -9,8 +9,7 @@ from database.tests.factories import CommitFactory, UploadFactory
 from tasks.bundle_analysis_processor import BundleAnalysisProcessorTask
 
 
-@pytest.mark.asyncio
-async def test_bundle_analysis_processor_task(
+def test_bundle_analysis_processor_task(
     mocker,
     mock_configuration,
     dbsession,
@@ -65,8 +64,7 @@ async def test_bundle_analysis_processor_task(
     assert upload.state == "processed"
 
 
-@pytest.mark.asyncio
-async def test_bundle_analysis_processor_task_error(
+def test_bundle_analysis_processor_task_error(
     mocker,
     mock_configuration,
     dbsession,
@@ -127,8 +125,7 @@ async def test_bundle_analysis_processor_task_error(
     retry.assert_called_once_with(countdown=20, max_retries=5)
 
 
-@pytest.mark.asyncio
-async def test_bundle_analysis_processor_task_general_error(
+def test_bundle_analysis_processor_task_general_error(
     mocker,
     mock_configuration,
     dbsession,
@@ -184,8 +181,7 @@ async def test_bundle_analysis_processor_task_general_error(
     assert not retry.called
 
 
-@pytest.mark.asyncio
-async def test_bundle_analysis_processor_task_locked(
+def test_bundle_analysis_processor_task_locked(
     mocker,
     mock_configuration,
     dbsession,

--- a/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -40,7 +40,7 @@ async def test_bundle_analysis_processor_task(
     ingest = mocker.patch("shared.bundle_analysis.BundleAnalysisReport.ingest")
     ingest.return_value = 123  # session_id
 
-    result = await BundleAnalysisProcessorTask().run_async(
+    result = BundleAnalysisProcessorTask().run_impl(
         dbsession,
         {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
@@ -98,7 +98,7 @@ async def test_bundle_analysis_processor_task_error(
     task = BundleAnalysisProcessorTask()
     retry = mocker.patch.object(task, "retry")
 
-    result = await task.run_async(
+    result = task.run_impl(
         dbsession,
         {"results": [{"previous": "result"}]},
         repoid=commit.repoid,
@@ -168,7 +168,7 @@ async def test_bundle_analysis_processor_task_general_error(
     retry = mocker.patch.object(task, "retry")
 
     with pytest.raises(Exception):
-        await task.run_async(
+        task.run_impl(
             dbsession,
             {"results": [{"previous": "result"}]},
             repoid=commit.repoid,
@@ -220,7 +220,7 @@ async def test_bundle_analysis_processor_task_locked(
     task = BundleAnalysisProcessorTask()
     retry = mocker.patch.object(task, "retry")
 
-    result = await task.run_async(
+    result = task.run_impl(
         dbsession,
         {"results": [{"previous": "result"}]},
         repoid=commit.repoid,

--- a/tasks/tests/unit/test_check_static_analysis.py
+++ b/tasks/tests/unit/test_check_static_analysis.py
@@ -12,7 +12,7 @@ class TestStaticAnalysisCheckTask(object):
     @pytest.mark.asyncio
     async def test_simple_call_no_object_saved(self, dbsession):
         task = StaticAnalysisSuiteCheckTask()
-        res = await task.run_async(dbsession, suite_id=987654321 * 7)
+        res = task.run_impl(dbsession, suite_id=987654321 * 7)
         assert res == {"changed_count": None, "successful": False}
 
     @pytest.mark.asyncio
@@ -44,7 +44,7 @@ class TestStaticAnalysisCheckTask(object):
         )
         dbsession.add(fp_obj)
         dbsession.flush()
-        res = await task.run_async(dbsession, suite_id=obj.id_)
+        res = task.run_impl(dbsession, suite_id=obj.id_)
         mock_metric_context.assert_called_with(
             repo_id=obj.commit.repository.repoid, commit_id=obj.commit.id
         )
@@ -101,5 +101,5 @@ class TestStaticAnalysisCheckTask(object):
             )
             dbsession.add(fp_obj)
         dbsession.flush()
-        res = await task.run_async(dbsession, suite_id=obj.id_)
+        res = task.run_impl(dbsession, suite_id=obj.id_)
         assert res == {"changed_count": 23, "successful": True}

--- a/tasks/tests/unit/test_check_static_analysis.py
+++ b/tasks/tests/unit/test_check_static_analysis.py
@@ -46,17 +46,18 @@ class TestStaticAnalysisCheckTask(object):
         mock_metric_context.assert_called_with(
             repo_id=obj.commit.repository.repoid, commit_id=obj.commit.id
         )
-        mock_metric_context.return_value.attempt_log_simple_metric.assert_any_call(
+        mock_metric_context.return_value.log_simple_metric.assert_any_call(
             "static_analysis.data_sent_for_commit", float(True)
         )
-        mock_metric_context.return_value.attempt_log_simple_metric.assert_any_call(
+        mock_metric_context.return_value.log_simple_metric.assert_any_call(
             "static_analysis.files_changed", 8
         )
         assert res == {"changed_count": 8, "successful": True}
 
     def test_simple_call_with_suite_mix_from_other(
-        self, dbsession, mock_storage, mock_configuration
+        self, dbsession, mock_storage, mock_configuration, mocker
     ):
+        _ = mocker.patch("tasks.static_analysis_suite_check.MetricContext")
         obj = StaticAnalysisSuiteFactory.create()
         another_obj_same_repo = StaticAnalysisSuiteFactory.create(
             commit__repository=obj.commit.repository

--- a/tasks/tests/unit/test_check_static_analysis.py
+++ b/tasks/tests/unit/test_check_static_analysis.py
@@ -9,14 +9,12 @@ from tasks.static_analysis_suite_check import StaticAnalysisSuiteCheckTask
 
 
 class TestStaticAnalysisCheckTask(object):
-    @pytest.mark.asyncio
-    async def test_simple_call_no_object_saved(self, dbsession):
+    def test_simple_call_no_object_saved(self, dbsession):
         task = StaticAnalysisSuiteCheckTask()
         res = task.run_impl(dbsession, suite_id=987654321 * 7)
         assert res == {"changed_count": None, "successful": False}
 
-    @pytest.mark.asyncio
-    async def test_simple_call_with_suite_all_created(
+    def test_simple_call_with_suite_all_created(
         self, dbsession, mock_storage, mock_configuration, mocker
     ):
         mock_metric_context = mocker.patch(
@@ -56,8 +54,7 @@ class TestStaticAnalysisCheckTask(object):
         )
         assert res == {"changed_count": 8, "successful": True}
 
-    @pytest.mark.asyncio
-    async def test_simple_call_with_suite_mix_from_other(
+    def test_simple_call_with_suite_mix_from_other(
         self, dbsession, mock_storage, mock_configuration
     ):
         obj = StaticAnalysisSuiteFactory.create()

--- a/tasks/tests/unit/test_clean_labels_index.py
+++ b/tasks/tests/unit/test_clean_labels_index.py
@@ -128,7 +128,7 @@ class TestCleanLabelsIndexSyncronization(object):
         )
         task = CleanLabelsIndexTask()
         with pytest.raises(Retry):
-            await task.run_async(dbsession, commit.repository.repoid, commit.commitid)
+            task.run_impl(dbsession, commit.repository.repoid, commit.commitid)
         lock_name = UPLOAD_PROCESSING_LOCK_NAME(
             commit.repository.repoid, commit.commitid
         )
@@ -152,7 +152,7 @@ class TestCleanLabelsIndexSyncronization(object):
         mock_redis.lock.side_effect = LockError
         task = CleanLabelsIndexTask()
         with pytest.raises(Retry):
-            await task.run_async(dbsession, commit.repository.repoid, commit.commitid)
+            task.run_impl(dbsession, commit.repository.repoid, commit.commitid)
         mock_currently_processing.assert_called()
         mock_run_impl_within_lock.assert_not_called()
 
@@ -171,7 +171,7 @@ class TestCleanLabelsIndexSyncronization(object):
             CleanLabelsIndexTask, "_get_best_effort_commit_yaml", return_value={}
         )
         task = CleanLabelsIndexTask()
-        await task.run_async(
+        task.run_impl(
             dbsession, commit.repository.repoid, commit.commitid, report_code="code"
         )
         mock_currently_processing.assert_called()
@@ -256,7 +256,7 @@ class TestCleanLabelsIndexLogic(BaseTestCase):
         )
         task = CleanLabelsIndexTask()
         read_only_args = ReadOnlyArgs(commit=commit, report_code=None, commit_yaml={})
-        res = await task.run_impl_within_lock(read_only_args)
+        res = task.run_impl_within_lock(read_only_args)
         assert res == {"success": False, "error": "Report not found"}
         mock_get_report.assert_called_with(commit, report_code=None)
 
@@ -271,7 +271,7 @@ class TestCleanLabelsIndexLogic(BaseTestCase):
         )
         task = CleanLabelsIndexTask()
         read_only_args = ReadOnlyArgs(commit=commit, report_code=None, commit_yaml={})
-        res = await task.run_impl_within_lock(read_only_args)
+        res = task.run_impl_within_lock(read_only_args)
         assert res == {
             "success": False,
             "error": "Labels index is empty, nothing to do",
@@ -297,7 +297,7 @@ class TestCleanLabelsIndexLogic(BaseTestCase):
         sample_report_better_read_original = self.convert_report_to_better_readable(
             sample_report_with_labels
         )
-        res = await task.run_impl_within_lock(read_only_args)
+        res = task.run_impl_within_lock(read_only_args)
         assert res == {"success": True}
         mock_get_report.assert_called_with(commit, report_code=None)
         mock_save_report.assert_called()
@@ -327,7 +327,7 @@ class TestCleanLabelsIndexLogic(BaseTestCase):
         )
         task = CleanLabelsIndexTask()
         read_only_args = ReadOnlyArgs(commit=commit, report_code=None, commit_yaml={})
-        res = await task.run_impl_within_lock(read_only_args)
+        res = task.run_impl_within_lock(read_only_args)
         assert res == {"success": True}
         mock_get_report.assert_called_with(commit, report_code=None)
         mock_save_report.assert_called()

--- a/tasks/tests/unit/test_clean_labels_index.py
+++ b/tasks/tests/unit/test_clean_labels_index.py
@@ -118,8 +118,7 @@ class TestCleanLabelsIndexSyncronization(object):
             == is_currently_processing
         )
 
-    @pytest.mark.asyncio
-    async def test_retry_currently_processing(self, dbsession, mocker, mock_redis):
+    def test_retry_currently_processing(self, dbsession, mocker, mock_redis):
         commit = CommitFactory()
         dbsession.add(commit)
         dbsession.flush()
@@ -134,8 +133,7 @@ class TestCleanLabelsIndexSyncronization(object):
         )
         mock_currently_processing.assert_called_with(mock_redis, lock_name)
 
-    @pytest.mark.asyncio
-    async def test_retry_failed_to_get_lock(self, dbsession, mocker, mock_redis):
+    def test_retry_failed_to_get_lock(self, dbsession, mocker, mock_redis):
         commit = CommitFactory()
         dbsession.add(commit)
         dbsession.flush()
@@ -156,8 +154,7 @@ class TestCleanLabelsIndexSyncronization(object):
         mock_currently_processing.assert_called()
         mock_run_impl_within_lock.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_call_actual_logic(self, dbsession, mocker, mock_redis):
+    def test_call_actual_logic(self, dbsession, mocker, mock_redis):
         commit = CommitFactory()
         dbsession.add(commit)
         dbsession.flush()
@@ -200,8 +197,7 @@ class TestCleanLabelsIndexReadOnlyArgs(object):
             task._get_commit_or_fail(dbsession, 10000, "commit_that_dont_exist")
         assert str(exp.value) == "Commit not found in database."
 
-    @pytest.mark.asyncio
-    async def test__get_best_effort_commit_yaml_from_provider(self, dbsession, mocker):
+    def test__get_best_effort_commit_yaml_from_provider(self, dbsession, mocker):
         commit = CommitFactory()
         dbsession.add(commit)
         mock_repo_service = MagicMock(name="repo_provider_service")
@@ -213,15 +209,14 @@ class TestCleanLabelsIndexReadOnlyArgs(object):
             },
         )
         task = CleanLabelsIndexTask()
-        res = await task._get_best_effort_commit_yaml(commit, mock_repo_service)
+        res = task._get_best_effort_commit_yaml(commit, mock_repo_service)
         assert res == {
             "yaml_for": f"commit_{commit.commitid}",
             "origin": "git_provider",
         }
         mock_fetch_commit.assert_called_with(commit, mock_repo_service)
 
-    @pytest.mark.asyncio
-    async def test__get_best_effort_commit_yaml_from_db(self, dbsession, mocker):
+    def test__get_best_effort_commit_yaml_from_db(self, dbsession, mocker):
         commit = CommitFactory()
         dbsession.add(commit)
         mock_fetch_commit = mocker.patch(
@@ -235,7 +230,7 @@ class TestCleanLabelsIndexReadOnlyArgs(object):
             ),
         )
         task = CleanLabelsIndexTask()
-        res = await task._get_best_effort_commit_yaml(commit, None)
+        res = task._get_best_effort_commit_yaml(commit, None)
         assert res == {"yaml_for": f"commit_{commit.commitid}", "origin": "database"}
         mock_fetch_commit.assert_not_called()
         mock_final_yaml.assert_called_with(
@@ -247,8 +242,7 @@ class TestCleanLabelsIndexReadOnlyArgs(object):
 
 
 class TestCleanLabelsIndexLogic(BaseTestCase):
-    @pytest.mark.asyncio
-    async def test_clean_labels_report_not_found(self, dbsession, mocker):
+    def test_clean_labels_report_not_found(self, dbsession, mocker):
         commit = CommitFactory()
         dbsession.add(commit)
         mock_get_report = mocker.patch.object(
@@ -260,8 +254,7 @@ class TestCleanLabelsIndexLogic(BaseTestCase):
         assert res == {"success": False, "error": "Report not found"}
         mock_get_report.assert_called_with(commit, report_code=None)
 
-    @pytest.mark.asyncio
-    async def test_clean_labels_no_labels_index_in_report(self, dbsession, mocker):
+    def test_clean_labels_no_labels_index_in_report(self, dbsession, mocker):
         commit = CommitFactory()
         dbsession.add(commit)
         report = Report()
@@ -278,8 +271,7 @@ class TestCleanLabelsIndexLogic(BaseTestCase):
         }
         mock_get_report.assert_called_with(commit, report_code=None)
 
-    @pytest.mark.asyncio
-    async def test_clean_labels_no_change_needed(
+    def test_clean_labels_no_change_needed(
         self, dbsession, mocker, sample_report_with_labels
     ):
         commit = CommitFactory()
@@ -311,8 +303,7 @@ class TestCleanLabelsIndexLogic(BaseTestCase):
             == sample_report_better_read_original
         )
 
-    @pytest.mark.asyncio
-    async def test_clean_labels_with_renames(
+    def test_clean_labels_with_renames(
         self, dbsession, mocker, sample_report_with_labels_and_renames
     ):
         commit = CommitFactory()

--- a/tasks/tests/unit/test_commit_update.py
+++ b/tasks/tests/unit/test_commit_update.py
@@ -12,8 +12,7 @@ from tasks.commit_update import CommitUpdateTask
 
 @pytest.mark.integration
 class TestCommitUpdate(object):
-    @pytest.mark.asyncio
-    async def test_update_commit(
+    def test_update_commit(
         self,
         mocker,
         mock_configuration,
@@ -44,8 +43,7 @@ class TestCommitUpdate(object):
         assert commit.branch == "featureA"
         assert commit.pullid == 1
 
-    @pytest.mark.asyncio
-    async def test_update_commit_bot_unauthorized(
+    def test_update_commit_bot_unauthorized(
         self,
         mocker,
         mock_configuration,
@@ -75,8 +73,7 @@ class TestCommitUpdate(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
 
-    @pytest.mark.asyncio
-    async def test_update_commit_no_bot(
+    def test_update_commit_no_bot(
         self,
         mocker,
         mock_configuration,
@@ -106,8 +103,7 @@ class TestCommitUpdate(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
 
-    @pytest.mark.asyncio
-    async def test_update_commit_repo_not_found(
+    def test_update_commit_repo_not_found(
         self,
         mocker,
         mock_configuration,
@@ -139,8 +135,7 @@ class TestCommitUpdate(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
 
-    @pytest.mark.asyncio
-    async def test_update_commit_not_found(
+    def test_update_commit_not_found(
         self,
         mocker,
         mock_configuration,
@@ -173,8 +168,7 @@ class TestCommitUpdate(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
 
-    @pytest.mark.asyncio
-    async def test_update_commit_already_populated(
+    def test_update_commit_already_populated(
         self,
         mocker,
         mock_configuration,

--- a/tasks/tests/unit/test_commit_update.py
+++ b/tasks/tests/unit/test_commit_update.py
@@ -36,9 +36,7 @@ class TestCommitUpdate(object):
         dbsession.add(commit)
         dbsession.flush()
 
-        result = await CommitUpdateTask().run_async(
-            dbsession, commit.repoid, commit.commitid
-        )
+        result = CommitUpdateTask().run_impl(dbsession, commit.repoid, commit.commitid)
         expected_result = {"was_updated": True}
         assert expected_result == result
         assert commit.message == "random-commit-msg"
@@ -72,9 +70,7 @@ class TestCommitUpdate(object):
         dbsession.add(commit)
         dbsession.flush()
 
-        result = await CommitUpdateTask().run_async(
-            dbsession, commit.repoid, commit.commitid
-        )
+        result = CommitUpdateTask().run_impl(dbsession, commit.repoid, commit.commitid)
         assert {"was_updated": False} == result
         assert commit.message == ""
         assert commit.parent_commit_id is None
@@ -104,9 +100,7 @@ class TestCommitUpdate(object):
         )
         dbsession.add(commit)
         dbsession.flush()
-        result = await CommitUpdateTask().run_async(
-            dbsession, commit.repoid, commit.commitid
-        )
+        result = CommitUpdateTask().run_impl(dbsession, commit.repoid, commit.commitid)
         expected_result = {"was_updated": False}
         assert expected_result == result
         assert commit.message == ""
@@ -139,9 +133,7 @@ class TestCommitUpdate(object):
         dbsession.add(commit)
         dbsession.flush()
 
-        result = await CommitUpdateTask().run_async(
-            dbsession, commit.repoid, commit.commitid
-        )
+        result = CommitUpdateTask().run_impl(dbsession, commit.repoid, commit.commitid)
         expected_result = {"was_updated": False}
         assert expected_result == result
         assert commit.message == ""
@@ -175,9 +167,7 @@ class TestCommitUpdate(object):
         dbsession.add(commit)
         dbsession.flush()
 
-        result = await CommitUpdateTask().run_async(
-            dbsession, commit.repoid, commit.commitid
-        )
+        result = CommitUpdateTask().run_impl(dbsession, commit.repoid, commit.commitid)
         expected_result = {"was_updated": False}
         assert expected_result == result
         assert commit.message == ""
@@ -204,9 +194,7 @@ class TestCommitUpdate(object):
         dbsession.add(commit)
         dbsession.flush()
 
-        result = await CommitUpdateTask().run_async(
-            dbsession, commit.repoid, commit.commitid
-        )
+        result = CommitUpdateTask().run_impl(dbsession, commit.repoid, commit.commitid)
         expected_result = {"was_updated": False}
         assert expected_result == result
         assert commit.message == "commit_msg"

--- a/tasks/tests/unit/test_compute_comparison.py
+++ b/tasks/tests/unit/test_compute_comparison.py
@@ -14,8 +14,7 @@ from tasks.compute_comparison import ComputeComparisonTask
 
 
 class TestComputeComparisonTask(object):
-    @pytest.mark.asyncio
-    async def test_set_state_to_processed(
+    def test_set_state_to_processed(
         self, dbsession, mocker, mock_repo_provider, mock_storage
     ):
         comparison = CompareCommitFactory.create()
@@ -70,8 +69,7 @@ class TestComputeComparisonTask(object):
             },
         }
 
-    @pytest.mark.asyncio
-    async def test_set_state_to_processed_non_empty_report_with_flag_comparisons(
+    def test_set_state_to_processed_non_empty_report_with_flag_comparisons(
         self,
         dbsession,
         mocker,
@@ -172,8 +170,7 @@ class TestComputeComparisonTask(object):
             },
         }
 
-    @pytest.mark.asyncio
-    async def test_flag_comparisons_without_head_report(
+    def test_flag_comparisons_without_head_report(
         self,
         dbsession,
         mocker,
@@ -264,8 +261,7 @@ class TestComputeComparisonTask(object):
             },
         }
 
-    @pytest.mark.asyncio
-    async def test_update_existing_flag_comparisons(
+    def test_update_existing_flag_comparisons(
         self, dbsession, mocker, mock_repo_provider, mock_storage, sample_report
     ):
         comparison = CompareCommitFactory.create()
@@ -316,8 +312,7 @@ class TestComputeComparisonTask(object):
         assert compare_flag_records[0].repositoryflag_id == repositoryflag.id_
         assert compare_flag_records[0].patch_totals is not None
 
-    @pytest.mark.asyncio
-    async def test_set_state_to_error_missing_base_report(self, dbsession, mocker):
+    def test_set_state_to_error_missing_base_report(self, dbsession, mocker):
         comparison = CompareCommitFactory.create()
         dbsession.add(comparison)
         dbsession.flush()
@@ -333,8 +328,7 @@ class TestComputeComparisonTask(object):
         assert comparison.state == CompareCommitState.error.value
         assert comparison.error == CompareCommitError.missing_base_report.value
 
-    @pytest.mark.asyncio
-    async def test_set_state_to_error_missing_head_report(
+    def test_set_state_to_error_missing_head_report(
         self, dbsession, mocker, sample_report
     ):
         comparison = CompareCommitFactory.create()
@@ -354,8 +348,7 @@ class TestComputeComparisonTask(object):
         assert comparison.state == CompareCommitState.error.value
         assert comparison.error == CompareCommitError.missing_head_report.value
 
-    @pytest.mark.asyncio
-    async def test_run_task_ratelimit_error(self, dbsession, mocker, sample_report):
+    def test_run_task_ratelimit_error(self, dbsession, mocker, sample_report):
         comparison = CompareCommitFactory.create()
         dbsession.add(comparison)
         dbsession.flush()
@@ -376,8 +369,7 @@ class TestComputeComparisonTask(object):
         assert comparison.state == CompareCommitState.pending.value
         assert comparison.error is None
 
-    @pytest.mark.asyncio
-    async def test_compute_component_comparisons(
+    def test_compute_component_comparisons(
         self, dbsession, mocker, mock_repo_provider, mock_storage, sample_report
     ):
         mocker.patch.object(
@@ -524,8 +516,7 @@ class TestComputeComparisonTask(object):
             "diff": 0,
         }
 
-    @pytest.mark.asyncio
-    async def test_compute_component_comparisons_empty_diff(
+    def test_compute_component_comparisons_empty_diff(
         self,
         dbsession,
         mocker,

--- a/tasks/tests/unit/test_compute_comparison.py
+++ b/tasks/tests/unit/test_compute_comparison.py
@@ -46,7 +46,7 @@ class TestComputeComparisonTask(object):
         get_current_yaml = mocker.patch("tasks.compute_comparison.get_current_yaml")
         get_current_yaml.return_value = UserYaml({"coverage": {"status": None}})
 
-        await task.run_async(dbsession, comparison.id)
+        task.run_impl(dbsession, comparison.id)
         dbsession.flush()
         assert comparison.state == CompareCommitState.processed.value
         data_in_storage = mock_storage.read_file(
@@ -113,7 +113,7 @@ class TestComputeComparisonTask(object):
             repository_id=comparison.compare_commit.repository.repoid, flag_name="unit"
         )
         dbsession.add(unit_repositoryflag)
-        await task.run_async(dbsession, comparison.id)
+        task.run_impl(dbsession, comparison.id)
         dbsession.flush()
         assert comparison.state == CompareCommitState.processed.value
         compare_flag_records = dbsession.query(CompareFlag).all()
@@ -209,7 +209,7 @@ class TestComputeComparisonTask(object):
         get_current_yaml = mocker.patch("tasks.compute_comparison.get_current_yaml")
         get_current_yaml.return_value = UserYaml({"coverage": {"status": None}})
 
-        await task.run_async(dbsession, comparison.id)
+        task.run_impl(dbsession, comparison.id)
         dbsession.flush()
         assert comparison.state == CompareCommitState.processed.value
         data_in_storage = mock_storage.read_file(
@@ -308,7 +308,7 @@ class TestComputeComparisonTask(object):
             base_totals=None,
         )
         dbsession.add(existing_flag_comparison)
-        await task.run_async(dbsession, comparison.id)
+        task.run_impl(dbsession, comparison.id)
         dbsession.flush()
         assert comparison.state == CompareCommitState.processed.value
         compare_flag_records = dbsession.query(CompareFlag).all()
@@ -328,7 +328,7 @@ class TestComputeComparisonTask(object):
         mocker.patch.object(
             ReportService, "get_existing_report_for_commit", return_value=None
         )
-        await task.run_async(dbsession, comparison.id)
+        task.run_impl(dbsession, comparison.id)
         dbsession.flush()
         assert comparison.state == CompareCommitState.error.value
         assert comparison.error == CompareCommitError.missing_base_report.value
@@ -349,7 +349,7 @@ class TestComputeComparisonTask(object):
             "get_existing_report_for_commit",
             side_effect=(ReadOnlyReport.create_from_report(sample_report), None),
         )
-        await task.run_async(dbsession, comparison.id)
+        task.run_impl(dbsession, comparison.id)
         dbsession.flush()
         assert comparison.state == CompareCommitState.error.value
         assert comparison.error == CompareCommitError.missing_head_report.value
@@ -370,7 +370,7 @@ class TestComputeComparisonTask(object):
             "get_existing_report_for_commit",
             return_value=ReadOnlyReport.create_from_report(sample_report),
         )
-        res = await task.run_async(dbsession, comparison.id)
+        res = task.run_impl(dbsession, comparison.id)
         assert res == {"successful": False}
         dbsession.flush()
         assert comparison.state == CompareCommitState.pending.value
@@ -418,7 +418,7 @@ class TestComputeComparisonTask(object):
         dbsession.flush()
 
         task = ComputeComparisonTask()
-        res = await task.run_async(dbsession, comparison.id)
+        res = task.run_impl(dbsession, comparison.id)
         assert res == {"successful": True}
 
         component_comparisons = (
@@ -562,7 +562,7 @@ class TestComputeComparisonTask(object):
         dbsession.flush()
 
         task = ComputeComparisonTask()
-        res = await task.run_async(dbsession, comparison.id)
+        res = task.run_impl(dbsession, comparison.id)
         assert res == {"successful": True}
 
         component_comparisons = (

--- a/tasks/tests/unit/test_crontasks.py
+++ b/tasks/tests/unit/test_crontasks.py
@@ -25,7 +25,7 @@ class TestCrontasks(object):
     async def test_simple_run(self, dbsession, mock_redis):
         generation_time = datetime(2021, 1, 2, 0, 3, 4).replace(tzinfo=timezone.utc)
         task = SampleCronTask()
-        res = await task.run_async(
+        res = task.run_impl(
             dbsession, cron_task_generation_time_iso=generation_time.isoformat()
         )
         assert res == {
@@ -40,7 +40,7 @@ class TestCrontasks(object):
             generation_time - timedelta(seconds=5)
         ).timestamp()
         task = SampleCronTask()
-        res = await task.run_async(
+        res = task.run_impl(
             dbsession, cron_task_generation_time_iso=generation_time.isoformat()
         )
         assert res == {"executed": False}
@@ -50,7 +50,7 @@ class TestCrontasks(object):
         generation_time = datetime(2021, 1, 2, 0, 3, 4).replace(tzinfo=timezone.utc)
         mock_redis.lock.side_effect = LockError
         task = SampleCronTask()
-        res = await task.run_async(
+        res = task.run_impl(
             dbsession, cron_task_generation_time_iso=generation_time.isoformat()
         )
         assert res == {"executed": False}

--- a/tasks/tests/unit/test_crontasks.py
+++ b/tasks/tests/unit/test_crontasks.py
@@ -16,13 +16,12 @@ class SampleCronTask(CodecovCronTask):
     def hard_time_limit_task(self):
         return 100
 
-    async def run_cron_task(self, dbsession):
+    def run_cron_task(self, dbsession):
         return {"unusual": "return", "value": ["something"]}
 
 
 class TestCrontasks(object):
-    @pytest.mark.asyncio
-    async def test_simple_run(self, dbsession, mock_redis):
+    def test_simple_run(self, dbsession, mock_redis):
         generation_time = datetime(2021, 1, 2, 0, 3, 4).replace(tzinfo=timezone.utc)
         task = SampleCronTask()
         res = task.run_impl(
@@ -33,8 +32,7 @@ class TestCrontasks(object):
             "result": {"unusual": "return", "value": ["something"]},
         }
 
-    @pytest.mark.asyncio
-    async def test_simple_run_with_too_recent_call(self, dbsession, mock_redis):
+    def test_simple_run_with_too_recent_call(self, dbsession, mock_redis):
         generation_time = datetime(2021, 1, 2, 0, 3, 4).replace(tzinfo=timezone.utc)
         mock_redis.get.return_value = (
             generation_time - timedelta(seconds=5)
@@ -45,8 +43,7 @@ class TestCrontasks(object):
         )
         assert res == {"executed": False}
 
-    @pytest.mark.asyncio
-    async def test_simple_run_with_lock_error(self, dbsession, mock_redis):
+    def test_simple_run_with_lock_error(self, dbsession, mock_redis):
         generation_time = datetime(2021, 1, 2, 0, 3, 4).replace(tzinfo=timezone.utc)
         mock_redis.lock.side_effect = LockError
         task = SampleCronTask()

--- a/tasks/tests/unit/test_delete_owner.py
+++ b/tasks/tests/unit/test_delete_owner.py
@@ -20,14 +20,12 @@ here = Path(__file__)
 
 
 class TestDeleteOwnerTaskUnit(object):
-    @pytest.mark.asyncio
-    async def test_unknown_owner(self, mocker, mock_configuration, dbsession):
+    def test_unknown_owner(self, mocker, mock_configuration, dbsession):
         unknown_ownerid = 10404
         with pytest.raises(AssertionError, match="Owner not found"):
             DeleteOwnerTask().run_impl(dbsession, unknown_ownerid)
 
-    @pytest.mark.asyncio
-    async def test_delete_owner_deletes_owner_with_ownerid(
+    def test_delete_owner_deletes_owner_with_ownerid(
         self, mocker, mock_configuration, mock_storage, dbsession
     ):
         ownerid = 10777
@@ -75,8 +73,7 @@ class TestDeleteOwnerTaskUnit(object):
         assert branches == []
         assert pulls == []
 
-    @pytest.mark.asyncio
-    async def test_delete_owner_deletes_owner_with_commit_compares(
+    def test_delete_owner_deletes_owner_with_commit_compares(
         self, mocker, mock_configuration, mock_storage, dbsession
     ):
         ownerid = 10777
@@ -202,8 +199,7 @@ class TestDeleteOwnerTaskUnit(object):
 
         assert mocked_delete_repo_files.call_count == 2
 
-    @pytest.mark.asyncio
-    async def test_delete_owner_timeout(
+    def test_delete_owner_timeout(
         self, mocker, mock_configuration, mock_storage, dbsession
     ):
         org_ownerid = 123

--- a/tasks/tests/unit/test_delete_owner.py
+++ b/tasks/tests/unit/test_delete_owner.py
@@ -24,7 +24,7 @@ class TestDeleteOwnerTaskUnit(object):
     async def test_unknown_owner(self, mocker, mock_configuration, dbsession):
         unknown_ownerid = 10404
         with pytest.raises(AssertionError, match="Owner not found"):
-            await DeleteOwnerTask().run_async(dbsession, unknown_ownerid)
+            DeleteOwnerTask().run_impl(dbsession, unknown_ownerid)
 
     @pytest.mark.asyncio
     async def test_delete_owner_deletes_owner_with_ownerid(
@@ -57,7 +57,7 @@ class TestDeleteOwnerTaskUnit(object):
 
         dbsession.flush()
 
-        await DeleteOwnerTask().run_async(dbsession, ownerid)
+        DeleteOwnerTask().run_impl(dbsession, ownerid)
 
         owner = dbsession.query(Owner).filter(Owner.ownerid == ownerid).first()
 
@@ -120,7 +120,7 @@ class TestDeleteOwnerTaskUnit(object):
 
         dbsession.flush()
 
-        await DeleteOwnerTask().run_async(dbsession, ownerid)
+        DeleteOwnerTask().run_impl(dbsession, ownerid)
 
         owner = dbsession.query(Owner).filter(Owner.ownerid == ownerid).first()
 
@@ -216,4 +216,4 @@ class TestDeleteOwnerTaskUnit(object):
             DeleteOwnerTask, "delete_repo_archives", side_effect=SoftTimeLimitExceeded()
         )
         with pytest.raises(Retry):
-            await DeleteOwnerTask().run_async(dbsession, org_ownerid)
+            DeleteOwnerTask().run_impl(dbsession, org_ownerid)

--- a/tasks/tests/unit/test_find_uncollected_profiling_uploads.py
+++ b/tasks/tests/unit/test_find_uncollected_profiling_uploads.py
@@ -14,14 +14,12 @@ class TestFindUncollectedProfilingsTask(object):
         task = FindUncollectedProfilingsTask()
         assert task.get_min_seconds_interval_between_executions() == 800
 
-    @pytest.mark.asyncio
-    async def test_run_cron_task_empty(self, dbsession):
+    def test_run_cron_task_empty(self, dbsession):
         task = FindUncollectedProfilingsTask()
-        res = await task.run_cron_task(dbsession)
+        res = task.run_cron_task(dbsession)
         assert res == {"delayed_profiling_ids": [], "delayed_profiling_ids_count": 0}
 
-    @pytest.mark.asyncio
-    async def test_run_cron_task_one_matching_profiling(self, dbsession, mocker):
+    def test_run_cron_task_one_matching_profiling(self, dbsession, mocker):
         mocked_get_utc_now = mocker.patch(
             "tasks.profiling_find_uncollected.get_utc_now"
         )
@@ -41,7 +39,7 @@ class TestFindUncollectedProfilingsTask(object):
         dbsession.add(profiling_upload)
         dbsession.flush()
         task = FindUncollectedProfilingsTask()
-        res = await task.run_cron_task(dbsession)
+        res = task.run_cron_task(dbsession)
         assert res == {
             "delayed_profiling_ids": [(pcf.id, 1, ("1234",))],
             "delayed_profiling_ids_count": 1,

--- a/tasks/tests/unit/test_flush_repo.py
+++ b/tasks/tests/unit/test_flush_repo.py
@@ -19,7 +19,7 @@ class TestFlushRepo(object):
         repo = RepositoryFactory.create()
         dbsession.add(repo)
         dbsession.flush()
-        res = await task.run_async(dbsession, repoid=repo.repoid)
+        res = task.run_impl(dbsession, repoid=repo.repoid)
         assert res == FlushRepoTaskReturnType(
             **{
                 "delete_branches_count": 0,
@@ -63,7 +63,7 @@ class TestFlushRepo(object):
             branch = BranchFactory.create(repository=repo)
             dbsession.add(branch)
         dbsession.flush()
-        res = await task.run_async(dbsession, repoid=repo.repoid)
+        res = task.run_impl(dbsession, repoid=repo.repoid)
         assert res == FlushRepoTaskReturnType(
             **{
                 "delete_branches_count": 23,
@@ -82,7 +82,7 @@ class TestFlushRepo(object):
         for i in range(4):
             archive_service.write_chunks(f"commit_sha{i}", f"data{i}")
         task = FlushRepoTask()
-        res = await task.run_async(dbsession, repoid=repo.repoid)
+        res = task.run_impl(dbsession, repoid=repo.repoid)
         assert res == FlushRepoTaskReturnType(
             **{
                 "delete_branches_count": 0,
@@ -111,7 +111,7 @@ class TestFlushRepo(object):
         for i in range(4):
             archive_service.write_chunks(f"commit_sha{i}", f"data{i}")
         task = FlushRepoTask()
-        res = await task.run_async(dbsession, repoid=repo.repoid)
+        res = task.run_impl(dbsession, repoid=repo.repoid)
         assert res == FlushRepoTaskReturnType(
             **{
                 "delete_branches_count": 23,

--- a/tasks/tests/unit/test_flush_repo.py
+++ b/tasks/tests/unit/test_flush_repo.py
@@ -13,8 +13,7 @@ from tasks.flush_repo import FlushRepoTask, FlushRepoTaskReturnType
 
 
 class TestFlushRepo(object):
-    @pytest.mark.asyncio
-    async def test_flush_repo_nothing(self, dbsession, mock_storage):
+    def test_flush_repo_nothing(self, dbsession, mock_storage):
         task = FlushRepoTask()
         repo = RepositoryFactory.create()
         dbsession.add(repo)
@@ -29,10 +28,7 @@ class TestFlushRepo(object):
             }
         )
 
-    @pytest.mark.asyncio
-    async def test_flush_repo_few_of_each_only_db_objects(
-        self, dbsession, mock_storage
-    ):
+    def test_flush_repo_few_of_each_only_db_objects(self, dbsession, mock_storage):
         task = FlushRepoTask()
         repo = RepositoryFactory.create()
         dbsession.add(repo)
@@ -73,8 +69,7 @@ class TestFlushRepo(object):
             }
         )
 
-    @pytest.mark.asyncio
-    async def test_flush_repo_only_archives(self, dbsession, mock_storage):
+    def test_flush_repo_only_archives(self, dbsession, mock_storage):
         repo = RepositoryFactory.create()
         dbsession.add(repo)
         dbsession.flush()
@@ -92,8 +87,7 @@ class TestFlushRepo(object):
             }
         )
 
-    @pytest.mark.asyncio
-    async def test_flush_repo_little_bit_of_everything(self, dbsession, mock_storage):
+    def test_flush_repo_little_bit_of_everything(self, dbsession, mock_storage):
         repo = RepositoryFactory.create()
         dbsession.add(repo)
         dbsession.flush()

--- a/tasks/tests/unit/test_github_app_webhooks_check.py
+++ b/tasks/tests/unit/test_github_app_webhooks_check.py
@@ -194,14 +194,15 @@ class TestGHAppWebhooksTask(object):
         assert len(filtered_deliveries) == 1
         assert filtered_deliveries[0] == sample_deliveries[2]
 
-    def test_request_redeliveries_return_early(self, mocker):
+    @pytest.mark.asyncio
+    async def test_request_redeliveries_return_early(self, mocker):
         fake_redelivery = mocker.patch.object(
             Github,
             "request_webhook_redelivery",
             return_value=True,
         )
         task = GitHubAppWebhooksCheckTask()
-        assert task.request_redeliveries(mocker.MagicMock(), []) == 0
+        assert await task.request_redeliveries(mocker.MagicMock(), []) == 0
         fake_redelivery.assert_not_called()
 
     def test_skip_check_if_enterprise(self, dbsession, mocker):

--- a/tasks/tests/unit/test_healthcheck_task.py
+++ b/tasks/tests/unit/test_healthcheck_task.py
@@ -77,7 +77,7 @@ class TestHealthCheckTask(object):
         mock_redis.llen.return_value = 10
         mock_redis.return_value = MagicMock()
         health_check_task = HealthCheckTask()
-        await health_check_task.run_cron_task(dbsession)
+        health_check_task.run_cron_task(dbsession)
         mock_metrics.assert_any_call("celery.queue.celery.len", 10)
         mock_metrics.assert_any_call("celery.queue.enterprise_celery.len", 10)
 
@@ -103,7 +103,7 @@ class TestHealthCheckTask(object):
         mock_redis.llen.return_value = 10
         mock_redis.return_value = MagicMock()
         health_check_task = HealthCheckTask()
-        await health_check_task.run_cron_task(dbsession)
+        health_check_task.run_cron_task(dbsession)
         mock_metrics.assert_any_call("celery.queue.custom_celery.len", 10)
         mock_metrics.assert_any_call("celery.queue.notify_queue.len", 10)
         mock_metrics.assert_any_call("celery.queue.pulls_queue.len", 10)

--- a/tasks/tests/unit/test_healthcheck_task.py
+++ b/tasks/tests/unit/test_healthcheck_task.py
@@ -1,7 +1,5 @@
 from unittest.mock import MagicMock
 
-import pytest
-
 from tasks.health_check import HealthCheckTask
 
 
@@ -74,8 +72,7 @@ class TestHealthCheckTask(object):
         mock_redis_instance_from_url.assert_not_called()
         mock_redis_connection.assert_called()
 
-    @pytest.mark.asyncio
-    async def test_run_async(self, mocker, mock_redis, dbsession):
+    def test_run_impl(self, mocker, mock_redis, dbsession):
         mock_metrics = mocker.patch("tasks.health_check.metrics.gauge")
         mock_redis.llen.return_value = 10
         mock_redis.return_value = MagicMock()
@@ -84,8 +81,7 @@ class TestHealthCheckTask(object):
         mock_metrics.assert_any_call("celery.queue.celery.len", 10)
         mock_metrics.assert_any_call("celery.queue.enterprise_celery.len", 10)
 
-    @pytest.mark.asyncio
-    async def test_run_async_with_configs(
+    def test_run_impl_with_configs(
         self, mocker, mock_redis, mock_configuration, dbsession
     ):
         mock_configuration.set_params(
@@ -114,8 +110,7 @@ class TestHealthCheckTask(object):
         mock_metrics.assert_any_call("celery.queue.synchronize_queue.len", 10)
         mock_metrics.assert_any_call("celery.queue.flush_repo_queue.len", 10)
 
-    @pytest.mark.asyncio
-    async def test_get_min_seconds_interval_between_executions(self, dbsession):
+    def test_get_min_seconds_interval_between_executions(self, dbsession):
         assert isinstance(
             HealthCheckTask.get_min_seconds_interval_between_executions(), int
         )

--- a/tasks/tests/unit/test_hourly_check.py
+++ b/tasks/tests/unit/test_hourly_check.py
@@ -1,16 +1,12 @@
-import pytest
-
 from tasks.hourly_check import HourlyCheckTask
 
 
 class TestHourlyCheck(object):
-    @pytest.mark.asyncio
-    async def test_simple_case(self, dbsession):
+    def test_simple_case(self, dbsession):
         task = HourlyCheckTask()
         assert await task.run_cron_task(dbsession) == {"checked": True}
 
-    @pytest.mark.asyncio
-    async def test_get_min_seconds_interval_between_executions(self, dbsession):
+    def test_get_min_seconds_interval_between_executions(self, dbsession):
         assert isinstance(
             HourlyCheckTask.get_min_seconds_interval_between_executions(), int
         )

--- a/tasks/tests/unit/test_hourly_check.py
+++ b/tasks/tests/unit/test_hourly_check.py
@@ -4,7 +4,7 @@ from tasks.hourly_check import HourlyCheckTask
 class TestHourlyCheck(object):
     def test_simple_case(self, dbsession):
         task = HourlyCheckTask()
-        assert await task.run_cron_task(dbsession) == {"checked": True}
+        assert task.run_cron_task(dbsession) == {"checked": True}
 
     def test_get_min_seconds_interval_between_executions(self, dbsession):
         assert isinstance(

--- a/tasks/tests/unit/test_label_analysis.py
+++ b/tasks/tests/unit/test_label_analysis.py
@@ -418,8 +418,7 @@ def sample_report_with_labels():
     return r
 
 
-@pytest.mark.asyncio
-async def test_simple_call_without_requested_labels_then_with_requested_labels(
+def test_simple_call_without_requested_labels_then_with_requested_labels(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
@@ -570,8 +569,7 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     )
 
 
-@pytest.mark.asyncio
-async def test_simple_call_with_requested_labels(
+def test_simple_call_with_requested_labels(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
@@ -647,8 +645,7 @@ def test_get_requested_labels(dbsession, mocker):
     assert labels == ["tangerine", "pear", "banana", "apple"]
 
 
-@pytest.mark.asyncio
-async def test_call_label_analysis_no_request_object(dbsession, mocker):
+def test_call_label_analysis_no_request_object(dbsession, mocker):
     task = LabelAnalysisRequestProcessingTask()
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
     res = task.run_impl(db_session=dbsession, request_id=-1)
@@ -824,8 +821,7 @@ def test_get_relevant_executable_lines_with_static_analyses(dbsession, mocker):
     )
 
 
-@pytest.mark.asyncio
-async def test_run_impl_with_error(
+def test_run_impl_with_error(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
@@ -864,8 +860,7 @@ async def test_run_impl_with_error(
     )
 
 
-@pytest.mark.asyncio
-async def test_calculate_result_no_report(
+def test_calculate_result_no_report(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
@@ -912,9 +907,8 @@ async def test_calculate_result_no_report(
     )
 
 
-@pytest.mark.asyncio
 @patch("tasks.label_analysis.parse_git_diff_json", return_value=["parsed_git_diff"])
-async def test__get_parsed_git_diff(mock_parse_diff, dbsession, mock_repo_provider):
+def test__get_parsed_git_diff(mock_parse_diff, dbsession, mock_repo_provider):
     repository = RepositoryFactory.create()
     dbsession.add(repository)
     dbsession.flush()
@@ -926,7 +920,7 @@ async def test__get_parsed_git_diff(mock_parse_diff, dbsession, mock_repo_provid
     mock_repo_provider.get_compare.return_value = {"diff": "json"}
     task = LabelAnalysisRequestProcessingTask()
     task.errors = []
-    parsed_diff = await task._get_parsed_git_diff(larq)
+    parsed_diff = task._get_parsed_git_diff(larq)
     assert parsed_diff == ["parsed_git_diff"]
     mock_parse_diff.assert_called_with({"diff": "json"})
     mock_repo_provider.get_compare.assert_called_with(
@@ -934,11 +928,8 @@ async def test__get_parsed_git_diff(mock_parse_diff, dbsession, mock_repo_provid
     )
 
 
-@pytest.mark.asyncio
 @patch("tasks.label_analysis.parse_git_diff_json", return_value=["parsed_git_diff"])
-async def test__get_parsed_git_diff_error(
-    mock_parse_diff, dbsession, mock_repo_provider
-):
+def test__get_parsed_git_diff_error(mock_parse_diff, dbsession, mock_repo_provider):
     repository = RepositoryFactory.create()
     dbsession.add(repository)
     dbsession.flush()
@@ -951,7 +942,7 @@ async def test__get_parsed_git_diff_error(
     task = LabelAnalysisRequestProcessingTask()
     task.errors = []
     task.dbsession = dbsession
-    parsed_diff = await task._get_parsed_git_diff(larq)
+    parsed_diff = task._get_parsed_git_diff(larq)
     assert parsed_diff == None
     mock_parse_diff.assert_not_called()
     mock_repo_provider.get_compare.assert_called_with(
@@ -959,7 +950,6 @@ async def test__get_parsed_git_diff_error(
     )
 
 
-@pytest.mark.asyncio
 @patch(
     "tasks.label_analysis.LabelAnalysisRequestProcessingTask.get_relevant_executable_lines",
     return_value=[{"all": False, "files": {}}],
@@ -968,7 +958,7 @@ async def test__get_parsed_git_diff_error(
     "tasks.label_analysis.LabelAnalysisRequestProcessingTask._get_parsed_git_diff",
     return_value=["parsed_git_diff"],
 )
-async def test__get_lines_relevant_to_diff(
+def test__get_lines_relevant_to_diff(
     mock_parse_diff, mock_get_relevant_lines, dbsession
 ):
     repository = RepositoryFactory.create()
@@ -980,13 +970,12 @@ async def test__get_lines_relevant_to_diff(
     dbsession.add(larq)
     dbsession.flush()
     task = LabelAnalysisRequestProcessingTask()
-    lines = await task._get_lines_relevant_to_diff(larq)
+    lines = task._get_lines_relevant_to_diff(larq)
     assert lines == [{"all": False, "files": {}}]
     mock_parse_diff.assert_called_with(larq)
     mock_get_relevant_lines.assert_called_with(larq, ["parsed_git_diff"])
 
 
-@pytest.mark.asyncio
 @patch(
     "tasks.label_analysis.LabelAnalysisRequestProcessingTask.get_relevant_executable_lines"
 )
@@ -994,7 +983,7 @@ async def test__get_lines_relevant_to_diff(
     "tasks.label_analysis.LabelAnalysisRequestProcessingTask._get_parsed_git_diff",
     return_value=None,
 )
-async def test__get_lines_relevant_to_diff_error(
+def test__get_lines_relevant_to_diff_error(
     mock_parse_diff, mock_get_relevant_lines, dbsession
 ):
     repository = RepositoryFactory.create()
@@ -1006,7 +995,7 @@ async def test__get_lines_relevant_to_diff_error(
     dbsession.add(larq)
     dbsession.flush()
     task = LabelAnalysisRequestProcessingTask()
-    lines = await task._get_lines_relevant_to_diff(larq)
+    lines = task._get_lines_relevant_to_diff(larq)
     assert lines == None
     mock_parse_diff.assert_called_with(larq)
     mock_get_relevant_lines.assert_not_called()

--- a/tasks/tests/unit/test_label_analysis.py
+++ b/tasks/tests/unit/test_label_analysis.py
@@ -484,7 +484,7 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     dbsession.flush()
 
     task = LabelAnalysisRequestProcessingTask()
-    res = await task.run_async(dbsession, larf.id)
+    res = task.run_impl(dbsession, larf.id)
     expected_present_report_labels = [
         "apple",
         "applejuice",
@@ -535,7 +535,7 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     # And trigger the task again to save the new results
     larf.requested_labels = ["tangerine", "pear", "banana", "apple"]
     dbsession.flush()
-    res = await task.run_async(dbsession, larf.id)
+    res = task.run_impl(dbsession, larf.id)
     expected_present_diff_labels = ["banana"]
     expected_present_report_labels = ["apple", "banana"]
     expected_absent_labels = ["pear", "tangerine"]
@@ -595,7 +595,7 @@ async def test_simple_call_with_requested_labels(
     dbsession.add(larf)
     dbsession.flush()
     task = LabelAnalysisRequestProcessingTask()
-    res = await task.run_async(dbsession, larf.id)
+    res = task.run_impl(dbsession, larf.id)
     expected_present_diff_labels = ["banana"]
     expected_present_report_labels = ["apple", "banana"]
     expected_absent_labels = ["pear", "tangerine"]
@@ -651,7 +651,7 @@ def test_get_requested_labels(dbsession, mocker):
 async def test_call_label_analysis_no_request_object(dbsession, mocker):
     task = LabelAnalysisRequestProcessingTask()
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
-    res = await task.run_async(db_session=dbsession, request_id=-1)
+    res = task.run_impl(db_session=dbsession, request_id=-1)
     assert res == {
         "success": False,
         "present_report_labels": [],
@@ -825,7 +825,7 @@ def test_get_relevant_executable_lines_with_static_analyses(dbsession, mocker):
 
 
 @pytest.mark.asyncio
-async def test_run_async_with_error(
+async def test_run_impl_with_error(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
@@ -840,7 +840,7 @@ async def test_run_async_with_error(
     dbsession.add(larf)
     dbsession.flush()
     task = LabelAnalysisRequestProcessingTask()
-    res = await task.run_async(dbsession, larf.id)
+    res = task.run_impl(dbsession, larf.id)
     expected_result = {
         "absent_labels": [],
         "present_diff_labels": [],
@@ -871,7 +871,7 @@ async def test_calculate_result_no_report(
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
     larf: LabelAnalysisRequest = LabelAnalysisRequestFactory.create(
         # This being not-ordered is important in the test
-        # TO make sure we go through the warning at the bottom of run_async
+        # TO make sure we go through the warning at the bottom of run_impl
         requested_labels=["tangerine", "pear", "banana", "apple"]
     )
     dbsession.add(larf)
@@ -887,7 +887,7 @@ async def test_calculate_result_no_report(
         return_value=(set(), set(), set()),
     )
     task = LabelAnalysisRequestProcessingTask()
-    res = await task.run_async(dbsession, larf.id)
+    res = task.run_impl(dbsession, larf.id)
     assert res == {
         "success": True,
         "absent_labels": larf.requested_labels,

--- a/tasks/tests/unit/test_label_analysis_encoded_labels.py
+++ b/tasks/tests/unit/test_label_analysis_encoded_labels.py
@@ -433,8 +433,7 @@ def sample_report_with_labels():
     return r
 
 
-@pytest.mark.asyncio
-async def test_simple_call_without_requested_labels_then_with_requested_labels(
+def test_simple_call_without_requested_labels_then_with_requested_labels(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
@@ -590,8 +589,7 @@ async def test_simple_call_without_requested_labels_then_with_requested_labels(
     )
 
 
-@pytest.mark.asyncio
-async def test_simple_call_with_requested_labels(
+def test_simple_call_with_requested_labels(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
@@ -669,8 +667,7 @@ def test_get_requested_labels(dbsession, mocker):
     assert labels == ["tangerine", "pear", "banana", "apple"]
 
 
-@pytest.mark.asyncio
-async def test_call_label_analysis_no_request_object(dbsession, mocker):
+def test_call_label_analysis_no_request_object(dbsession, mocker):
     task = LabelAnalysisRequestProcessingTask()
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
     res = task.run_impl(db_session=dbsession, request_id=-1)
@@ -846,8 +843,7 @@ def test_get_relevant_executable_lines_with_static_analyses(dbsession, mocker):
     )
 
 
-@pytest.mark.asyncio
-async def test_run_impl_with_error(
+def test_run_impl_with_error(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
@@ -886,8 +882,7 @@ async def test_run_impl_with_error(
     )
 
 
-@pytest.mark.asyncio
-async def test_calculate_result_no_report(
+def test_calculate_result_no_report(
     dbsession, mock_storage, mocker, sample_report_with_labels, mock_repo_provider
 ):
     mock_metrics = mocker.patch("tasks.label_analysis.metrics")
@@ -934,9 +929,8 @@ async def test_calculate_result_no_report(
     )
 
 
-@pytest.mark.asyncio
 @patch("tasks.label_analysis.parse_git_diff_json", return_value=["parsed_git_diff"])
-async def test__get_parsed_git_diff(mock_parse_diff, dbsession, mock_repo_provider):
+def test__get_parsed_git_diff(mock_parse_diff, dbsession, mock_repo_provider):
     repository = RepositoryFactory.create()
     dbsession.add(repository)
     dbsession.flush()
@@ -948,7 +942,7 @@ async def test__get_parsed_git_diff(mock_parse_diff, dbsession, mock_repo_provid
     mock_repo_provider.get_compare.return_value = {"diff": "json"}
     task = LabelAnalysisRequestProcessingTask()
     task.errors = []
-    parsed_diff = await task._get_parsed_git_diff(larq)
+    parsed_diff = task._get_parsed_git_diff(larq)
     assert parsed_diff == ["parsed_git_diff"]
     mock_parse_diff.assert_called_with({"diff": "json"})
     mock_repo_provider.get_compare.assert_called_with(
@@ -956,11 +950,8 @@ async def test__get_parsed_git_diff(mock_parse_diff, dbsession, mock_repo_provid
     )
 
 
-@pytest.mark.asyncio
 @patch("tasks.label_analysis.parse_git_diff_json", return_value=["parsed_git_diff"])
-async def test__get_parsed_git_diff_error(
-    mock_parse_diff, dbsession, mock_repo_provider
-):
+def test__get_parsed_git_diff_error(mock_parse_diff, dbsession, mock_repo_provider):
     repository = RepositoryFactory.create()
     dbsession.add(repository)
     dbsession.flush()
@@ -973,7 +964,7 @@ async def test__get_parsed_git_diff_error(
     task = LabelAnalysisRequestProcessingTask()
     task.errors = []
     task.dbsession = dbsession
-    parsed_diff = await task._get_parsed_git_diff(larq)
+    parsed_diff = task._get_parsed_git_diff(larq)
     assert parsed_diff == None
     mock_parse_diff.assert_not_called()
     mock_repo_provider.get_compare.assert_called_with(
@@ -981,7 +972,6 @@ async def test__get_parsed_git_diff_error(
     )
 
 
-@pytest.mark.asyncio
 @patch(
     "tasks.label_analysis.LabelAnalysisRequestProcessingTask.get_relevant_executable_lines",
     return_value=[{"all": False, "files": {}}],
@@ -990,7 +980,7 @@ async def test__get_parsed_git_diff_error(
     "tasks.label_analysis.LabelAnalysisRequestProcessingTask._get_parsed_git_diff",
     return_value=["parsed_git_diff"],
 )
-async def test__get_lines_relevant_to_diff(
+def test__get_lines_relevant_to_diff(
     mock_parse_diff, mock_get_relevant_lines, dbsession
 ):
     repository = RepositoryFactory.create()
@@ -1002,13 +992,12 @@ async def test__get_lines_relevant_to_diff(
     dbsession.add(larq)
     dbsession.flush()
     task = LabelAnalysisRequestProcessingTask()
-    lines = await task._get_lines_relevant_to_diff(larq)
+    lines = task._get_lines_relevant_to_diff(larq)
     assert lines == [{"all": False, "files": {}}]
     mock_parse_diff.assert_called_with(larq)
     mock_get_relevant_lines.assert_called_with(larq, ["parsed_git_diff"])
 
 
-@pytest.mark.asyncio
 @patch(
     "tasks.label_analysis.LabelAnalysisRequestProcessingTask.get_relevant_executable_lines"
 )
@@ -1016,7 +1005,7 @@ async def test__get_lines_relevant_to_diff(
     "tasks.label_analysis.LabelAnalysisRequestProcessingTask._get_parsed_git_diff",
     return_value=None,
 )
-async def test__get_lines_relevant_to_diff_error(
+def test__get_lines_relevant_to_diff_error(
     mock_parse_diff, mock_get_relevant_lines, dbsession
 ):
     repository = RepositoryFactory.create()
@@ -1028,7 +1017,7 @@ async def test__get_lines_relevant_to_diff_error(
     dbsession.add(larq)
     dbsession.flush()
     task = LabelAnalysisRequestProcessingTask()
-    lines = await task._get_lines_relevant_to_diff(larq)
+    lines = task._get_lines_relevant_to_diff(larq)
     assert lines == None
     mock_parse_diff.assert_called_with(larq)
     mock_get_relevant_lines.assert_not_called()

--- a/tasks/tests/unit/test_manual_trigger.py
+++ b/tasks/tests/unit/test_manual_trigger.py
@@ -8,8 +8,7 @@ from tasks.manual_trigger import ManualTriggerTask
 
 
 class TestUploadCompletionTask(object):
-    @pytest.mark.asyncio
-    async def test_manual_upload_completion_trigger(
+    def test_manual_upload_completion_trigger(
         self,
         mocker,
         mock_configuration,
@@ -70,8 +69,7 @@ class TestUploadCompletionTask(object):
             "app.tasks.compute_comparison.ComputeComparison"
         ].apply_async.assert_called_once()
 
-    @pytest.mark.asyncio
-    async def test_manual_upload_completion_trigger_uploads_still_processing(
+    def test_manual_upload_completion_trigger_uploads_still_processing(
         self,
         mocker,
         mock_configuration,

--- a/tasks/tests/unit/test_manual_trigger.py
+++ b/tasks/tests/unit/test_manual_trigger.py
@@ -41,7 +41,7 @@ class TestUploadCompletionTask(object):
         dbsession.add(pull)
         dbsession.add(compared_to)
         dbsession.flush()
-        result = await ManualTriggerTask().run_async(
+        result = ManualTriggerTask().run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -98,7 +98,7 @@ class TestUploadCompletionTask(object):
         dbsession.add(upload2)
         dbsession.flush()
         with pytest.raises(Retry):
-            result = await ManualTriggerTask().run_async(
+            result = ManualTriggerTask().run_impl(
                 dbsession,
                 repoid=commit.repoid,
                 commitid=commit.commitid,

--- a/tasks/tests/unit/test_mutation_upload_task.py
+++ b/tasks/tests/unit/test_mutation_upload_task.py
@@ -29,5 +29,5 @@ async def test_mutation_upload_task_call(
     task_data = dict(
         repoid=repository.repoid, upload_path=chunks_url, commitid=commit.commitid
     )
-    res = await MutationTestUploadTask().run_async(dbsession, **task_data)
+    res = MutationTestUploadTask().run_impl(dbsession, **task_data)
     assert res == fake_data.decode()

--- a/tasks/tests/unit/test_mutation_upload_task.py
+++ b/tasks/tests/unit/test_mutation_upload_task.py
@@ -6,8 +6,7 @@ from services.archive import ArchiveService
 from tasks.mutation_test_upload import MutationTestUploadTask
 
 
-@pytest.mark.asyncio
-async def test_mutation_upload_task_call(
+def test_mutation_upload_task_call(
     mocker,
     mock_configuration,
     dbsession,

--- a/tasks/tests/unit/test_new_user_activated.py
+++ b/tasks/tests/unit/test_new_user_activated.py
@@ -95,8 +95,7 @@ class TestNewUserActivatedTaskUnit(object):
         res = NewUserActivatedTask().is_org_on_pr_plan(dbsession, subgroup.ownerid)
         assert res is True
 
-    @pytest.mark.asyncio
-    async def test_org_not_found(self, mocker, dbsession):
+    def test_org_not_found(self, mocker, dbsession):
         unknown_org_ownerid = 404123
         user_ownerid = 123
         res = NewUserActivatedTask().run_impl(
@@ -108,8 +107,7 @@ class TestNewUserActivatedTaskUnit(object):
             "reason": "org not on pr author billing plan",
         }
 
-    @pytest.mark.asyncio
-    async def test_org_not_on_pr_plan(self, mocker, dbsession, pull):
+    def test_org_not_on_pr_plan(self, mocker, dbsession, pull):
         pull.repository.owner.plan = "users-inappm"
         dbsession.flush()
         res = NewUserActivatedTask().run_impl(
@@ -121,8 +119,7 @@ class TestNewUserActivatedTaskUnit(object):
             "reason": "org not on pr author billing plan",
         }
 
-    @pytest.mark.asyncio
-    async def test_org_not_on_pr_plan(self, mocker, dbsession, pull):
+    def test_org_not_on_pr_plan(self, mocker, dbsession, pull):
         pull.repository.owner.plan = "users-inappm"
         dbsession.flush()
         res = NewUserActivatedTask().run_impl(
@@ -134,8 +131,7 @@ class TestNewUserActivatedTaskUnit(object):
             "reason": "org not on pr author billing plan",
         }
 
-    @pytest.mark.asyncio
-    async def test_no_commit_notifications_found(self, mocker, dbsession, pull):
+    def test_no_commit_notifications_found(self, mocker, dbsession, pull):
         mocked_possibly_resend_notifications = mocker.patch(
             "tasks.new_user_activated.NewUserActivatedTask.possibly_resend_notifications"
         )
@@ -149,8 +145,7 @@ class TestNewUserActivatedTaskUnit(object):
         }
         assert not mocked_possibly_resend_notifications.called
 
-    @pytest.mark.asyncio
-    async def test_no_head_commit_on_pull(self, mocker, dbsession, pull):
+    def test_no_head_commit_on_pull(self, mocker, dbsession, pull):
         pull.head = None
         mocked_possibly_resend_notifications = mocker.patch(
             "tasks.new_user_activated.NewUserActivatedTask.possibly_resend_notifications"
@@ -165,8 +160,7 @@ class TestNewUserActivatedTaskUnit(object):
         }
         assert not mocked_possibly_resend_notifications.called
 
-    @pytest.mark.asyncio
-    async def test_commit_notifications_all_standard(self, mocker, dbsession, pull):
+    def test_commit_notifications_all_standard(self, mocker, dbsession, pull):
         pull_head_commit = pull.get_head_commit()
         cn1 = CommitNotificationFactory.create(
             commit=pull_head_commit,
@@ -193,10 +187,7 @@ class TestNewUserActivatedTaskUnit(object):
             "reason": "no pulls/pull notifications met criteria",
         }
 
-    @pytest.mark.asyncio
-    async def test_commit_notifications_resend_single_pull(
-        self, mocker, dbsession, pull
-    ):
+    def test_commit_notifications_resend_single_pull(self, mocker, dbsession, pull):
         pull_head_commit = pull.get_head_commit()
         cn1 = CommitNotificationFactory.create(
             commit=pull_head_commit,

--- a/tasks/tests/unit/test_new_user_activated.py
+++ b/tasks/tests/unit/test_new_user_activated.py
@@ -99,7 +99,7 @@ class TestNewUserActivatedTaskUnit(object):
     async def test_org_not_found(self, mocker, dbsession):
         unknown_org_ownerid = 404123
         user_ownerid = 123
-        res = await NewUserActivatedTask().run_async(
+        res = NewUserActivatedTask().run_impl(
             dbsession, unknown_org_ownerid, user_ownerid
         )
         assert res == {
@@ -112,7 +112,7 @@ class TestNewUserActivatedTaskUnit(object):
     async def test_org_not_on_pr_plan(self, mocker, dbsession, pull):
         pull.repository.owner.plan = "users-inappm"
         dbsession.flush()
-        res = await NewUserActivatedTask().run_async(
+        res = NewUserActivatedTask().run_impl(
             dbsession, pull.repository.owner.ownerid, pull.author.ownerid
         )
         assert res == {
@@ -125,7 +125,7 @@ class TestNewUserActivatedTaskUnit(object):
     async def test_org_not_on_pr_plan(self, mocker, dbsession, pull):
         pull.repository.owner.plan = "users-inappm"
         dbsession.flush()
-        res = await NewUserActivatedTask().run_async(
+        res = NewUserActivatedTask().run_impl(
             dbsession, pull.repository.owner.ownerid, pull.author.ownerid
         )
         assert res == {
@@ -139,7 +139,7 @@ class TestNewUserActivatedTaskUnit(object):
         mocked_possibly_resend_notifications = mocker.patch(
             "tasks.new_user_activated.NewUserActivatedTask.possibly_resend_notifications"
         )
-        res = await NewUserActivatedTask().run_async(
+        res = NewUserActivatedTask().run_impl(
             dbsession, pull.repository.owner.ownerid, pull.author.ownerid
         )
         assert res == {
@@ -155,7 +155,7 @@ class TestNewUserActivatedTaskUnit(object):
         mocked_possibly_resend_notifications = mocker.patch(
             "tasks.new_user_activated.NewUserActivatedTask.possibly_resend_notifications"
         )
-        res = await NewUserActivatedTask().run_async(
+        res = NewUserActivatedTask().run_impl(
             dbsession, pull.repository.owner.ownerid, pull.author.ownerid
         )
         assert res == {
@@ -184,7 +184,7 @@ class TestNewUserActivatedTaskUnit(object):
         dbsession.add(cn2)
         dbsession.flush()
 
-        res = await NewUserActivatedTask().run_async(
+        res = NewUserActivatedTask().run_impl(
             dbsession, pull.repository.owner.ownerid, pull.author.ownerid
         )
         assert res == {
@@ -220,7 +220,7 @@ class TestNewUserActivatedTaskUnit(object):
             tasks={"app.tasks.notify.Notify": mocker.MagicMock()},
         )
 
-        res = await NewUserActivatedTask().run_async(
+        res = NewUserActivatedTask().run_impl(
             dbsession, pull.repository.owner.ownerid, pull.author.ownerid
         )
 

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -267,7 +267,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml={}
         )
         assert result == {"notified": False, "notifications": None}
@@ -305,7 +305,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml=None
         )
         assert result == {"notified": False, "notifications": None}
@@ -355,7 +355,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -425,7 +425,7 @@ class TestNotifyTask(object):
         kwargs = {_kwargs_key(UploadFlow): checkpoints.data}
 
         task = NotifyTask()
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -494,7 +494,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -536,7 +536,7 @@ class TestNotifyTask(object):
         dbsession.flush()
         task = NotifyTask()
         with pytest.raises(Retry):
-            await task.run_async_within_lock(
+            await task.run_impl_within_lock(
                 dbsession,
                 repoid=commit.repoid,
                 commitid=commit.commitid,
@@ -576,7 +576,7 @@ class TestNotifyTask(object):
         dbsession.flush()
         task = NotifyTask()
         with pytest.raises(Retry):
-            await task.run_async_within_lock(
+            await task.run_impl_within_lock(
                 dbsession,
                 repoid=commit.repoid,
                 commitid=commit.commitid,
@@ -610,7 +610,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        res = await task.run_async_within_lock(
+        res = await task.run_impl_within_lock(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml={}
         )
         expected_result = {
@@ -643,7 +643,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        res = await task.run_async_within_lock(
+        res = await task.run_impl_within_lock(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml={}
         )
         expected_result = {
@@ -710,7 +710,7 @@ class TestNotifyTask(object):
         dbsession.flush()
         current_yaml = {"codecov": {"require_ci_to_pass": True}}
         task = NotifyTask()
-        res = await task.run_async_within_lock(
+        res = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -823,7 +823,7 @@ class TestNotifyTask(object):
         dbsession.flush()
         current_yaml = {"codecov": {"require_ci_to_pass": True}}
         task = NotifyTask()
-        res = await task.run_async_within_lock(
+        res = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -838,8 +838,8 @@ class TestNotifyTask(object):
 
     @pytest.mark.asyncio
     async def test_run_async_unobtainable_lock(self, dbsession, mock_redis, mocker):
-        mocked_run_async_within_lock = mocker.patch.object(
-            NotifyTask, "run_async_within_lock"
+        mocked_run_impl_within_lock = mocker.patch.object(
+            NotifyTask, "run_impl_within_lock"
         )
         mocked_has_upcoming_notifies_according_to_redis = mocker.patch.object(
             NotifyTask, "has_upcoming_notifies_according_to_redis", return_value=False
@@ -865,12 +865,12 @@ class TestNotifyTask(object):
             "notified": False,
             "reason": "unobtainable_lock",
         }
-        assert not mocked_run_async_within_lock.called
+        assert not mocked_run_impl_within_lock.called
 
     @pytest.mark.asyncio
     async def test_run_async_other_jobs_coming(self, dbsession, mock_redis, mocker):
-        mocked_run_async_within_lock = mocker.patch.object(
-            NotifyTask, "run_async_within_lock"
+        mocked_run_impl_within_lock = mocker.patch.object(
+            NotifyTask, "run_impl_within_lock"
         )
         commit = CommitFactory.create()
         dbsession.add(commit)
@@ -889,14 +889,14 @@ class TestNotifyTask(object):
             "notified": False,
             "reason": "has_other_notifies_coming",
         }
-        assert not mocked_run_async_within_lock.called
+        assert not mocked_run_impl_within_lock.called
 
     @pytest.mark.asyncio
     async def test_run_async_can_run_logic(self, dbsession, mock_redis, mocker):
-        mocked_run_async_within_lock = mocker.patch.object(
-            NotifyTask, "run_async_within_lock"
+        mocked_run_impl_within_lock = mocker.patch.object(
+            NotifyTask, "run_impl_within_lock"
         )
-        mocked_run_async_within_lock.return_value = {
+        mocked_run_impl_within_lock.return_value = {
             "notifications": [],
             "notified": True,
             "reason": "yay",
@@ -919,7 +919,7 @@ class TestNotifyTask(object):
         )
         assert res == {"notifications": [], "notified": True, "reason": "yay"}
         kwargs = {_kwargs_key(UploadFlow): mocker.ANY}
-        mocked_run_async_within_lock.assert_called_with(
+        mocked_run_impl_within_lock.assert_called_with(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -972,7 +972,7 @@ class TestNotifyTask(object):
         dbsession.flush()
 
         task = NotifyTask()
-        result = await task.run_async_within_lock(
+        result = await task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -782,7 +782,7 @@ class TestNotifyTask(object):
                 },
             },
         ]
-        res = await task.submit_third_party_notifications(
+        res = task.submit_third_party_notifications(
             current_yaml,
             base_commit,
             head_commit,

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -241,8 +241,7 @@ class TestNotifyTaskHelpers(object):
 
 
 class TestNotifyTask(object):
-    @pytest.mark.asyncio
-    async def test_simple_call_no_notifications(
+    def test_simple_call_no_notifications(
         self, dbsession, mocker, mock_storage, mock_configuration
     ):
         mock_configuration.params["setup"][
@@ -267,7 +266,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml={}
         )
         assert result == {"notified": False, "notifications": None}
@@ -275,8 +274,7 @@ class TestNotifyTask(object):
             UserYaml({}), commit, fetch_and_update_whether_ci_passed_result, None
         )
 
-    @pytest.mark.asyncio
-    async def test_simple_call_no_notifications_no_yaml_given(
+    def test_simple_call_no_notifications_no_yaml_given(
         self, dbsession, mocker, mock_storage, mock_configuration, mock_repo_provider
     ):
         mock_configuration.params["setup"][
@@ -305,7 +303,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml=None
         )
         assert result == {"notified": False, "notifications": None}
@@ -314,8 +312,7 @@ class TestNotifyTask(object):
         )
         mocked_fetch_yaml.assert_called_with(commit, mock_repo_provider)
 
-    @pytest.mark.asyncio
-    async def test_simple_call_no_notifications_commit_differs_from_pulls_head(
+    def test_simple_call_no_notifications_commit_differs_from_pulls_head(
         self,
         dbsession,
         mocker,
@@ -355,7 +352,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -373,8 +370,7 @@ class TestNotifyTask(object):
             head_report,
         )
 
-    @pytest.mark.asyncio
-    async def test_simple_call_yes_notifications_no_base(
+    def test_simple_call_yes_notifications_no_base(
         self,
         dbsession,
         mocker,
@@ -425,7 +421,7 @@ class TestNotifyTask(object):
         kwargs = {_kwargs_key(UploadFlow): checkpoints.data}
 
         task = NotifyTask()
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -465,8 +461,7 @@ class TestNotifyTask(object):
         ]
         mock_checkpoint_submit.assert_has_calls(calls)
 
-    @pytest.mark.asyncio
-    async def test_simple_call_no_pullrequest_found(
+    def test_simple_call_no_pullrequest_found(
         self, dbsession, mocker, mock_storage, mock_configuration
     ):
         mocked_submit_third_party_notifications = mocker.patch.object(
@@ -494,7 +489,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -508,8 +503,7 @@ class TestNotifyTask(object):
         dbsession.refresh(commit)
         assert commit.notified is True
 
-    @pytest.mark.asyncio
-    async def test_simple_call_should_delay(
+    def test_simple_call_should_delay(
         self, dbsession, mocker, mock_storage, mock_configuration
     ):
         mock_configuration.params["setup"][
@@ -536,7 +530,7 @@ class TestNotifyTask(object):
         dbsession.flush()
         task = NotifyTask()
         with pytest.raises(Retry):
-            await task.run_impl_within_lock(
+            task.run_impl_within_lock(
                 dbsession,
                 repoid=commit.repoid,
                 commitid=commit.commitid,
@@ -547,8 +541,7 @@ class TestNotifyTask(object):
             UserYaml({}), commit, fetch_and_update_whether_ci_passed_result
         )
 
-    @pytest.mark.asyncio
-    async def test_simple_call_should_delay_using_integration(
+    def test_simple_call_should_delay_using_integration(
         self, dbsession, mocker, mock_storage, mock_configuration
     ):
         mock_configuration.params["setup"][
@@ -576,7 +569,7 @@ class TestNotifyTask(object):
         dbsession.flush()
         task = NotifyTask()
         with pytest.raises(Retry):
-            await task.run_impl_within_lock(
+            task.run_impl_within_lock(
                 dbsession,
                 repoid=commit.repoid,
                 commitid=commit.commitid,
@@ -587,8 +580,7 @@ class TestNotifyTask(object):
             UserYaml({}), commit, fetch_and_update_whether_ci_passed_result
         )
 
-    @pytest.mark.asyncio
-    async def test_simple_call_not_able_fetch_ci(
+    def test_simple_call_not_able_fetch_ci(
         self, dbsession, mocker, mock_storage, mock_configuration
     ):
         mock_configuration.params["setup"][
@@ -610,7 +602,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        res = await task.run_impl_within_lock(
+        res = task.run_impl_within_lock(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml={}
         )
         expected_result = {
@@ -620,8 +612,7 @@ class TestNotifyTask(object):
         }
         assert expected_result == res
 
-    @pytest.mark.asyncio
-    async def test_simple_call_not_able_fetch_ci_server_issues(
+    def test_simple_call_not_able_fetch_ci_server_issues(
         self, dbsession, mocker, mock_storage, mock_configuration
     ):
         mock_configuration.params["setup"][
@@ -643,7 +634,7 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.flush()
         task = NotifyTask()
-        res = await task.run_impl_within_lock(
+        res = task.run_impl_within_lock(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml={}
         )
         expected_result = {
@@ -693,8 +684,7 @@ class TestNotifyTask(object):
         res = task.should_send_notifications(current_yaml, commit, True, mock_report)
         assert not res
 
-    @pytest.mark.asyncio
-    async def test_notify_task_no_bot(self, dbsession, mocker):
+    def test_notify_task_no_bot(self, dbsession, mocker):
         get_repo_provider_service = mocker.patch(
             "tasks.notify.get_repo_provider_service"
         )
@@ -710,7 +700,7 @@ class TestNotifyTask(object):
         dbsession.flush()
         current_yaml = {"codecov": {"require_ci_to_pass": True}}
         task = NotifyTask()
-        res = await task.run_impl_within_lock(
+        res = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -723,8 +713,7 @@ class TestNotifyTask(object):
         }
         assert expected_result == res
 
-    @pytest.mark.asyncio
-    async def test_submit_third_party_notifications_exception(self, mocker, dbsession):
+    def test_submit_third_party_notifications_exception(self, mocker, dbsession):
         current_yaml = {}
         repository = RepositoryFactory.create()
         dbsession.add(repository)
@@ -803,8 +792,7 @@ class TestNotifyTask(object):
         )
         assert expected_result == res
 
-    @pytest.mark.asyncio
-    async def test_notify_task_max_retries_exceeded(
+    def test_notify_task_max_retries_exceeded(
         self, dbsession, mocker, mock_repo_provider
     ):
         mocker.patch.object(NotifyTask, "should_wait_longer", return_value=True)
@@ -823,7 +811,7 @@ class TestNotifyTask(object):
         dbsession.flush()
         current_yaml = {"codecov": {"require_ci_to_pass": True}}
         task = NotifyTask()
-        res = await task.run_impl_within_lock(
+        res = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -836,8 +824,7 @@ class TestNotifyTask(object):
         }
         assert expected_result == res
 
-    @pytest.mark.asyncio
-    async def test_run_async_unobtainable_lock(self, dbsession, mock_redis, mocker):
+    def test_run_impl_unobtainable_lock(self, dbsession, mock_redis, mocker):
         mocked_run_impl_within_lock = mocker.patch.object(
             NotifyTask, "run_impl_within_lock"
         )
@@ -853,7 +840,7 @@ class TestNotifyTask(object):
         m.return_value.locked.return_value.__enter__.side_effect = LockError()
         mocker.patch("tasks.notify.LockManager", m)
 
-        res = await task.run_async(
+        res = task.run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -867,8 +854,7 @@ class TestNotifyTask(object):
         }
         assert not mocked_run_impl_within_lock.called
 
-    @pytest.mark.asyncio
-    async def test_run_async_other_jobs_coming(self, dbsession, mock_redis, mocker):
+    def test_run_impl_other_jobs_coming(self, dbsession, mock_redis, mocker):
         mocked_run_impl_within_lock = mocker.patch.object(
             NotifyTask, "run_impl_within_lock"
         )
@@ -878,7 +864,7 @@ class TestNotifyTask(object):
         current_yaml = {"codecov": {"require_ci_to_pass": True}}
         task = NotifyTask()
         mock_redis.get.return_value = True
-        res = await task.run_async(
+        res = task.run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -891,8 +877,7 @@ class TestNotifyTask(object):
         }
         assert not mocked_run_impl_within_lock.called
 
-    @pytest.mark.asyncio
-    async def test_run_async_can_run_logic(self, dbsession, mock_redis, mocker):
+    def test_run_impl_can_run_logic(self, dbsession, mock_redis, mocker):
         mocked_run_impl_within_lock = mocker.patch.object(
             NotifyTask, "run_impl_within_lock"
         )
@@ -910,7 +895,7 @@ class TestNotifyTask(object):
         checkpoints = _create_checkpoint_logger(mocker)
         checkpoints_data = json.loads(json.dumps(checkpoints.data))
         kwargs = {_kwargs_key(UploadFlow): checkpoints_data}
-        res = await task.run_async(
+        res = task.run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -928,8 +913,7 @@ class TestNotifyTask(object):
             **kwargs,
         )
 
-    @pytest.mark.asyncio
-    async def test_checkpoints_not_logged_outside_upload_flow(
+    def test_checkpoints_not_logged_outside_upload_flow(
         self, dbsession, mock_redis, mocker, mock_checkpoint_submit, mock_configuration
     ):
         fake_notifier = mocker.MagicMock(
@@ -972,7 +956,7 @@ class TestNotifyTask(object):
         dbsession.flush()
 
         task = NotifyTask()
-        result = await task.run_impl_within_lock(
+        result = task.run_impl_within_lock(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,

--- a/tasks/tests/unit/test_planmanager_task.py
+++ b/tasks/tests/unit/test_planmanager_task.py
@@ -7,8 +7,7 @@ from tasks.plan_manager_task import DailyPlanManagerTask
 
 
 class TestDailyPlanManagerTask(object):
-    @pytest.mark.asyncio
-    async def test_simple_case(self, dbsession):
+    def test_simple_case(self, dbsession):
         task = DailyPlanManagerTask()
         # Populate DB
         owner_in_enterprise_plan = OwnerFactory.create(
@@ -30,7 +29,7 @@ class TestDailyPlanManagerTask(object):
         dbsession.flush()
         assert dbsession.query(OrganizationLevelToken).count() == 3
 
-        result = await task.run_cron_task(dbsession)
+        result = task.run_cron_task(dbsession)
         assert result.get("checked") == True
         assert result.get("deleted") == 2
         assert dbsession.query(OrganizationLevelToken).count() == 1
@@ -39,8 +38,7 @@ class TestDailyPlanManagerTask(object):
             == owner_in_enterprise_plan.ownerid
         )
 
-    @pytest.mark.asyncio
-    async def test_get_min_seconds_interval_between_executions(self, dbsession):
+    def test_get_min_seconds_interval_between_executions(self, dbsession):
         assert isinstance(
             DailyPlanManagerTask.get_min_seconds_interval_between_executions(), int
         )

--- a/tasks/tests/unit/test_preprocess_upload.py
+++ b/tasks/tests/unit/test_preprocess_upload.py
@@ -15,8 +15,7 @@ from tasks.preprocess_upload import PreProcessUpload
 
 
 class TestPreProcessUpload(object):
-    @pytest.mark.asyncio
-    async def test_preprocess_task(
+    def test_preprocess_task(
         self,
         mocker,
         mock_configuration,
@@ -177,8 +176,7 @@ class TestPreProcessUpload(object):
         dbsession.flush()
         return commit, report
 
-    @pytest.mark.asyncio
-    async def test_run_impl_unobtainable_lock(self, dbsession, mocker, mock_redis):
+    def test_run_impl_unobtainable_lock(self, dbsession, mocker, mock_redis):
         commit = CommitFactory.create()
         dbsession.add(commit)
         dbsession.flush()

--- a/tasks/tests/unit/test_preprocess_upload.py
+++ b/tasks/tests/unit/test_preprocess_upload.py
@@ -57,7 +57,7 @@ class TestPreProcessUpload(object):
         )
         commit, report = self.create_commit_and_report(dbsession)
 
-        result = await PreProcessUpload().run_async(
+        result = PreProcessUpload().run_impl(
             dbsession,
             repoid=commit.repository.repoid,
             commitid=commit.commitid,
@@ -178,12 +178,12 @@ class TestPreProcessUpload(object):
         return commit, report
 
     @pytest.mark.asyncio
-    async def test_run_async_unobtainable_lock(self, dbsession, mocker, mock_redis):
+    async def test_run_impl_unobtainable_lock(self, dbsession, mocker, mock_redis):
         commit = CommitFactory.create()
         dbsession.add(commit)
         dbsession.flush()
         mock_redis.lock.side_effect = LockError()
-        result = await PreProcessUpload().run_async(
+        result = PreProcessUpload().run_impl(
             dbsession,
             repoid=commit.repository.repoid,
             commitid=commit.commitid,

--- a/tasks/tests/unit/test_profiling_collection.py
+++ b/tasks/tests/unit/test_profiling_collection.py
@@ -29,7 +29,7 @@ def sample_open_telemetry_collected():
 
 
 @pytest.mark.asyncio
-async def test_run_async_simple_run_no_existing_data(
+async def test_run_impl_simple_run_no_existing_data(
     dbsession, mock_storage, mock_configuration, mock_redis, mocker
 ):
     mock_delay = mocker.patch("tasks.profiling_collection.profiling_summarization_task")
@@ -38,7 +38,7 @@ async def test_run_async_simple_run_no_existing_data(
     dbsession.add(pcf)
     dbsession.flush()
     task = ProfilingCollectionTask()
-    res = await task.run_async(dbsession, profiling_id=pcf.id)
+    res = task.run_impl(dbsession, profiling_id=pcf.id)
     assert res["successful"]
     assert json.loads(mock_storage.read_file("bucket", res["location"]).decode()) == {
         "files": [],
@@ -49,7 +49,7 @@ async def test_run_async_simple_run_no_existing_data(
 
 
 @pytest.mark.asyncio
-async def test_run_async_simple_run_no_existing_data_yes_new_uploads(
+async def test_run_impl_simple_run_no_existing_data_yes_new_uploads(
     dbsession, mock_storage, mock_configuration, mock_redis, mocker
 ):
     mock_delay = mocker.patch("tasks.profiling_collection.profiling_summarization_task")
@@ -81,7 +81,7 @@ async def test_run_async_simple_run_no_existing_data_yes_new_uploads(
     dbsession.add(pu)
     dbsession.flush()
     task = ProfilingCollectionTask()
-    res = await task.run_async(dbsession, profiling_id=pcf.id)
+    res = task.run_impl(dbsession, profiling_id=pcf.id)
     assert res["successful"]
     assert json.loads(mock_storage.read_file("bucket", res["location"]).decode()) == {
         "groups": [
@@ -98,7 +98,7 @@ async def test_run_async_simple_run_no_existing_data_yes_new_uploads(
 
 
 @pytest.mark.asyncio
-async def test_run_async_simple_run_no_existing_data_sample_new_uploads(
+async def test_run_impl_simple_run_no_existing_data_sample_new_uploads(
     dbsession,
     mock_storage,
     mock_configuration,
@@ -123,7 +123,7 @@ async def test_run_async_simple_run_no_existing_data_sample_new_uploads(
     dbsession.add(pu)
     dbsession.flush()
     task = ProfilingCollectionTask()
-    res = await task.run_async(dbsession, profiling_id=pcf.id)
+    res = task.run_impl(dbsession, profiling_id=pcf.id)
     assert res["successful"]
     print(mock_storage.read_file("bucket", res["location"]).decode())
     assert (
@@ -140,7 +140,7 @@ async def test_collection_task_redis_lock_unavailable(dbsession, mocker, mock_re
     dbsession.flush()
     task = ProfilingCollectionTask()
     mock_redis.lock.return_value.__enter__.side_effect = LockError()
-    res = await task.run_async(dbsession, profiling_id=pcf.id)
+    res = task.run_impl(dbsession, profiling_id=pcf.id)
     assert res == {"location": None, "successful": False, "summarization_task_id": None}
 
 

--- a/tasks/tests/unit/test_profiling_collection.py
+++ b/tasks/tests/unit/test_profiling_collection.py
@@ -28,8 +28,7 @@ def sample_open_telemetry_collected():
         return json.load(file)
 
 
-@pytest.mark.asyncio
-async def test_run_impl_simple_run_no_existing_data(
+def test_run_impl_simple_run_no_existing_data(
     dbsession, mock_storage, mock_configuration, mock_redis, mocker
 ):
     mock_delay = mocker.patch("tasks.profiling_collection.profiling_summarization_task")
@@ -48,8 +47,7 @@ async def test_run_impl_simple_run_no_existing_data(
     mock_delay.delay.assert_called_with(profiling_id=pcf.id)
 
 
-@pytest.mark.asyncio
-async def test_run_impl_simple_run_no_existing_data_yes_new_uploads(
+def test_run_impl_simple_run_no_existing_data_yes_new_uploads(
     dbsession, mock_storage, mock_configuration, mock_redis, mocker
 ):
     mock_delay = mocker.patch("tasks.profiling_collection.profiling_summarization_task")
@@ -97,8 +95,7 @@ async def test_run_impl_simple_run_no_existing_data_yes_new_uploads(
     mock_delay.delay.assert_called_with(profiling_id=pcf.id)
 
 
-@pytest.mark.asyncio
-async def test_run_impl_simple_run_no_existing_data_sample_new_uploads(
+def test_run_impl_simple_run_no_existing_data_sample_new_uploads(
     dbsession,
     mock_storage,
     mock_configuration,
@@ -133,8 +130,7 @@ async def test_run_impl_simple_run_no_existing_data_sample_new_uploads(
     mock_delay.delay.assert_called_with(profiling_id=pcf.id)
 
 
-@pytest.mark.asyncio
-async def test_collection_task_redis_lock_unavailable(dbsession, mocker, mock_redis):
+def test_collection_task_redis_lock_unavailable(dbsession, mocker, mock_redis):
     pcf = ProfilingCommitFactory.create(joined_location=None)
     dbsession.add(pcf)
     dbsession.flush()

--- a/tasks/tests/unit/test_profiling_normalizer.py
+++ b/tasks/tests/unit/test_profiling_normalizer.py
@@ -27,7 +27,7 @@ def sample_open_telemetry_normalized():
 
 
 @pytest.mark.asyncio
-async def test_run_async_simple_normalizing_run(
+async def test_run_impl_simple_normalizing_run(
     dbsession,
     mock_storage,
     mock_configuration,
@@ -50,7 +50,7 @@ async def test_run_async_simple_normalizing_run(
     dbsession.add(puf)
     dbsession.flush()
     task = ProfilingNormalizerTask()
-    res = await task.run_async(dbsession, profiling_upload_id=puf.id)
+    res = task.run_impl(dbsession, profiling_upload_id=puf.id)
     assert res["successful"]
     result = json.loads(mock_storage.read_file("bucket", res["location"]).decode())
     print(mock_storage.read_file("bucket", res["location"]).decode())
@@ -69,5 +69,5 @@ async def test_run_sync_normalizing_run_no_file(
     dbsession.add(puf)
     dbsession.flush()
     task = ProfilingNormalizerTask()
-    res = await task.run_async(dbsession, profiling_upload_id=puf.id)
+    res = task.run_impl(dbsession, profiling_upload_id=puf.id)
     assert res == {"successful": False}

--- a/tasks/tests/unit/test_profiling_normalizer.py
+++ b/tasks/tests/unit/test_profiling_normalizer.py
@@ -26,8 +26,7 @@ def sample_open_telemetry_normalized():
         return json.load(file)
 
 
-@pytest.mark.asyncio
-async def test_run_impl_simple_normalizing_run(
+def test_run_impl_simple_normalizing_run(
     dbsession,
     mock_storage,
     mock_configuration,
@@ -57,10 +56,7 @@ async def test_run_impl_simple_normalizing_run(
     assert result == sample_open_telemetry_normalized
 
 
-@pytest.mark.asyncio
-async def test_run_sync_normalizing_run_no_file(
-    dbsession, mock_storage, mock_configuration
-):
+def test_run_sync_normalizing_run_no_file(dbsession, mock_storage, mock_configuration):
     puf = ProfilingUploadFactory.create(
         profiling_commit__repository__yaml={"codecov": {"max_report_age": None}},
         raw_upload_location="raw_upload_location",

--- a/tasks/tests/unit/test_profiling_summarization.py
+++ b/tasks/tests/unit/test_profiling_summarization.py
@@ -9,7 +9,7 @@ from tasks.profiling_summarization import ProfilingSummarizationTask
 
 
 @pytest.mark.asyncio
-async def test_summarize_run_async_simple_run(
+async def test_summarize_run_impl_simple_run(
     dbsession, mock_storage, mock_configuration, mocker
 ):
     mocker.patch(
@@ -40,7 +40,7 @@ async def test_summarize_run_async_simple_run(
     dbsession.add(pfc)
     dbsession.flush()
     task = ProfilingSummarizationTask()
-    res = await task.run_async(dbsession, profiling_id=pfc.id)
+    res = task.run_impl(dbsession, profiling_id=pfc.id)
     assert res["successful"]
     assert json.loads(mock_storage.read_file("bucket", res["location"]).decode()) == {
         "version": "v1",
@@ -67,7 +67,7 @@ async def test_summarize_run_async_simple_run(
 
 
 @pytest.mark.asyncio
-async def test_summarize_run_async_simple_run_no_file(
+async def test_summarize_run_impl_simple_run_no_file(
     dbsession, mock_storage, mock_configuration
 ):
     mock_configuration._params["services"]["minio"]["bucket"] = "bucket"
@@ -75,7 +75,7 @@ async def test_summarize_run_async_simple_run_no_file(
     dbsession.add(pfc)
     dbsession.flush()
     task = ProfilingSummarizationTask()
-    res = await task.run_async(dbsession, profiling_id=pfc.id)
+    res = task.run_impl(dbsession, profiling_id=pfc.id)
     assert res == {"successful": False}
 
 

--- a/tasks/tests/unit/test_profiling_summarization.py
+++ b/tasks/tests/unit/test_profiling_summarization.py
@@ -8,8 +8,7 @@ from database.tests.factories.profiling import ProfilingCommitFactory
 from tasks.profiling_summarization import ProfilingSummarizationTask
 
 
-@pytest.mark.asyncio
-async def test_summarize_run_impl_simple_run(
+def test_summarize_run_impl_simple_run(
     dbsession, mock_storage, mock_configuration, mocker
 ):
     mocker.patch(
@@ -66,8 +65,7 @@ async def test_summarize_run_impl_simple_run(
     )
 
 
-@pytest.mark.asyncio
-async def test_summarize_run_impl_simple_run_no_file(
+def test_summarize_run_impl_simple_run_no_file(
     dbsession, mock_storage, mock_configuration
 ):
     mock_configuration._params["services"]["minio"]["bucket"] = "bucket"

--- a/tasks/tests/unit/test_save_commit_measurements.py
+++ b/tasks/tests/unit/test_save_commit_measurements.py
@@ -1,12 +1,9 @@
-import pytest
-
 from database.tests.factories.core import CommitFactory, OwnerFactory, RepositoryFactory
 from tasks.save_commit_measurements import SaveCommitMeasurementsTask
 
 
 class TestSaveCommitMeasurements(object):
-    @pytest.mark.asyncio
-    async def test_save_commit_measurements_success(self, dbsession, mocker):
+    def test_save_commit_measurements_success(self, dbsession, mocker):
         save_commit_measurements_mock = mocker.patch(
             "tasks.save_commit_measurements.save_commit_measurements"
         )
@@ -23,29 +20,27 @@ class TestSaveCommitMeasurements(object):
         dbsession.flush()
 
         task = SaveCommitMeasurementsTask()
-        assert await task.run_async(
+        assert task.run_impl(
             dbsession, commitid=commit.commitid, repoid=commit.repoid
         ) == {"successful": True}
         assert save_commit_measurements_mock.called_with(
             commitid=commit.commitid, dataset_names=None
         )
 
-    @pytest.mark.asyncio
-    async def test_save_commit_measurements_no_commit(self, dbsession):
+    def test_save_commit_measurements_no_commit(self, dbsession):
         owner = OwnerFactory.create(service="github")
         dbsession.add(owner)
         dbsession.flush()
 
         task = SaveCommitMeasurementsTask()
-        assert await task.run_async(
+        assert task.run_impl(
             dbsession, commitid="123asdf", repoid=123, dataset_names=[]
         ) == {
             "successful": False,
             "error": "no_commit_in_db",
         }
 
-    @pytest.mark.asyncio
-    async def test_save_commit_measurements_exception(self, mocker, dbsession):
+    def test_save_commit_measurements_exception(self, mocker, dbsession):
         save_commit_measurements_mock = mocker.patch(
             "tasks.save_commit_measurements.save_commit_measurements"
         )
@@ -63,7 +58,7 @@ class TestSaveCommitMeasurements(object):
         dbsession.flush()
 
         task = SaveCommitMeasurementsTask()
-        assert await task.run_async(
+        assert task.run_impl(
             dbsession, commitid=commit.commitid, repoid=commit.repoid
         ) == {
             "successful": False,

--- a/tasks/tests/unit/test_save_report_results_task.py
+++ b/tasks/tests/unit/test_save_report_results_task.py
@@ -284,7 +284,7 @@ class TestSaveReportResultsTask(object):
         )
         mocked_fetch_pull.return_value = None
         task = SaveReportResultsTask()
-        result = await task.run_async(
+        result = task.run_impl(
             dbsession,
             repoid=commit.repository.repoid,
             commitid=commit.commitid,
@@ -318,7 +318,7 @@ class TestSaveReportResultsTask(object):
         )
         mock_get_repo_service.side_effect = RepositoryWithoutValidBotError()
         task = SaveReportResultsTask()
-        result = await task.run_async(
+        result = task.run_impl(
             dbsession,
             repoid=commit.repository.repoid,
             commitid=commit.commitid,
@@ -350,7 +350,7 @@ class TestSaveReportResultsTask(object):
         )
         mocked_fetch_pull.return_value = None
         task = SaveReportResultsTask()
-        result = await task.run_async(
+        result = task.run_impl(
             dbsession,
             repoid=commit.repository.repoid,
             commitid=commit.commitid,

--- a/tasks/tests/unit/test_save_report_results_task.py
+++ b/tasks/tests/unit/test_save_report_results_task.py
@@ -222,8 +222,7 @@ class TestSaveReportResultsTaskHelpers(object):
         assert base_report is not None
         assert head_report is not None
 
-    @pytest.mark.asyncio
-    async def test_fetch_yaml_dict(self, dbsession, mocker, mock_repo_provider):
+    def test_fetch_yaml_dict(self, dbsession, mocker, mock_repo_provider):
         task = SaveReportResultsTask()
         mocked_fetch_yaml = mocker.patch("tasks.save_report_results.get_current_yaml")
         mocked_fetch_yaml.return_value = {"coverage": {"status": {"patch": True}}}
@@ -235,7 +234,7 @@ class TestSaveReportResultsTaskHelpers(object):
         )
         dbsession.add(commit)
         dbsession.flush()
-        yaml = await task.fetch_yaml_dict(None, commit, mock_repo_provider)
+        yaml = task.fetch_yaml_dict(None, commit, mock_repo_provider)
         mocked_fetch_yaml.assert_called_with(commit, mock_repo_provider)
         assert yaml == {"coverage": {"status": {"patch": True}}}
 
@@ -256,8 +255,7 @@ class TestSaveReportResultsTaskHelpers(object):
 
 
 class TestSaveReportResultsTask(object):
-    @pytest.mark.asyncio
-    async def test_save_patch_results_successful(self, dbsession, mocker):
+    def test_save_patch_results_successful(self, dbsession, mocker):
         commit = CommitFactory.create(
             message="",
             pullid=None,
@@ -293,8 +291,7 @@ class TestSaveReportResultsTask(object):
         )
         assert result == {"report_results_saved": True, "reason": "success"}
 
-    @pytest.mark.asyncio
-    async def test_save_patch_results_no_valid_bot(self, dbsession, mocker):
+    def test_save_patch_results_no_valid_bot(self, dbsession, mocker):
         commit = CommitFactory.create(
             message="",
             pullid=None,
@@ -330,8 +327,7 @@ class TestSaveReportResultsTask(object):
             "reason": "repository without valid bot",
         }
 
-    @pytest.mark.asyncio
-    async def test_save_patch_results_no_head_report(self, dbsession, mocker):
+    def test_save_patch_results_no_head_report(self, dbsession, mocker):
         commit = CommitFactory.create(
             message="",
             pullid=None,

--- a/tasks/tests/unit/test_send_email_task.py
+++ b/tasks/tests/unit/test_send_email_task.py
@@ -48,8 +48,7 @@ def mock_configuration_no_smtp(mocker):
 
 
 class TestSendEmailTask(object):
-    @pytest.mark.asyncio
-    async def test_send_email(
+    def test_send_email(
         self,
         mocker,
         mock_configuration,
@@ -77,8 +76,7 @@ class TestSendEmailTask(object):
         assert metrics.data["worker.tasks.send_email.succeed"] == 1
         assert metrics.data["worker.tasks.send_email.fail"] == 0
 
-    @pytest.mark.asyncio
-    async def test_send_email_non_existent_template(
+    def test_send_email_non_existent_template(
         self, mocker, mock_configuration, dbsession, mock_smtp
     ):
         owner = OwnerFactory.create(email=to_addr)
@@ -94,8 +92,7 @@ class TestSendEmailTask(object):
                 username="test_username",
             )
 
-    @pytest.mark.asyncio
-    async def test_send_email_no_owner(
+    def test_send_email_no_owner(
         self, mocker, mock_configuration, dbsession, mock_smtp
     ):
         owner = OwnerFactory.create(email=None)
@@ -115,8 +112,7 @@ class TestSendEmailTask(object):
             "err_msg": "Owner does not have email",
         }
 
-    @pytest.mark.asyncio
-    async def test_send_email_missing_kwargs(
+    def test_send_email_missing_kwargs(
         self, mocker, mock_configuration, dbsession, mock_smtp
     ):
         owner = OwnerFactory.create(email=to_addr)
@@ -131,8 +127,7 @@ class TestSendEmailTask(object):
                 template_name="test",
             )
 
-    @pytest.mark.asyncio
-    async def test_send_email_invalid_owner_no_list_type(
+    def test_send_email_invalid_owner_no_list_type(
         self, mocker, mock_configuration, dbsession, mock_smtp
     ):
         result = SendEmailTask().run_impl(
@@ -145,8 +140,7 @@ class TestSendEmailTask(object):
         )
         assert result == {"email_successful": False, "err_msg": "Unable to find owner"}
 
-    @pytest.mark.asyncio
-    async def test_send_email_recipients_refused(
+    def test_send_email_recipients_refused(
         self, mocker, mock_configuration, dbsession, mock_smtp
     ):
         mock_smtp.configure_mock(
@@ -168,8 +162,7 @@ class TestSendEmailTask(object):
         assert result["email_successful"] == False
         assert result["err_msg"] == "All recipients were refused"
 
-    @pytest.mark.asyncio
-    async def test_send_email_sender_refused(
+    def test_send_email_sender_refused(
         self, mocker, mock_configuration, dbsession, mock_smtp
     ):
         mock_smtp.configure_mock(
@@ -189,8 +182,7 @@ class TestSendEmailTask(object):
         assert result["email_successful"] == False
         assert result["err_msg"] == "Sender was refused"
 
-    @pytest.mark.asyncio
-    async def test_send_email_data_error(
+    def test_send_email_data_error(
         self, mocker, mock_configuration, dbsession, mock_smtp
     ):
         mock_smtp.configure_mock(
@@ -214,8 +206,7 @@ class TestSendEmailTask(object):
         assert result["email_successful"] == False
         assert result["err_msg"] == "The SMTP server did not accept the data"
 
-    @pytest.mark.asyncio
-    async def test_send_email_sends_errs(
+    def test_send_email_sends_errs(
         self, mocker, mock_configuration, dbsession, mock_smtp
     ):
         mock_smtp.configure_mock(
@@ -235,8 +226,7 @@ class TestSendEmailTask(object):
         assert result["email_successful"] == False
         assert result["err_msg"] == "123 abc 456 def"
 
-    @pytest.mark.asyncio
-    async def test_send_email_no_smtp_config(
+    def test_send_email_no_smtp_config(
         self, mocker, mock_configuration_no_smtp, dbsession
     ):
         SMTPService.connection = None

--- a/tasks/tests/unit/test_send_email_task.py
+++ b/tasks/tests/unit/test_send_email_task.py
@@ -63,7 +63,7 @@ class TestSendEmailTask(object):
         owner = OwnerFactory.create(email=to_addr)
         dbsession.add(owner)
         dbsession.flush()
-        result = await SendEmailTask().run_async(
+        result = SendEmailTask().run_impl(
             db_session=dbsession,
             ownerid=owner.ownerid,
             from_addr="test_from@codecov.io",
@@ -85,7 +85,7 @@ class TestSendEmailTask(object):
         dbsession.add(owner)
         dbsession.flush()
         with pytest.raises(TemplateNotFound):
-            result = await SendEmailTask().run_async(
+            result = SendEmailTask().run_impl(
                 db_session=dbsession,
                 ownerid=owner.ownerid,
                 from_addr="test_from@codecov.io",
@@ -101,7 +101,7 @@ class TestSendEmailTask(object):
         owner = OwnerFactory.create(email=None)
         dbsession.add(owner)
         dbsession.flush()
-        result = await SendEmailTask().run_async(
+        result = SendEmailTask().run_impl(
             db_session=dbsession,
             ownerid=owner.ownerid,
             from_addr="test_from@codecov.io",
@@ -123,7 +123,7 @@ class TestSendEmailTask(object):
         dbsession.add(owner)
         dbsession.flush()
         with pytest.raises(UndefinedError):
-            result = await SendEmailTask().run_async(
+            result = SendEmailTask().run_impl(
                 db_session=dbsession,
                 ownerid=owner.ownerid,
                 from_addr="test_from@codecov.io",
@@ -135,7 +135,7 @@ class TestSendEmailTask(object):
     async def test_send_email_invalid_owner_no_list_type(
         self, mocker, mock_configuration, dbsession, mock_smtp
     ):
-        result = await SendEmailTask().run_async(
+        result = SendEmailTask().run_impl(
             db_session=dbsession,
             ownerid=99999999,
             from_addr="test_from@codecov.io",
@@ -156,7 +156,7 @@ class TestSendEmailTask(object):
         owner = OwnerFactory.create(email=to_addr)
         dbsession.add(owner)
         dbsession.flush()
-        result = await SendEmailTask().run_async(
+        result = SendEmailTask().run_impl(
             db_session=dbsession,
             ownerid=owner.ownerid,
             from_addr="test_from@codecov.io",
@@ -178,7 +178,7 @@ class TestSendEmailTask(object):
         owner = OwnerFactory.create(email=to_addr)
         dbsession.add(owner)
         dbsession.flush()
-        result = await SendEmailTask().run_async(
+        result = SendEmailTask().run_impl(
             db_session=dbsession,
             ownerid=owner.ownerid,
             from_addr="test_from@codecov.io",
@@ -203,7 +203,7 @@ class TestSendEmailTask(object):
         owner = OwnerFactory.create(email=to_addr)
         dbsession.add(owner)
         dbsession.flush()
-        result = await SendEmailTask().run_async(
+        result = SendEmailTask().run_impl(
             db_session=dbsession,
             ownerid=owner.ownerid,
             from_addr="test_from@codecov.io",
@@ -224,7 +224,7 @@ class TestSendEmailTask(object):
         owner = OwnerFactory.create(email=to_addr)
         dbsession.add(owner)
         dbsession.flush()
-        result = await SendEmailTask().run_async(
+        result = SendEmailTask().run_impl(
             db_session=dbsession,
             ownerid=owner.ownerid,
             from_addr="test_from@codecov.io",
@@ -243,7 +243,7 @@ class TestSendEmailTask(object):
         owner = OwnerFactory.create(email=to_addr)
         dbsession.add(owner)
         dbsession.flush()
-        result = await SendEmailTask().run_async(
+        result = SendEmailTask().run_impl(
             db_session=dbsession,
             ownerid=owner.ownerid,
             from_addr="test_from@codecov.io",

--- a/tasks/tests/unit/test_status_set_error.py
+++ b/tasks/tests/unit/test_status_set_error.py
@@ -30,7 +30,7 @@ class TestSetErrorTaskUnit(object):
         dbsession.flush()
         repoid = commit.repoid
         commitid = commit.commitid
-        res = await StatusSetErrorTask().run_async(dbsession, repoid, commitid)
+        res = StatusSetErrorTask().run_impl(dbsession, repoid, commitid)
         assert not repo.set_commit_status.called
         assert res == {"status_set": False}
 
@@ -93,7 +93,7 @@ class TestSetErrorTaskUnit(object):
         dbsession.flush()
         repoid = commit.repoid
         commitid = commit.commitid
-        await StatusSetErrorTask().run_async(dbsession, repoid, commitid)
+        StatusSetErrorTask().run_impl(dbsession, repoid, commitid)
         if cc_status_exists:
             repo.set_commit_status.assert_called_with(
                 commit=commitid,
@@ -153,7 +153,7 @@ class TestSetErrorTaskUnit(object):
         repoid = commit.repoid
         commitid = commit.commitid
         custom_message = "Uh-oh. This is bad."
-        await StatusSetErrorTask().run_async(
+        StatusSetErrorTask().run_impl(
             dbsession, repoid, commitid, message=custom_message
         )
 

--- a/tasks/tests/unit/test_status_set_error.py
+++ b/tasks/tests/unit/test_status_set_error.py
@@ -12,8 +12,7 @@ here = Path(__file__)
 
 
 class TestSetErrorTaskUnit(object):
-    @pytest.mark.asyncio
-    async def test_no_status(self, mocker, mock_configuration, dbsession):
+    def test_no_status(self, mocker, mock_configuration, dbsession):
         mocked_1 = mocker.patch("tasks.status_set_error.get_repo_provider_service")
         repo = mocker.MagicMock(
             service="github",
@@ -34,7 +33,6 @@ class TestSetErrorTaskUnit(object):
         assert not repo.set_commit_status.called
         assert res == {"status_set": False}
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "context, cc_status_exists",
         [
@@ -46,7 +44,7 @@ class TestSetErrorTaskUnit(object):
             ("changes", False),
         ],
     )
-    async def test_set_error(
+    def test_set_error(
         self, context, cc_status_exists, mocker, mock_configuration, dbsession
     ):
         statuses = [
@@ -105,10 +103,7 @@ class TestSetErrorTaskUnit(object):
         else:
             assert not repo.set_commit_status.called
 
-    @pytest.mark.asyncio
-    async def test_set_error_custom_message(
-        self, mocker, mock_configuration, dbsession
-    ):
+    def test_set_error_custom_message(self, mocker, mock_configuration, dbsession):
         context = "project"
         statuses = [
             {

--- a/tasks/tests/unit/test_status_set_pending.py
+++ b/tasks/tests/unit/test_status_set_pending.py
@@ -12,8 +12,7 @@ here = Path(__file__)
 
 
 class TestSetPendingTaskUnit(object):
-    @pytest.mark.asyncio
-    async def test_no_status(self, mocker, mock_configuration, dbsession, mock_redis):
+    def test_no_status(self, mocker, mock_configuration, dbsession, mock_redis):
         mocked_1 = mocker.patch("tasks.status_set_pending.get_repo_provider_service")
         repo = mocker.MagicMock(
             service="github",
@@ -41,8 +40,7 @@ class TestSetPendingTaskUnit(object):
         assert res["status_set"] == False
         assert not repo.set_commit_status.called
 
-    @pytest.mark.asyncio
-    async def test_not_in_beta(self, mocker, mock_configuration, dbsession, mock_redis):
+    def test_not_in_beta(self, mocker, mock_configuration, dbsession, mock_redis):
         mocked_1 = mocker.patch("tasks.status_set_pending.get_repo_provider_service")
         repo = mocker.MagicMock(
             service="github",
@@ -72,10 +70,7 @@ class TestSetPendingTaskUnit(object):
             )
         mock_redis.sismember.assert_called_with("beta.pending", repoid)
 
-    @pytest.mark.asyncio
-    async def test_skip_set_pending(
-        self, mocker, mock_configuration, dbsession, mock_redis
-    ):
+    def test_skip_set_pending(self, mocker, mock_configuration, dbsession, mock_redis):
         mocked_1 = mocker.patch("tasks.status_set_pending.get_repo_provider_service")
         get_commit_statuses = Status([])
         set_commit_status = None
@@ -111,8 +106,7 @@ class TestSetPendingTaskUnit(object):
         assert not repo.set_commit_status.called
         assert res["status_set"] == False
 
-    @pytest.mark.asyncio
-    async def test_skip_set_pending_unknown_branch(
+    def test_skip_set_pending_unknown_branch(
         self, mocker, mock_configuration, dbsession, mock_redis
     ):
         mocked_1 = mocker.patch("tasks.status_set_pending.get_repo_provider_service")
@@ -152,7 +146,6 @@ class TestSetPendingTaskUnit(object):
         assert not repo.set_commit_status.called
         assert res["status_set"] == False
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "context, branch, cc_status_exists",
         [
@@ -169,7 +162,7 @@ class TestSetPendingTaskUnit(object):
             ("changes", "skip", False),
         ],
     )
-    async def test_set_pending(
+    def test_set_pending(
         self,
         context,
         branch,

--- a/tasks/tests/unit/test_status_set_pending.py
+++ b/tasks/tests/unit/test_status_set_pending.py
@@ -35,7 +35,7 @@ class TestSetPendingTaskUnit(object):
         commitid = commit.commitid
         branch = "master"
         on_a_pull_request = False
-        res = await StatusSetPendingTask().run_async(
+        res = StatusSetPendingTask().run_impl(
             dbsession, repoid, commitid, branch, on_a_pull_request
         )
         assert res["status_set"] == False
@@ -67,7 +67,7 @@ class TestSetPendingTaskUnit(object):
         with pytest.raises(
             AssertionError, match="Pending disabled. Please request to be in beta."
         ):
-            await StatusSetPendingTask().run_async(
+            StatusSetPendingTask().run_impl(
                 dbsession, repoid, commitid, branch, on_a_pull_request
             )
         mock_redis.sismember.assert_called_with("beta.pending", repoid)
@@ -105,7 +105,7 @@ class TestSetPendingTaskUnit(object):
         commitid = commit.commitid
         branch = "master"
         on_a_pull_request = False
-        res = await StatusSetPendingTask().run_async(
+        res = StatusSetPendingTask().run_impl(
             dbsession, repoid, commitid, branch, on_a_pull_request
         )
         assert not repo.set_commit_status.called
@@ -146,7 +146,7 @@ class TestSetPendingTaskUnit(object):
         commitid = commit.commitid
         branch = None
         on_a_pull_request = False
-        res = await StatusSetPendingTask().run_async(
+        res = StatusSetPendingTask().run_impl(
             dbsession, repoid, commitid, branch, on_a_pull_request
         )
         assert not repo.set_commit_status.called
@@ -227,7 +227,7 @@ class TestSetPendingTaskUnit(object):
         repoid = commit.repoid
         commitid = commit.commitid
         on_a_pull_request = False
-        await StatusSetPendingTask().run_async(
+        StatusSetPendingTask().run_impl(
             dbsession, repoid, commitid, branch, on_a_pull_request
         )
         if branch == "master" and not cc_status_exists:

--- a/tasks/tests/unit/test_sync_pull.py
+++ b/tasks/tests/unit/test_sync_pull.py
@@ -137,10 +137,7 @@ class TestPullSyncTask(object):
         assert not third_commit.merged
         assert not fourth_commit.merged
 
-    @pytest.mark.asyncio
-    async def test_call_pullsync_task_no_head_commit(
-        self, dbsession, mocker, mock_redis
-    ):
+    def test_call_pullsync_task_no_head_commit(self, dbsession, mocker, mock_redis):
         task = PullSyncTask()
         pull = PullFactory.create(head="head_commit_nonexistent_sha", state="open")
         dbsession.add(pull)
@@ -159,8 +156,7 @@ class TestPullSyncTask(object):
             "reason": "no_head",
         }
 
-    @pytest.mark.asyncio
-    async def test_call_pullsync_task_nolock(self, dbsession, mock_redis):
+    def test_call_pullsync_task_nolock(self, dbsession, mock_redis):
         task = PullSyncTask()
         pull = PullFactory.create(state="open")
         dbsession.add(pull)
@@ -174,10 +170,7 @@ class TestPullSyncTask(object):
             "reason": "unable_fetch_lock",
         }
 
-    @pytest.mark.asyncio
-    async def test_call_pullsync_task_no_database_pull(
-        self, dbsession, mocker, mock_redis
-    ):
+    def test_call_pullsync_task_no_database_pull(self, dbsession, mocker, mock_redis):
         repository = RepositoryFactory.create()
         dbsession.add(repository)
         dbsession.flush()
@@ -196,8 +189,7 @@ class TestPullSyncTask(object):
             "reason": "no_db_pull",
         }
 
-    @pytest.mark.asyncio
-    async def test_call_pullsync_task_no_provider_pull_only(
+    def test_call_pullsync_task_no_provider_pull_only(
         self, dbsession, mocker, mock_redis
     ):
         repository = RepositoryFactory.create()
@@ -221,8 +213,7 @@ class TestPullSyncTask(object):
             "reason": "not_in_provider",
         }
 
-    @pytest.mark.asyncio
-    async def test_call_pullsync_no_bot(self, dbsession, mock_redis, mocker):
+    def test_call_pullsync_no_bot(self, dbsession, mock_redis, mocker):
         task = PullSyncTask()
         pull = PullFactory.create(state="open")
         dbsession.add(pull)
@@ -239,8 +230,7 @@ class TestPullSyncTask(object):
             "reason": "no_bot",
         }
 
-    @pytest.mark.asyncio
-    async def test_call_pullsync_no_permissions_get_compare(
+    def test_call_pullsync_no_permissions_get_compare(
         self, dbsession, mock_redis, mocker, mock_repo_provider, mock_storage
     ):
         mocker.patch.object(PullSyncTask, "app")
@@ -280,8 +270,7 @@ class TestPullSyncTask(object):
             "reason": "success",
         }
 
-    @pytest.mark.asyncio
-    async def test_run_impl_unobtainable_lock(self, dbsession, mocker, mock_redis):
+    def test_run_impl_unobtainable_lock(self, dbsession, mocker, mock_redis):
         pull = PullFactory.create()
         dbsession.add(pull)
         dbsession.flush()

--- a/tasks/tests/unit/test_sync_repo_languages.py
+++ b/tasks/tests/unit/test_sync_repo_languages.py
@@ -60,8 +60,7 @@ def setup_with_torngit_error(mocker, mock_repo_provider):
 
 
 class TestSyncRepoLanguages(object):
-    @pytest.mark.asyncio
-    async def test_languages_no_intersection_and_not_synced_github(
+    def test_languages_no_intersection_and_not_synced_github(
         self, dbsession, setup_with_languages
     ):
         owner = OwnerFactory.create(service="github")
@@ -79,8 +78,7 @@ class TestSyncRepoLanguages(object):
         assert repo.languages == LIST_WITH_INTERSECTION
         assert repo.languages_last_updated == MOCKED_NOW
 
-    @pytest.mark.asyncio
-    async def test_languages_no_intersection_and_not_synced_gitlab(
+    def test_languages_no_intersection_and_not_synced_gitlab(
         self, dbsession, setup_with_languages
     ):
         owner = OwnerFactory.create(service="gitlab")
@@ -98,8 +96,7 @@ class TestSyncRepoLanguages(object):
         assert repo.languages == LIST_WITH_INTERSECTION
         assert repo.languages_last_updated == MOCKED_NOW
 
-    @pytest.mark.asyncio
-    async def test_languages_no_intersection_and_not_synced_bitbucket(
+    def test_languages_no_intersection_and_not_synced_bitbucket(
         self, dbsession, setup_with_languages_bitbucket
     ):
         owner = OwnerFactory.create(service="bitbucket")
@@ -120,8 +117,7 @@ class TestSyncRepoLanguages(object):
         assert repo.languages == ["javascript"]
         assert repo.languages_last_updated == MOCKED_NOW
 
-    @pytest.mark.asyncio
-    async def test_languages_no_intersection_and_synced_below_threshold(
+    def test_languages_no_intersection_and_synced_below_threshold(
         self, dbsession, setup_with_languages
     ):
         mocked_below_threshold = MOCKED_NOW + timedelta(days=-3)
@@ -137,8 +133,7 @@ class TestSyncRepoLanguages(object):
             task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
         )
 
-    @pytest.mark.asyncio
-    async def test_languages_no_intersection_and_synced_beyond_threshold(
+    def test_languages_no_intersection_and_synced_beyond_threshold(
         self, dbsession, setup_with_languages
     ):
         mocked_beyond_threshold = MOCKED_NOW + timedelta(days=-10)
@@ -156,8 +151,7 @@ class TestSyncRepoLanguages(object):
         assert repo.languages == LIST_WITH_INTERSECTION
         assert repo.languages_last_updated == MOCKED_NOW
 
-    @pytest.mark.asyncio
-    async def test_languages_intersection_and_synced_below_threshold(
+    def test_languages_intersection_and_synced_below_threshold(
         self, dbsession, setup_with_languages
     ):
         mocked_below_threshold = MOCKED_NOW + timedelta(days=-3)
@@ -173,8 +167,7 @@ class TestSyncRepoLanguages(object):
             task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
         )
 
-    @pytest.mark.asyncio
-    async def test_languages_intersection_and_synced_beyond_threshold(
+    def test_languages_intersection_and_synced_beyond_threshold(
         self, dbsession, setup_with_null_languages
     ):
         mocked_beyond_threshold = MOCKED_NOW + timedelta(days=-10)
@@ -190,8 +183,7 @@ class TestSyncRepoLanguages(object):
             task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
         )
 
-    @pytest.mark.asyncio
-    async def test_languages_intersection_and_synced_beyond_threshold(
+    def test_languages_intersection_and_synced_beyond_threshold(
         self, dbsession, setup_with_languages
     ):
         mocked_beyond_threshold = MOCKED_NOW + timedelta(days=-10)
@@ -207,8 +199,7 @@ class TestSyncRepoLanguages(object):
             task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
         )
 
-    @pytest.mark.asyncio
-    async def test_languages_intersection_and_synced_with_manual_trigger(
+    def test_languages_intersection_and_synced_with_manual_trigger(
         self, dbsession, setup_with_languages
     ):
         mocked_beyond_threshold = MOCKED_NOW + timedelta(days=-10)
@@ -226,8 +217,7 @@ class TestSyncRepoLanguages(object):
         assert repo.languages == LIST_WITH_INTERSECTION
         assert repo.languages_last_updated == MOCKED_NOW
 
-    @pytest.mark.asyncio
-    async def test_languages_torngit_error(self, dbsession, setup_with_torngit_error):
+    def test_languages_torngit_error(self, dbsession, setup_with_torngit_error):
         repo = RepositoryFactory.create(
             languages_last_updated=None, languages=["javascript"]
         )
@@ -239,8 +229,7 @@ class TestSyncRepoLanguages(object):
         assert res["successful"] == False
         assert res["error"] == "no_repo_in_provider"
 
-    @pytest.mark.asyncio
-    async def test_languages_no_repository(self, dbsession):
+    def test_languages_no_repository(self, dbsession):
         owner = OwnerFactory.create(service="github")
         dbsession.add(owner)
         dbsession.flush()

--- a/tasks/tests/unit/test_sync_repo_languages.py
+++ b/tasks/tests/unit/test_sync_repo_languages.py
@@ -73,9 +73,9 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert await task.run_async(
-            dbsession, repoid=repo.repoid, manual_trigger=False
-        ) == {"successful": True}
+        assert task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == {
+            "successful": True
+        }
         assert repo.languages == LIST_WITH_INTERSECTION
         assert repo.languages_last_updated == MOCKED_NOW
 
@@ -92,9 +92,9 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert await task.run_async(
-            dbsession, repoid=repo.repoid, manual_trigger=False
-        ) == {"successful": True}
+        assert task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == {
+            "successful": True
+        }
         assert repo.languages == LIST_WITH_INTERSECTION
         assert repo.languages_last_updated == MOCKED_NOW
 
@@ -114,9 +114,9 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert await task.run_async(
-            dbsession, repoid=repo.repoid, manual_trigger=False
-        ) == {"successful": True}
+        assert task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == {
+            "successful": True
+        }
         assert repo.languages == ["javascript"]
         assert repo.languages_last_updated == MOCKED_NOW
 
@@ -134,8 +134,7 @@ class TestSyncRepoLanguages(object):
 
         task = SyncRepoLanguagesTask()
         assert (
-            await task.run_async(dbsession, repoid=repo.repoid, manual_trigger=False)
-            == None
+            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
         )
 
     @pytest.mark.asyncio
@@ -151,9 +150,9 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert await task.run_async(
-            dbsession, repoid=repo.repoid, manual_trigger=False
-        ) == {"successful": True}
+        assert task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == {
+            "successful": True
+        }
         assert repo.languages == LIST_WITH_INTERSECTION
         assert repo.languages_last_updated == MOCKED_NOW
 
@@ -171,8 +170,7 @@ class TestSyncRepoLanguages(object):
 
         task = SyncRepoLanguagesTask()
         assert (
-            await task.run_async(dbsession, repoid=repo.repoid, manual_trigger=False)
-            == None
+            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
         )
 
     @pytest.mark.asyncio
@@ -189,8 +187,7 @@ class TestSyncRepoLanguages(object):
 
         task = SyncRepoLanguagesTask()
         assert (
-            await task.run_async(dbsession, repoid=repo.repoid, manual_trigger=False)
-            == None
+            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
         )
 
     @pytest.mark.asyncio
@@ -207,8 +204,7 @@ class TestSyncRepoLanguages(object):
 
         task = SyncRepoLanguagesTask()
         assert (
-            await task.run_async(dbsession, repoid=repo.repoid, manual_trigger=False)
-            == None
+            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
         )
 
     @pytest.mark.asyncio
@@ -224,9 +220,9 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert await task.run_async(
-            dbsession, repoid=repo.repoid, manual_trigger=True
-        ) == {"successful": True}
+        assert task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=True) == {
+            "successful": True
+        }
         assert repo.languages == LIST_WITH_INTERSECTION
         assert repo.languages_last_updated == MOCKED_NOW
 
@@ -239,7 +235,7 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        res = await task.run_async(dbsession, repoid=repo.repoid, manual_trigger=True)
+        res = task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=True)
         assert res["successful"] == False
         assert res["error"] == "no_repo_in_provider"
 
@@ -250,7 +246,7 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert await task.run_async(dbsession, repoid=123, manual_trigger=False) == {
+        assert task.run_impl(dbsession, repoid=123, manual_trigger=False) == {
             "successful": False,
             "error": "no_repo_in_db",
         }

--- a/tasks/tests/unit/test_sync_repos_task.py
+++ b/tasks/tests/unit/test_sync_repos_task.py
@@ -25,7 +25,7 @@ class AsyncIterator:
     def __aiter__(self):
         return self
 
-    async def __anext__(self):
+    def __anext__(self):
         try:
             return next(self.iter)
         except StopIteration:
@@ -42,8 +42,7 @@ def reuse_cassette(filepath):
 
 
 class TestSyncReposTaskUnit(object):
-    @pytest.mark.asyncio
-    async def test_unknown_owner(self, mocker, mock_configuration, dbsession):
+    def test_unknown_owner(self, mocker, mock_configuration, dbsession):
         unknown_ownerid = 10404
         with pytest.raises(AssertionError, match="Owner not found"):
             SyncReposTask().run_impl(
@@ -53,8 +52,7 @@ class TestSyncReposTaskUnit(object):
                 using_integration=False,
             )
 
-    @pytest.mark.asyncio
-    async def test_upsert_owner_add_new(self, mocker, mock_configuration, dbsession):
+    def test_upsert_owner_add_new(self, mocker, mock_configuration, dbsession):
         service = "github"
         service_id = "123456"
         username = "some_org"
@@ -79,10 +77,7 @@ class TestSyncReposTaskUnit(object):
         assert new_entry.username == username
         assert new_entry.createstamp is None
 
-    @pytest.mark.asyncio
-    async def test_upsert_owner_update_existing(
-        self, mocker, mock_configuration, dbsession
-    ):
+    def test_upsert_owner_update_existing(self, mocker, mock_configuration, dbsession):
         ownerid = 1
         service = "github"
         service_id = "123456"
@@ -115,9 +110,8 @@ class TestSyncReposTaskUnit(object):
         assert updated_owner.username == new_username
         assert updated_owner.createstamp == now
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
-    async def test_upsert_repo_update_existing(
+    def test_upsert_repo_update_existing(
         self, mocker, mock_configuration, dbsession, use_generator
     ):
         mocker.patch.object(
@@ -172,9 +166,8 @@ class TestSyncReposTaskUnit(object):
         assert updated_repo.updatestamp is not None
         assert updated_repo.deleted is False
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
-    async def test_upsert_repo_exists_but_wrong_owner(
+    def test_upsert_repo_exists_but_wrong_owner(
         self, mocker, mock_configuration, dbsession, use_generator
     ):
         mocker.patch.object(
@@ -235,9 +228,8 @@ class TestSyncReposTaskUnit(object):
         assert updated_repo.deleted is False
         assert updated_repo.updatestamp is not None
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
-    async def test_upsert_repo_exists_both_wrong_owner_and_service_id(
+    def test_upsert_repo_exists_both_wrong_owner_and_service_id(
         self, mocker, mock_configuration, dbsession, use_generator
     ):
         mocker.patch.object(
@@ -310,9 +302,8 @@ class TestSyncReposTaskUnit(object):
         assert repo_same_name.service_id == wrong_service_id
         assert repo_same_name.ownerid == correct_owner.ownerid
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
-    async def test_upsert_repo_exists_but_wrong_service_id(
+    def test_upsert_repo_exists_but_wrong_service_id(
         self, mocker, mock_configuration, dbsession, use_generator
     ):
         mocker.patch.object(
@@ -378,9 +369,8 @@ class TestSyncReposTaskUnit(object):
         )
         assert bad_service_id_repo is None
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
-    async def test_upsert_repo_create_new(
+    def test_upsert_repo_create_new(
         self, mocker, mock_configuration, dbsession, use_generator
     ):
         mocker.patch.object(
@@ -427,9 +417,8 @@ class TestSyncReposTaskUnit(object):
         assert new_repo.branch == repo_data.get("branch")
         assert new_repo.private is True
 
-    @pytest.mark.asyncio
     @pytest.mark.django_db(databases={"default"})
-    async def test_only_public_repos_already_in_db(
+    def test_only_public_repos_already_in_db(
         self, mocker, mock_configuration, dbsession, codecov_vcr, mock_redis
     ):
 
@@ -486,9 +475,8 @@ class TestSyncReposTaskUnit(object):
         assert user.permission == []  # there were no private repos to add
         assert len(repos) == 3
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
-    async def test_sync_repos_lock_error(
+    def test_sync_repos_lock_error(
         self, mocker, mock_configuration, dbsession, mock_redis, use_generator
     ):
         mocker.patch.object(
@@ -509,14 +497,13 @@ class TestSyncReposTaskUnit(object):
         )
         assert user.permission == []  # there were no private repos to add
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
     @reuse_cassette(
         "tasks/tests/unit/cassetes/test_sync_repos_task/TestSyncReposTaskUnit/test_only_public_repos_not_in_db.yaml"
     )
     @respx.mock
     @pytest.mark.django_db(databases={"default"})
-    async def test_only_public_repos_not_in_db(
+    def test_only_public_repos_not_in_db(
         self, mocker, mock_configuration, dbsession, mock_redis, use_generator
     ):
         mocker.patch.object(
@@ -559,14 +546,13 @@ class TestSyncReposTaskUnit(object):
         assert repos[0].service_id == public_repo_service_id
         assert repos[0].ownerid == user.ownerid
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
     @respx.mock
     @reuse_cassette(
         "tasks/tests/unit/cassetes/test_sync_repos_task/TestSyncReposTaskUnit/test_sync_repos_using_integration.yaml"
     )
     @pytest.mark.django_db(databases={"default"})
-    async def test_sync_repos_using_integration(
+    def test_sync_repos_using_integration(
         self,
         mocker,
         dbsession,
@@ -670,13 +656,12 @@ class TestSyncReposTaskUnit(object):
         for repo in repos:
             assert repo.using_integration is True
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
     @respx.mock
     @reuse_cassette(
         "tasks/tests/unit/cassetes/test_sync_repos_task/TestSyncReposTaskUnit/test_sync_repos_using_integration_no_repos.yaml"
     )
-    async def test_sync_repos_using_integration_no_repos(
+    def test_sync_repos_using_integration_no_repos(
         self, mocker, mock_configuration, dbsession, mock_redis, use_generator
     ):
         mocker.patch.object(
@@ -742,9 +727,8 @@ class TestSyncReposTaskUnit(object):
             # repos are no longer using integration
             assert repo.using_integration is False
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
-    async def test_sync_repos_no_github_access(
+    def test_sync_repos_no_github_access(
         self,
         mocker,
         mock_configuration,
@@ -779,9 +763,8 @@ class TestSyncReposTaskUnit(object):
         )
         assert user.permission == []  # repos were removed
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
-    async def test_sync_repos_timeout(
+    def test_sync_repos_timeout(
         self,
         mocker,
         mock_configuration,
@@ -819,13 +802,12 @@ class TestSyncReposTaskUnit(object):
             [r.repoid for r in repos]
         )  # repos were removed
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
     @reuse_cassette(
         "tasks/tests/unit/cassetes/test_sync_repos_task/TestSyncReposTaskUnit/test_only_public_repos_not_in_db.yaml"
     )
     @respx.mock
-    async def test_insert_repo_and_call_repo_sync_languages(
+    def test_insert_repo_and_call_repo_sync_languages(
         self, mocker, mock_configuration, dbsession, mock_redis, use_generator
     ):
         mocked_app = mocker.patch.object(
@@ -881,13 +863,12 @@ class TestSyncReposTaskUnit(object):
             kwargs={"repoid": repos[0].repoid, "manual_trigger": False}
         )
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("use_generator", [False])
     @respx.mock
     @reuse_cassette(
         "tasks/tests/unit/cassetes/test_sync_repos_task/TestSyncReposTaskUnit/test_sync_repos_using_integration.yaml"
     )
-    async def test_insert_repo_and_call_repo_sync_languages_using_integration(
+    def test_insert_repo_and_call_repo_sync_languages_using_integration(
         self,
         mocker,
         dbsession,
@@ -1005,8 +986,7 @@ class TestSyncReposTaskUnit(object):
             kwargs={"repoid": new_repo_list[0].repoid, "manual_trigger": False}
         )
 
-    @pytest.mark.asyncio
-    async def test_sync_repos_usgin_integration_affected_repos_known(
+    def test_sync_repos_usgin_integration_affected_repos_known(
         self,
         mocker,
         dbsession,
@@ -1074,7 +1054,7 @@ class TestSyncReposTaskUnit(object):
         dbsession.flush()
 
         # These are the repos we're supposed to query from the service provider
-        async def side_effect(*args, **kwargs):
+        def side_effect(*args, **kwargs):
             results = [
                 {
                     "branch": "main",

--- a/tasks/tests/unit/test_sync_repos_task.py
+++ b/tasks/tests/unit/test_sync_repos_task.py
@@ -46,7 +46,7 @@ class TestSyncReposTaskUnit(object):
     async def test_unknown_owner(self, mocker, mock_configuration, dbsession):
         unknown_ownerid = 10404
         with pytest.raises(AssertionError, match="Owner not found"):
-            await SyncReposTask().run_async(
+            SyncReposTask().run_impl(
                 dbsession,
                 ownerid=unknown_ownerid,
                 username=None,
@@ -474,7 +474,7 @@ class TestSyncReposTaskUnit(object):
         dbsession.add(repo_spack)
         dbsession.flush()
 
-        await SyncReposTask().run_async(
+        SyncReposTask().run_impl(
             dbsession, ownerid=user.ownerid, using_integration=False
         )
         repos = (
@@ -504,7 +504,7 @@ class TestSyncReposTaskUnit(object):
         dbsession.add(user)
         dbsession.flush()
         mock_redis.lock.side_effect = LockError
-        await SyncReposTask().run_async(
+        SyncReposTask().run_impl(
             dbsession, ownerid=user.ownerid, using_integration=False
         )
         assert user.permission == []  # there were no private repos to add
@@ -543,7 +543,7 @@ class TestSyncReposTaskUnit(object):
         )
         dbsession.add(user)
         dbsession.flush()
-        await SyncReposTask().run_async(
+        SyncReposTask().run_impl(
             dbsession, ownerid=user.ownerid, using_integration=False
         )
 
@@ -647,7 +647,7 @@ class TestSyncReposTaskUnit(object):
             dbsession.add(repo)
         dbsession.flush()
 
-        await SyncReposTask().run_async(
+        SyncReposTask().run_impl(
             dbsession, ownerid=user.ownerid, using_integration=True
         )
         dbsession.commit()
@@ -720,7 +720,7 @@ class TestSyncReposTaskUnit(object):
         dbsession.add(repo_spack)
         dbsession.flush()
 
-        await SyncReposTask().run_async(
+        SyncReposTask().run_impl(
             dbsession, ownerid=user.ownerid, using_integration=True
         )
 
@@ -774,7 +774,7 @@ class TestSyncReposTaskUnit(object):
         mock_owner_provider.list_repos.side_effect = TorngitClientError(
             "code", "response", "message"
         )
-        await SyncReposTask().run_async(
+        SyncReposTask().run_impl(
             dbsession, ownerid=user.ownerid, using_integration=False
         )
         assert user.permission == []  # repos were removed
@@ -812,7 +812,7 @@ class TestSyncReposTaskUnit(object):
             mock_owner_provider.list_repos.side_effect = SoftTimeLimitExceeded()
 
         with pytest.raises(SoftTimeLimitExceeded):
-            await SyncReposTask().run_async(
+            SyncReposTask().run_impl(
                 dbsession, ownerid=user.ownerid, using_integration=False
             )
         assert user.permission == sorted(
@@ -861,7 +861,7 @@ class TestSyncReposTaskUnit(object):
         )
         dbsession.add(user)
         dbsession.flush()
-        await SyncReposTask().run_async(
+        SyncReposTask().run_impl(
             dbsession, ownerid=user.ownerid, using_integration=False
         )
 
@@ -976,7 +976,7 @@ class TestSyncReposTaskUnit(object):
             dbsession.add(repo)
         dbsession.flush()
 
-        await SyncReposTask().run_async(
+        SyncReposTask().run_impl(
             dbsession, ownerid=user.ownerid, using_integration=True
         )
         dbsession.commit()
@@ -1121,7 +1121,7 @@ class TestSyncReposTaskUnit(object):
         mock_owner_provider.get_repos_from_nodeids_generator.side_effect = side_effect
         mock_owner_provider.service = "github"
 
-        await SyncReposTask().run_async(
+        SyncReposTask().run_impl(
             dbsession,
             ownerid=user.ownerid,
             using_integration=True,

--- a/tasks/tests/unit/test_sync_teams_task.py
+++ b/tasks/tests/unit/test_sync_teams_task.py
@@ -15,7 +15,7 @@ class TestSyncTeamsTaskUnit(object):
     async def test_unknown_owner(self, mocker, mock_configuration, dbsession):
         unknown_ownerid = 10404
         with pytest.raises(AssertionError, match="Owner not found"):
-            await SyncTeamsTask().run_async(
+            SyncTeamsTask().run_impl(
                 dbsession, unknown_ownerid, username=None, using_integration=False
             )
 
@@ -27,9 +27,7 @@ class TestSyncTeamsTaskUnit(object):
         )
         dbsession.add(user)
         dbsession.flush()
-        await SyncTeamsTask().run_async(
-            dbsession, user.ownerid, using_integration=False
-        )
+        SyncTeamsTask().run_impl(dbsession, user.ownerid, using_integration=False)
         assert user.organizations == []
 
     @pytest.mark.asyncio
@@ -46,9 +44,7 @@ class TestSyncTeamsTaskUnit(object):
         )
         dbsession.add(user)
         dbsession.flush()
-        await SyncTeamsTask().run_async(
-            dbsession, user.ownerid, using_integration=False
-        )
+        SyncTeamsTask().run_impl(dbsession, user.ownerid, using_integration=False)
         assert prev_team.ownerid not in user.organizations
 
     @pytest.mark.asyncio
@@ -72,9 +68,7 @@ class TestSyncTeamsTaskUnit(object):
         dbsession.add(user)
         dbsession.flush()
 
-        await SyncTeamsTask().run_async(
-            dbsession, user.ownerid, using_integration=False
-        )
+        SyncTeamsTask().run_impl(dbsession, user.ownerid, using_integration=False)
         assert old_team.ownerid in user.organizations
 
         # old team in db should have its data updated
@@ -99,9 +93,7 @@ class TestSyncTeamsTaskUnit(object):
         )
         dbsession.add(user)
         dbsession.flush()
-        await SyncTeamsTask().run_async(
-            dbsession, user.ownerid, using_integration=False
-        )
+        SyncTeamsTask().run_impl(dbsession, user.ownerid, using_integration=False)
 
         assert len(user.organizations) == 6
         gitlab_groups = (

--- a/tasks/tests/unit/test_sync_teams_task.py
+++ b/tasks/tests/unit/test_sync_teams_task.py
@@ -11,16 +11,14 @@ here = Path(__file__)
 
 
 class TestSyncTeamsTaskUnit(object):
-    @pytest.mark.asyncio
-    async def test_unknown_owner(self, mocker, mock_configuration, dbsession):
+    def test_unknown_owner(self, mocker, mock_configuration, dbsession):
         unknown_ownerid = 10404
         with pytest.raises(AssertionError, match="Owner not found"):
             SyncTeamsTask().run_impl(
                 dbsession, unknown_ownerid, username=None, using_integration=False
             )
 
-    @pytest.mark.asyncio
-    async def test_no_teams(self, mocker, mock_configuration, dbsession, codecov_vcr):
+    def test_no_teams(self, mocker, mock_configuration, dbsession, codecov_vcr):
         token = "testv2ztxs03zwys22v36ama292esl13swroe6dj"
         user = OwnerFactory.create(
             organizations=[], service="github", unencrypted_oauth_token=token
@@ -30,10 +28,7 @@ class TestSyncTeamsTaskUnit(object):
         SyncTeamsTask().run_impl(dbsession, user.ownerid, using_integration=False)
         assert user.organizations == []
 
-    @pytest.mark.asyncio
-    async def test_team_removed(
-        self, mocker, mock_configuration, dbsession, codecov_vcr
-    ):
+    def test_team_removed(self, mocker, mock_configuration, dbsession, codecov_vcr):
         token = "testv2ztxs03zwys22v36ama292esl13swroe6dj"
         prev_team = OwnerFactory.create(service="github", username="Evil_Corp")
         dbsession.add(prev_team)
@@ -47,8 +42,7 @@ class TestSyncTeamsTaskUnit(object):
         SyncTeamsTask().run_impl(dbsession, user.ownerid, using_integration=False)
         assert prev_team.ownerid not in user.organizations
 
-    @pytest.mark.asyncio
-    async def test_team_data_updated(
+    def test_team_data_updated(
         self, mocker, mock_configuration, dbsession, codecov_vcr
     ):
         token = "testh0ry1fe5tiysbtbh6x47fdwotcsoyv7orqrd"
@@ -77,8 +71,7 @@ class TestSyncTeamsTaskUnit(object):
         assert old_team.name == "codecov"
         assert str(old_team.updatestamp) > last_updated
 
-    @pytest.mark.asyncio
-    async def test_gitlab_subgroups(
+    def test_gitlab_subgroups(
         self, mocker, mock_configuration, dbsession, codecov_vcr, caplog
     ):
         import logging

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -168,7 +168,7 @@ class TestUploadTestFinisherTask(object):
         dbsession.add(test_instance4)
         dbsession.flush()
 
-        result = await TestResultsFinisherTask().run_async(
+        result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
                 [{"successful": True}],
@@ -348,7 +348,7 @@ class TestUploadTestFinisherTask(object):
         dbsession.add(test_instance4)
         dbsession.flush()
 
-        result = await TestResultsFinisherTask().run_async(
+        result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
                 [{"successful": True}],
@@ -522,7 +522,7 @@ class TestUploadTestFinisherTask(object):
         dbsession.add(test_instance3)
         dbsession.flush()
 
-        result = await TestResultsFinisherTask().run_async(
+        result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
                 [{"successful": True}],
@@ -699,7 +699,7 @@ class TestUploadTestFinisherTask(object):
         dbsession.add(test_instance3)
         dbsession.flush()
 
-        result = await TestResultsFinisherTask().run_async(
+        result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
                 [{"successful": False}],
@@ -861,7 +861,7 @@ class TestUploadTestFinisherTask(object):
         dbsession.add(test_instance3)
         dbsession.flush()
 
-        result = await TestResultsFinisherTask().run_async(
+        result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
                 [{"successful": True}],
@@ -1023,7 +1023,7 @@ class TestUploadTestFinisherTask(object):
         dbsession.add(test_instance3)
         dbsession.flush()
 
-        result = await TestResultsFinisherTask().run_async(
+        result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
                 [{"successful": True}],

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -17,9 +17,8 @@ here = Path(__file__)
 
 
 class TestUploadTestFinisherTask(object):
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_finisher_task_call(
+    def test_upload_finisher_task_call(
         self,
         mocker,
         mock_configuration,
@@ -186,9 +185,8 @@ class TestUploadTestFinisherTask(object):
 
         assert expected_result == result
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_finisher_task_call_multi_env_fail(
+    def test_upload_finisher_task_call_multi_env_fail(
         self,
         mocker,
         mock_configuration,
@@ -382,9 +380,8 @@ class TestUploadTestFinisherTask(object):
         for c in calls:
             assert c in mock_metrics.timing.mock_calls
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_finisher_task_call_no_failures(
+    def test_upload_finisher_task_call_no_failures(
         self,
         mocker,
         mock_configuration,
@@ -558,9 +555,8 @@ class TestUploadTestFinisherTask(object):
         for c in calls:
             assert c in mock_metrics.timing.mock_calls
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_finisher_task_call_no_success(
+    def test_upload_finisher_task_call_no_success(
         self,
         mocker,
         mock_configuration,
@@ -723,9 +719,8 @@ class TestUploadTestFinisherTask(object):
         )
         assert mock_metrics.timing.mock_calls == []
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_finisher_task_call_existing_comment(
+    def test_upload_finisher_task_call_existing_comment(
         self,
         mocker,
         mock_configuration,
@@ -881,9 +876,8 @@ class TestUploadTestFinisherTask(object):
 
         assert expected_result == result
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_finisher_task_call_comment_fails(
+    def test_upload_finisher_task_call_comment_fails(
         self,
         mocker,
         mock_configuration,

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -58,7 +58,7 @@ class TestUploadTestProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        result = await TestResultsProcessorTask().run_async(
+        result = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=upload.report.commit.repoid,
             commitid=commit.commitid,
@@ -142,7 +142,7 @@ class TestUploadTestProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        result = await TestResultsProcessorTask().run_async(
+        result = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -208,7 +208,7 @@ class TestUploadTestProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        result = await TestResultsProcessorTask().run_async(
+        result = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -287,7 +287,7 @@ class TestUploadTestProcessorTask(object):
         dbsession.add(current_report_row)
         dbsession.flush()
 
-        result = await TestResultsProcessorTask().run_async(
+        result = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -358,7 +358,7 @@ class TestUploadTestProcessorTask(object):
         dbsession.add(current_report_row)
         dbsession.flush()
 
-        result = await TestResultsProcessorTask().run_async(
+        result = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -422,7 +422,7 @@ class TestUploadTestProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        result = await TestResultsProcessorTask().run_async(
+        result = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -494,7 +494,7 @@ class TestUploadTestProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        result = await TestResultsProcessorTask().run_async(
+        result = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -561,7 +561,7 @@ class TestUploadTestProcessorTask(object):
         dbsession.add(existing_test)
         dbsession.flush()
 
-        result = await TestResultsProcessorTask().run_async(
+        result = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=repoid,
             commitid=commit.commitid,
@@ -648,7 +648,7 @@ class TestUploadTestProcessorTask(object):
         dbsession.add(existing_test)
         dbsession.flush()
 
-        result = await TestResultsProcessorTask().run_async(
+        result = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=repoid,
             commitid=commit.commitid,

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -19,9 +19,8 @@ here = Path(__file__)
 
 
 class TestUploadTestProcessorTask(object):
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_processor_task_call(
+    def test_upload_processor_task_call(
         self,
         mocker,
         mock_configuration,
@@ -107,9 +106,8 @@ class TestUploadTestProcessorTask(object):
         for c in calls:
             assert c in mock_metrics.timing.mock_calls
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_processor_task_call_pytest_reportlog(
+    def test_upload_processor_task_call_pytest_reportlog(
         self,
         mocker,
         mock_configuration,
@@ -173,9 +171,8 @@ class TestUploadTestProcessorTask(object):
         assert expected_result == result
         assert commit.message == "hello world"
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_processor_task_call_vitest(
+    def test_upload_processor_task_call_vitest(
         self,
         mocker,
         mock_configuration,
@@ -240,9 +237,8 @@ class TestUploadTestProcessorTask(object):
         assert expected_result == result
         assert commit.message == "hello world"
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_test_result_processor_task_error_report_matching(
+    def test_test_result_processor_task_error_report_matching(
         self,
         caplog,
         mocker,
@@ -311,9 +307,8 @@ class TestUploadTestProcessorTask(object):
         for c in calls:
             assert c in mock_metrics.timing.mock_calls
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_test_result_processor_task_error_parsing_file(
+    def test_test_result_processor_task_error_parsing_file(
         self,
         caplog,
         mocker,
@@ -382,9 +377,8 @@ class TestUploadTestProcessorTask(object):
         for c in calls:
             assert c in mock_metrics.timing.mock_calls
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_test_result_processor_task_delete_archive(
+    def test_test_result_processor_task_delete_archive(
         self,
         caplog,
         mocker,
@@ -455,9 +449,8 @@ class TestUploadTestProcessorTask(object):
         with pytest.raises(FileNotInStorageError):
             mock_storage.read_file("archive", url)
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_test_result_processor_task_bad_file(
+    def test_test_result_processor_task_bad_file(
         self,
         caplog,
         mocker,
@@ -506,9 +499,8 @@ class TestUploadTestProcessorTask(object):
         assert expected_result == result
         assert "File did not match any parser format" in caplog.text
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_processor_task_call_existing_test(
+    def test_upload_processor_task_call_existing_test(
         self,
         mocker,
         mock_configuration,
@@ -593,9 +585,8 @@ class TestUploadTestProcessorTask(object):
         assert expected_result == result
         assert commit.message == "hello world"
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_processor_task_call_existing_test_diff_flags_hash(
+    def test_upload_processor_task_call_existing_test_diff_flags_hash(
         self,
         mocker,
         mock_configuration,

--- a/tasks/tests/unit/test_timeseries_backfill_commits.py
+++ b/tasks/tests/unit/test_timeseries_backfill_commits.py
@@ -9,7 +9,7 @@ from tasks.timeseries_backfill import TimeseriesBackfillCommitsTask
 
 
 @pytest.mark.asyncio
-async def test_backfill_commits_run_async(dbsession, mocker):
+async def test_backfill_commits_run_impl(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=True)
     mocked_app = mocker.patch.object(
         TimeseriesBackfillCommitsTask,
@@ -36,7 +36,7 @@ async def test_backfill_commits_run_async(dbsession, mocker):
     dbsession.flush()
 
     task = TimeseriesBackfillCommitsTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         commit_ids=[commit1.id_, commit2.id_],
         dataset_names=[dataset.name],
@@ -64,12 +64,12 @@ async def test_backfill_commits_run_async(dbsession, mocker):
 
 
 @pytest.mark.asyncio
-async def test_backfill_commits_run_async_timeseries_not_enabled(dbsession, mocker):
+async def test_backfill_commits_run_impl_timeseries_not_enabled(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=False)
     mock_group = mocker.patch("tasks.timeseries_backfill.group")
 
     task = TimeseriesBackfillCommitsTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         commit_ids=[1, 2, 3],
         dataset_names=["testing"],

--- a/tasks/tests/unit/test_timeseries_backfill_commits.py
+++ b/tasks/tests/unit/test_timeseries_backfill_commits.py
@@ -8,8 +8,7 @@ from database.tests.factories.timeseries import DatasetFactory
 from tasks.timeseries_backfill import TimeseriesBackfillCommitsTask
 
 
-@pytest.mark.asyncio
-async def test_backfill_commits_run_impl(dbsession, mocker):
+def test_backfill_commits_run_impl(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=True)
     mocked_app = mocker.patch.object(
         TimeseriesBackfillCommitsTask,
@@ -63,8 +62,7 @@ async def test_backfill_commits_run_impl(dbsession, mocker):
     )
 
 
-@pytest.mark.asyncio
-async def test_backfill_commits_run_impl_timeseries_not_enabled(dbsession, mocker):
+def test_backfill_commits_run_impl_timeseries_not_enabled(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=False)
     mock_group = mocker.patch("tasks.timeseries_backfill.group")
 

--- a/tasks/tests/unit/test_timeseries_backfill_dataset.py
+++ b/tasks/tests/unit/test_timeseries_backfill_dataset.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from os import times
 
-import pytest
-
 from database.models import MeasurementName
 from database.tests.factories import RepositoryFactory
 from database.tests.factories.core import CommitFactory
@@ -13,8 +11,7 @@ from tasks.timeseries_backfill import (
 )
 
 
-@pytest.mark.asyncio
-async def test_backfill_dataset_run_async(dbsession, mocker):
+def test_backfill_dataset_run_impl(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=True)
     mock_group = mocker.patch("tasks.timeseries_backfill.group")
 
@@ -47,7 +44,7 @@ async def test_backfill_dataset_run_async(dbsession, mocker):
     dbsession.flush()
 
     task = TimeseriesBackfillDatasetTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         dataset_id=dataset.id_,
         start_date="2022-01-01T00:00:00",
@@ -73,8 +70,7 @@ async def test_backfill_dataset_run_async(dbsession, mocker):
     mock_group.assert_called_once_with(expected_signatures)
 
 
-@pytest.mark.asyncio
-async def test_backfill_dataset_run_async_invalid_dataset(dbsession, mocker):
+def test_backfill_dataset_run_impl_invalid_dataset(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=True)
     mock_group = mocker.patch("tasks.timeseries_backfill.group")
 
@@ -90,7 +86,7 @@ async def test_backfill_dataset_run_async_invalid_dataset(dbsession, mocker):
     dbsession.flush()
 
     task = TimeseriesBackfillDatasetTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         dataset_id=9999,
         start_date="2022-01-01T00:00:00",
@@ -101,8 +97,7 @@ async def test_backfill_dataset_run_async_invalid_dataset(dbsession, mocker):
     assert not mock_group.called
 
 
-@pytest.mark.asyncio
-async def test_backfill_dataset_run_async_invalid_repository(dbsession, mocker):
+def test_backfill_dataset_run_impl_invalid_repository(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=True)
     mock_group = mocker.patch("tasks.timeseries_backfill.group")
 
@@ -118,7 +113,7 @@ async def test_backfill_dataset_run_async_invalid_repository(dbsession, mocker):
     dbsession.flush()
 
     task = TimeseriesBackfillDatasetTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         dataset_id=dataset.id_,
         start_date="2022-01-01T00:00:00",
@@ -129,8 +124,7 @@ async def test_backfill_dataset_run_async_invalid_repository(dbsession, mocker):
     assert not mock_group.called
 
 
-@pytest.mark.asyncio
-async def test_backfill_dataset_run_async_invalid_start_date(dbsession, mocker):
+def test_backfill_dataset_run_impl_invalid_start_date(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=True)
     mock_group = mocker.patch("tasks.timeseries_backfill.group")
 
@@ -146,7 +140,7 @@ async def test_backfill_dataset_run_async_invalid_start_date(dbsession, mocker):
     dbsession.flush()
 
     task = TimeseriesBackfillDatasetTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         dataset_id=dataset.id_,
         start_date="invalid",
@@ -157,8 +151,7 @@ async def test_backfill_dataset_run_async_invalid_start_date(dbsession, mocker):
     assert not mock_group.called
 
 
-@pytest.mark.asyncio
-async def test_backfill_dataset_run_async_invalid_end_date(dbsession, mocker):
+def test_backfill_dataset_run_impl_invalid_end_date(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=True)
     mock_group = mocker.patch("tasks.timeseries_backfill.group")
 
@@ -174,7 +167,7 @@ async def test_backfill_dataset_run_async_invalid_end_date(dbsession, mocker):
     dbsession.flush()
 
     task = TimeseriesBackfillDatasetTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         dataset_id=dataset.id_,
         start_date="2022-01-01T00:00:00",
@@ -185,13 +178,12 @@ async def test_backfill_dataset_run_async_invalid_end_date(dbsession, mocker):
     assert not mock_group.called
 
 
-@pytest.mark.asyncio
-async def test_backfill_dataset_run_async_timeseries_not_enabled(dbsession, mocker):
+def test_backfill_dataset_run_impl_timeseries_not_enabled(dbsession, mocker):
     mocker.patch("tasks.timeseries_backfill.timeseries_enabled", return_value=False)
     mock_group = mocker.patch("tasks.timeseries_backfill.group")
 
     task = TimeseriesBackfillDatasetTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         dataset_id=9999,
         start_date="2022-01-01T00:00:00",

--- a/tasks/tests/unit/test_timeseries_delete.py
+++ b/tasks/tests/unit/test_timeseries_delete.py
@@ -5,7 +5,7 @@ from tasks.timeseries_delete import TimeseriesDeleteTask
 
 
 @pytest.mark.asyncio
-async def test_timeseries_delete_run_async(dbsession, mocker):
+async def test_timeseries_delete_run_impl(dbsession, mocker):
     mocker.patch("tasks.timeseries_delete.timeseries_enabled", return_value=True)
     delete_repository_data = mocker.patch(
         "tasks.timeseries_delete.delete_repository_data"
@@ -16,7 +16,7 @@ async def test_timeseries_delete_run_async(dbsession, mocker):
     dbsession.flush()
 
     task = TimeseriesDeleteTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         repository_id=repository.repoid,
     )
@@ -26,11 +26,11 @@ async def test_timeseries_delete_run_async(dbsession, mocker):
 
 
 @pytest.mark.asyncio
-async def test_timeseries_delete_run_async_invalid_repository(dbsession, mocker):
+async def test_timeseries_delete_run_impl_invalid_repository(dbsession, mocker):
     mocker.patch("tasks.timeseries_delete.timeseries_enabled", return_value=True)
 
     task = TimeseriesDeleteTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         repository_id=9999,
     )
@@ -38,7 +38,7 @@ async def test_timeseries_delete_run_async_invalid_repository(dbsession, mocker)
 
 
 @pytest.mark.asyncio
-async def test_timeseries_delete_run_async_timeseries_not_enabled(dbsession, mocker):
+async def test_timeseries_delete_run_impl_timeseries_not_enabled(dbsession, mocker):
     mocker.patch("tasks.timeseries_delete.timeseries_enabled", return_value=False)
 
     repository = RepositoryFactory.create()
@@ -46,7 +46,7 @@ async def test_timeseries_delete_run_async_timeseries_not_enabled(dbsession, moc
     dbsession.flush()
 
     task = TimeseriesDeleteTask()
-    res = await task.run_async(
+    res = task.run_impl(
         dbsession,
         repository_id=repository.repoid,
     )

--- a/tasks/tests/unit/test_timeseries_delete.py
+++ b/tasks/tests/unit/test_timeseries_delete.py
@@ -4,8 +4,7 @@ from database.tests.factories import RepositoryFactory
 from tasks.timeseries_delete import TimeseriesDeleteTask
 
 
-@pytest.mark.asyncio
-async def test_timeseries_delete_run_impl(dbsession, mocker):
+def test_timeseries_delete_run_impl(dbsession, mocker):
     mocker.patch("tasks.timeseries_delete.timeseries_enabled", return_value=True)
     delete_repository_data = mocker.patch(
         "tasks.timeseries_delete.delete_repository_data"
@@ -25,8 +24,7 @@ async def test_timeseries_delete_run_impl(dbsession, mocker):
     delete_repository_data.assert_called_once_with(repository)
 
 
-@pytest.mark.asyncio
-async def test_timeseries_delete_run_impl_invalid_repository(dbsession, mocker):
+def test_timeseries_delete_run_impl_invalid_repository(dbsession, mocker):
     mocker.patch("tasks.timeseries_delete.timeseries_enabled", return_value=True)
 
     task = TimeseriesDeleteTask()
@@ -37,8 +35,7 @@ async def test_timeseries_delete_run_impl_invalid_repository(dbsession, mocker):
     assert res == {"successful": False, "reason": "Repository not found"}
 
 
-@pytest.mark.asyncio
-async def test_timeseries_delete_run_impl_timeseries_not_enabled(dbsession, mocker):
+def test_timeseries_delete_run_impl_timeseries_not_enabled(dbsession, mocker):
     mocker.patch("tasks.timeseries_delete.timeseries_enabled", return_value=False)
 
     repository = RepositoryFactory.create()

--- a/tasks/tests/unit/test_trial_expiration.py
+++ b/tasks/tests/unit/test_trial_expiration.py
@@ -16,7 +16,7 @@ class TestTrialExpiration(object):
         dbsession.flush()
 
         task = TrialExpirationTask()
-        assert await task.run_async(dbsession, owner.ownerid) == {"successful": True}
+        assert task.run_impl(dbsession, owner.ownerid) == {"successful": True}
 
         assert owner.plan == BillingPlan.users_basic.value
         assert owner.plan_activated_users == None
@@ -33,7 +33,7 @@ class TestTrialExpiration(object):
         dbsession.flush()
 
         task = TrialExpirationTask()
-        assert await task.run_async(dbsession, owner.ownerid) == {"successful": True}
+        assert task.run_impl(dbsession, owner.ownerid) == {"successful": True}
 
         assert owner.plan == BillingPlan.users_basic.value
         assert owner.plan_activated_users == None
@@ -48,7 +48,7 @@ class TestTrialExpiration(object):
         dbsession.flush()
 
         task = TrialExpirationTask()
-        assert await task.run_async(dbsession, owner.ownerid) == {"successful": True}
+        assert task.run_impl(dbsession, owner.ownerid) == {"successful": True}
 
         assert owner.plan == BillingPlan.users_basic.value
         assert owner.plan_activated_users == [9]

--- a/tasks/tests/unit/test_trial_expiration.py
+++ b/tasks/tests/unit/test_trial_expiration.py
@@ -7,10 +7,7 @@ from tasks.trial_expiration import TrialExpirationTask
 
 
 class TestTrialExpiration(object):
-    @pytest.mark.asyncio
-    async def test_trial_expiration_task_with_pretrial_users_count(
-        self, dbsession, mocker
-    ):
+    def test_trial_expiration_task_with_pretrial_users_count(self, dbsession, mocker):
         owner = OwnerFactory.create(pretrial_users_count=5)
         dbsession.add(owner)
         dbsession.flush()
@@ -24,8 +21,7 @@ class TestTrialExpiration(object):
         assert owner.stripe_subscription_id == None
         assert owner.trial_status == TrialStatus.EXPIRED.value
 
-    @pytest.mark.asyncio
-    async def test_trial_expiration_task_without_pretrial_users_count(
+    def test_trial_expiration_task_without_pretrial_users_count(
         self, dbsession, mocker
     ):
         owner = OwnerFactory.create()
@@ -41,8 +37,7 @@ class TestTrialExpiration(object):
         assert owner.stripe_subscription_id == None
         assert owner.trial_status == TrialStatus.EXPIRED.value
 
-    @pytest.mark.asyncio
-    async def test_trial_expiration_task_with_trial_fired_by(self, dbsession, mocker):
+    def test_trial_expiration_task_with_trial_fired_by(self, dbsession, mocker):
         owner = OwnerFactory.create(trial_fired_by=9)
         dbsession.add(owner)
         dbsession.flush()

--- a/tasks/tests/unit/test_trial_expiration_cron.py
+++ b/tasks/tests/unit/test_trial_expiration_cron.py
@@ -11,9 +11,8 @@ from tasks.trial_expiration_cron import TrialExpirationCronTask
 
 
 class TestTrialExpirationCheck(object):
-    @pytest.mark.asyncio
     @patch("tasks.trial_expiration_cron.yield_amount", 1)
-    async def test_enqueue_trial_expiration_task(self, dbsession, mocker):
+    def test_enqueue_trial_expiration_task(self, dbsession, mocker):
         mocked_now = datetime(2023, 7, 3, 6, 8, 12)
         mocker.patch(
             "tasks.trial_expiration_cron.get_utc_now",
@@ -79,7 +78,7 @@ class TestTrialExpirationCheck(object):
         )
         task = TrialExpirationCronTask()
 
-        assert await task.run_cron_task(dbsession) == {"successful": True}
+        assert task.run_cron_task(dbsession) == {"successful": True}
         mocked_app.tasks[trial_expiration_task_name].apply_async.assert_any_call(
             kwargs={"ownerid": second_ongoing_owner_that_should_expire.ownerid}
         )
@@ -88,8 +87,7 @@ class TestTrialExpirationCheck(object):
         )
         # TODO: couldn't find a way to assert I didn't call the other owners
 
-    @pytest.mark.asyncio
-    async def test_get_min_seconds_interval_between_executions(self, dbsession):
+    def test_get_min_seconds_interval_between_executions(self, dbsession):
         assert isinstance(
             TrialExpirationCronTask.get_min_seconds_interval_between_executions(), int
         )

--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -70,7 +70,7 @@ class TestUploadFinisherTask(object):
         checkpoints = _create_checkpoint_logger(mocker)
         checkpoints_data = json.loads(json.dumps(checkpoints.data))
         kwargs = {_kwargs_key(UploadFlow): checkpoints_data}
-        result = await UploadFinisherTask().run_async(
+        result = UploadFinisherTask().run_impl(
             dbsession,
             previous_results,
             repoid=commit.repoid,
@@ -136,7 +136,7 @@ class TestUploadFinisherTask(object):
         previous_results = {
             "processings_so_far": [{"arguments": {"url": url}, "successful": True}]
         }
-        result = await UploadFinisherTask().run_async(
+        result = UploadFinisherTask().run_impl(
             dbsession,
             previous_results,
             repoid=commit.repoid,
@@ -185,7 +185,7 @@ class TestUploadFinisherTask(object):
         previous_results = {
             "processings_so_far": [{"arguments": {"url": url}, "successful": True}]
         }
-        result = await UploadFinisherTask().run_async(
+        result = UploadFinisherTask().run_impl(
             dbsession,
             previous_results,
             repoid=commit.repoid,
@@ -563,7 +563,7 @@ class TestUploadFinisherTask(object):
         dbsession.add(commit)
         dbsession.flush()
 
-        await UploadFinisherTask().run_async(
+        UploadFinisherTask().run_impl(
             dbsession,
             {},
             repoid=commit.repoid,

--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -27,8 +27,7 @@ def _create_checkpoint_logger(mocker):
 
 
 class TestUploadFinisherTask(object):
-    @pytest.mark.asyncio
-    async def test_upload_finisher_task_call(
+    def test_upload_finisher_task_call(
         self,
         mocker,
         mock_configuration,
@@ -104,8 +103,7 @@ class TestUploadFinisherTask(object):
         ]
         mock_checkpoint_submit.assert_has_calls(calls)
 
-    @pytest.mark.asyncio
-    async def test_upload_finisher_task_call_no_author(
+    def test_upload_finisher_task_call_no_author(
         self, mocker, mock_configuration, dbsession, mock_storage, mock_redis
     ):
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
@@ -154,8 +152,7 @@ class TestUploadFinisherTask(object):
             timeout=300,
         )
 
-    @pytest.mark.asyncio
-    async def test_upload_finisher_task_call_different_branch(
+    def test_upload_finisher_task_call_different_branch(
         self, mocker, mock_configuration, dbsession, mock_storage, mock_redis
     ):
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
@@ -203,8 +200,7 @@ class TestUploadFinisherTask(object):
             timeout=300,
         )
 
-    @pytest.mark.asyncio
-    async def test_should_call_notifications(self, dbsession):
+    def test_should_call_notifications(self, dbsession):
         commit_yaml = {"codecov": {"max_report_age": "1y ago"}}
         commit = CommitFactory.create(
             message="dsidsahdsahdsa",
@@ -222,8 +218,7 @@ class TestUploadFinisherTask(object):
             commit, commit_yaml, processing_results, None
         )
 
-    @pytest.mark.asyncio
-    async def test_should_call_notifications_local_upload(self, dbsession):
+    def test_should_call_notifications_local_upload(self, dbsession):
         commit_yaml = {"codecov": {"max_report_age": "1y ago"}}
         commit = CommitFactory.create(
             message="dsidsahdsahdsa",
@@ -239,8 +234,7 @@ class TestUploadFinisherTask(object):
             commit, commit_yaml, processing_results, "local_report1"
         )
 
-    @pytest.mark.asyncio
-    async def test_should_call_notifications_manual_trigger(self, dbsession):
+    def test_should_call_notifications_manual_trigger(self, dbsession):
         commit_yaml = {"codecov": {"notify": {"manual_trigger": True}}}
         commit = CommitFactory.create(
             message="dsidsahdsahdsa",
@@ -256,8 +250,7 @@ class TestUploadFinisherTask(object):
             commit, commit_yaml, processing_results, None
         )
 
-    @pytest.mark.asyncio
-    async def test_should_call_notifications_manual_trigger_off(self, dbsession):
+    def test_should_call_notifications_manual_trigger_off(self, dbsession):
         commit_yaml = {
             "codecov": {"max_report_age": "1y ago", "notify": {"manual_trigger": False}}
         }
@@ -277,8 +270,7 @@ class TestUploadFinisherTask(object):
             commit, commit_yaml, processing_results, None
         )
 
-    @pytest.mark.asyncio
-    async def test_should_call_notifications_no_successful_reports(self, dbsession):
+    def test_should_call_notifications_no_successful_reports(self, dbsession):
         commit_yaml = {"codecov": {"max_report_age": "1y ago"}}
         commit = CommitFactory.create(
             message="dsidsahdsahdsa",
@@ -297,8 +289,7 @@ class TestUploadFinisherTask(object):
             commit, commit_yaml, processing_results, None
         )
 
-    @pytest.mark.asyncio
-    async def test_should_call_notifications_not_enough_builds(self, dbsession, mocker):
+    def test_should_call_notifications_not_enough_builds(self, dbsession, mocker):
         commit_yaml = {"codecov": {"notify": {"after_n_builds": 9}}}
         commit = CommitFactory.create(
             message="dsidsahdsahdsa",
@@ -324,10 +315,7 @@ class TestUploadFinisherTask(object):
             commit, commit_yaml, processing_results, None
         )
 
-    @pytest.mark.asyncio
-    async def test_should_call_notifications_more_than_enough_builds(
-        self, dbsession, mocker
-    ):
+    def test_should_call_notifications_more_than_enough_builds(self, dbsession, mocker):
         commit_yaml = {"codecov": {"notify": {"after_n_builds": 9}}}
         commit = CommitFactory.create(
             message="dsidsahdsahdsa",
@@ -353,8 +341,7 @@ class TestUploadFinisherTask(object):
             commit, commit_yaml, processing_results, None
         )
 
-    @pytest.mark.asyncio
-    async def test_finish_reports_processing(self, dbsession, mocker):
+    def test_finish_reports_processing(self, dbsession, mocker):
         commit_yaml = {}
         mocked_app = mocker.patch.object(UploadFinisherTask, "app")
         commit = CommitFactory.create(
@@ -369,7 +356,7 @@ class TestUploadFinisherTask(object):
         dbsession.flush()
 
         checkpoints = _create_checkpoint_logger(mocker)
-        res = await UploadFinisherTask().finish_reports_processing(
+        res = UploadFinisherTask().finish_reports_processing(
             dbsession,
             commit,
             UserYaml(commit_yaml),
@@ -388,8 +375,7 @@ class TestUploadFinisherTask(object):
         )
         assert mocked_app.send_task.call_count == 0
 
-    @pytest.mark.asyncio
-    async def test_finish_reports_processing_with_pull(self, dbsession, mocker):
+    def test_finish_reports_processing_with_pull(self, dbsession, mocker):
         commit_yaml = {}
         mocked_app = mocker.patch.object(
             UploadFinisherTask,
@@ -424,7 +410,7 @@ class TestUploadFinisherTask(object):
         dbsession.flush()
 
         checkpoints = _create_checkpoint_logger(mocker)
-        res = await UploadFinisherTask().finish_reports_processing(
+        res = UploadFinisherTask().finish_reports_processing(
             dbsession,
             commit,
             UserYaml(commit_yaml),
@@ -457,8 +443,7 @@ class TestUploadFinisherTask(object):
             "app.tasks.upload.UploadCleanLabelsIndex"
         ].apply_async.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_finish_reports_processing_call_clean_labels(self, dbsession, mocker):
+    def test_finish_reports_processing_call_clean_labels(self, dbsession, mocker):
         commit_yaml = {
             "flag_management": {
                 "individual_flags": [
@@ -491,7 +476,7 @@ class TestUploadFinisherTask(object):
         dbsession.flush()
 
         checkpoints = _create_checkpoint_logger(mocker)
-        res = await UploadFinisherTask().finish_reports_processing(
+        res = UploadFinisherTask().finish_reports_processing(
             dbsession,
             commit,
             UserYaml(commit_yaml),
@@ -519,8 +504,7 @@ class TestUploadFinisherTask(object):
         )
         assert mocked_app.send_task.call_count == 0
 
-    @pytest.mark.asyncio
-    async def test_finish_reports_processing_no_notification(self, dbsession, mocker):
+    def test_finish_reports_processing_no_notification(self, dbsession, mocker):
         commit_yaml = {}
         mocked_app = mocker.patch.object(UploadFinisherTask, "app")
         commit = CommitFactory.create(
@@ -535,7 +519,7 @@ class TestUploadFinisherTask(object):
         dbsession.flush()
 
         checkpoints = _create_checkpoint_logger(mocker)
-        res = await UploadFinisherTask().finish_reports_processing(
+        res = UploadFinisherTask().finish_reports_processing(
             dbsession,
             commit,
             UserYaml(commit_yaml),
@@ -547,8 +531,7 @@ class TestUploadFinisherTask(object):
         assert mocked_app.send_task.call_count == 0
         assert not mocked_app.tasks["app.tasks.notify.Notify"].apply_async.called
 
-    @pytest.mark.asyncio
-    async def test_upload_finisher_task_calls_save_commit_measurements_task(
+    def test_upload_finisher_task_calls_save_commit_measurements_task(
         self, mocker, dbsession, mock_redis
     ):
         mocked_app = mocker.patch.object(

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -47,9 +47,8 @@ class TestUploadProcessorTask(object):
             task.schedule_for_later_try()
         mock_retry.assert_called_with(countdown=180, max_retries=5)
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_processor_task_call(
+    def test_upload_processor_task_call(
         self,
         mocker,
         mock_configuration,
@@ -170,9 +169,8 @@ class TestUploadProcessorTask(object):
             timeout=300,
         )
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_processor_task_call_should_delete(
+    def test_upload_processor_task_call_should_delete(
         self,
         mocker,
         mock_configuration,
@@ -302,8 +300,7 @@ class TestUploadProcessorTask(object):
             timeout=300,
         )
 
-    @pytest.mark.asyncio
-    async def test_upload_processor_call_with_upload_obj(
+    def test_upload_processor_call_with_upload_obj(
         self, mocker, mock_configuration, dbsession, mock_storage, mock_redis
     ):
         mocker.patch.object(
@@ -345,7 +342,7 @@ class TestUploadProcessorTask(object):
         redis_queue = [{"url": url, "upload_pk": upload.id_}]
         mocked_3 = mocker.patch.object(UploadProcessorTask, "app")
         mocked_3.send_task.return_value = True
-        result = await UploadProcessorTask().process_impl_within_lock(
+        result = UploadProcessorTask().process_impl_within_lock(
             db_session=dbsession,
             redis_connection=mock_redis,
             previous_results={},
@@ -421,9 +418,8 @@ class TestUploadProcessorTask(object):
         )
         assert data == parsed.content().getvalue()
 
-    @pytest.mark.asyncio
     @pytest.mark.integration
-    async def test_upload_task_call_existing_chunks(
+    def test_upload_task_call_existing_chunks(
         self,
         mocker,
         mock_configuration,
@@ -498,8 +494,7 @@ class TestUploadProcessorTask(object):
             timeout=300,
         )
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_exception_within_individual_upload(
+    def test_upload_task_call_exception_within_individual_upload(
         self,
         mocker,
         mock_configuration,
@@ -556,8 +551,7 @@ class TestUploadProcessorTask(object):
         mocked_4.assert_called_with(commit.repository, upload)
         mocked_5.assert_called()
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_with_redis_lock_unobtainable(
+    def test_upload_task_call_with_redis_lock_unobtainable(
         self, mocker, mock_configuration, dbsession, mock_redis, celery_app
     ):
         # Mocking retry to also raise the exception so we can see how it is called
@@ -594,8 +588,7 @@ class TestUploadProcessorTask(object):
         mocked_3.assert_called_with(countdown=179, max_retries=5)
         mocked_random.assert_called_with(100, 200)
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_with_expired_report(
+    def test_upload_task_call_with_expired_report(
         self,
         mocker,
         mock_configuration,
@@ -690,8 +683,7 @@ class TestUploadProcessorTask(object):
         assert expected_result == result
         assert commit.state == "complete"
 
-    @pytest.mark.asyncio
-    async def test_upload_task_process_individual_report_with_notfound_report(
+    def test_upload_task_process_individual_report_with_notfound_report(
         self,
         mocker,
         mock_configuration,
@@ -742,8 +734,7 @@ class TestUploadProcessorTask(object):
         assert commit.state == "complete"
         assert upload.state == "error"
 
-    @pytest.mark.asyncio
-    async def test_upload_task_process_individual_report_with_notfound_report_no_retries_yet(
+    def test_upload_task_process_individual_report_with_notfound_report_no_retries_yet(
         self,
         mocker,
         mock_configuration,
@@ -783,8 +774,7 @@ class TestUploadProcessorTask(object):
             )
         mock_schedule_for_later_try.assert_called_with()
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_with_empty_report(
+    def test_upload_task_call_with_empty_report(
         self,
         mocker,
         mock_configuration,
@@ -883,8 +873,7 @@ class TestUploadProcessorTask(object):
         assert upload_2.errors[0].report_upload == upload_2
         assert len(upload_1.errors) == 0
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_no_successful_report(
+    def test_upload_task_call_no_successful_report(
         self,
         mocker,
         mock_configuration,
@@ -978,8 +967,7 @@ class TestUploadProcessorTask(object):
         assert upload_1.errors[0].error_params == {}
         assert upload_1.errors[0].report_upload == upload_1
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_softtimelimit(
+    def test_upload_task_call_softtimelimit(
         self,
         mocker,
         mock_configuration,
@@ -1023,8 +1011,7 @@ class TestUploadProcessorTask(object):
             )
         assert commit.state == "error"
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_celeryerror(
+    def test_upload_task_call_celeryerror(
         self,
         mocker,
         mock_configuration,
@@ -1068,8 +1055,7 @@ class TestUploadProcessorTask(object):
             )
         assert commit.state == "pending"
 
-    @pytest.mark.asyncio
-    async def test_save_report_results_apply_diff_not_there(
+    def test_save_report_results_apply_diff_not_there(
         self, mocker, mock_configuration, dbsession, mock_repo_provider, mock_storage
     ):
         commit = CommitFactory.create(
@@ -1097,7 +1083,7 @@ class TestUploadProcessorTask(object):
         mock_repo_provider.get_commit_diff.side_effect = TorngitObjectNotFoundError(
             "response", "message"
         )
-        result = await UploadProcessorTask().save_report_results(
+        result = UploadProcessorTask().save_report_results(
             db_session=dbsession,
             report_service=ReportService({}),
             repository=commit.repository,
@@ -1111,8 +1097,7 @@ class TestUploadProcessorTask(object):
         assert expected_result == result
         assert report.diff_totals is None
 
-    @pytest.mark.asyncio
-    async def test_save_report_results_apply_diff_no_bot(
+    def test_save_report_results_apply_diff_no_bot(
         self, mocker, mock_configuration, dbsession, mock_repo_provider, mock_storage
     ):
         commit = CommitFactory.create(
@@ -1141,7 +1126,7 @@ class TestUploadProcessorTask(object):
         report.append(report_file_1)
         report.append(report_file_2)
         chunks_archive_service = ArchiveService(commit.repository)
-        result = await UploadProcessorTask().save_report_results(
+        result = UploadProcessorTask().save_report_results(
             db_session=dbsession,
             report_service=ReportService({}),
             repository=commit.repository,
@@ -1155,8 +1140,7 @@ class TestUploadProcessorTask(object):
         assert expected_result == result
         assert report.diff_totals is None
 
-    @pytest.mark.asyncio
-    async def test_save_report_results_apply_diff_valid(
+    def test_save_report_results_apply_diff_valid(
         self, mocker, mock_configuration, dbsession, mock_repo_provider, mock_storage
     ):
         commit = CommitFactory.create(
@@ -1203,7 +1187,7 @@ class TestUploadProcessorTask(object):
             }
         }
         mock_repo_provider.get_commit_diff.return_value = f
-        result = await UploadProcessorTask().save_report_results(
+        result = UploadProcessorTask().save_report_results(
             db_session=dbsession,
             report_service=ReportService({}),
             commit=commit,
@@ -1232,8 +1216,7 @@ class TestUploadProcessorTask(object):
         )
         assert report.diff_totals == expected_diff_totals
 
-    @pytest.mark.asyncio
-    async def test_save_report_results_empty_report(
+    def test_save_report_results_empty_report(
         self, mocker, mock_configuration, dbsession, mock_repo_provider, mock_storage
     ):
         commit = CommitFactory.create(
@@ -1270,7 +1253,7 @@ class TestUploadProcessorTask(object):
             }
         }
         mock_repo_provider.get_commit_diff.return_value = f
-        result = await UploadProcessorTask().save_report_results(
+        result = UploadProcessorTask().save_report_results(
             db_session=dbsession,
             report_service=ReportService({}),
             commit=commit,
@@ -1300,11 +1283,10 @@ class TestUploadProcessorTask(object):
         assert report.diff_totals == expected_diff_totals
         assert commit.state == "error"
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "pr_value, expected_pr_result", [(1, 1), ("1", 1), ("true", None), ([], None)]
     )
-    async def test_save_report_results_pr_values(
+    def test_save_report_results_pr_values(
         self,
         mocker,
         mock_configuration,
@@ -1322,7 +1304,7 @@ class TestUploadProcessorTask(object):
             "files": {"path/to/first.py": {}}
         }
         mock_report_service = mocker.Mock(save_report=mocker.Mock(return_value="aaaa"))
-        result = await UploadProcessorTask().save_report_results(
+        result = UploadProcessorTask().save_report_results(
             db_session=dbsession,
             report_service=mock_report_service,
             commit=commit,

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -95,7 +95,7 @@ class TestUploadProcessorTask(object):
         )
         dbsession.add(report_details)
         dbsession.flush()
-        result = await UploadProcessorTask().run_async(
+        result = UploadProcessorTask().run_impl(
             dbsession,
             {},
             repoid=commit.repoid,
@@ -222,7 +222,7 @@ class TestUploadProcessorTask(object):
         )
         dbsession.add(report_details)
         dbsession.flush()
-        result = await UploadProcessorTask().run_async(
+        result = UploadProcessorTask().run_impl(
             dbsession,
             {},
             repoid=commit.repoid,
@@ -345,7 +345,7 @@ class TestUploadProcessorTask(object):
         redis_queue = [{"url": url, "upload_pk": upload.id_}]
         mocked_3 = mocker.patch.object(UploadProcessorTask, "app")
         mocked_3.send_task.return_value = True
-        result = await UploadProcessorTask().process_async_within_lock(
+        result = await UploadProcessorTask().process_impl_within_lock(
             db_session=dbsession,
             redis_connection=mock_redis,
             previous_results={},
@@ -473,7 +473,7 @@ class TestUploadProcessorTask(object):
         dbsession.add(upload)
         dbsession.flush()
         redis_queue = [{"url": url, "upload_pk": upload.id_}]
-        result = await UploadProcessorTask().run_async(
+        result = UploadProcessorTask().run_impl(
             dbsession,
             {},
             repoid=commit.repoid,
@@ -540,7 +540,7 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         redis_queue = [{"url": "url", "upload_pk": upload.id_}]
         with pytest.raises(Exception) as exc:
-            await UploadProcessorTask().run_async(
+            UploadProcessorTask().run_impl(
                 dbsession,
                 {},
                 repoid=commit.repoid,
@@ -583,7 +583,7 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         mocked_random = mocker.patch("random.randint", return_value=179)
         with pytest.raises(celery.exceptions.Retry):
-            await UploadProcessorTask().run_async(
+            UploadProcessorTask().run_impl(
                 dbsession,
                 {},
                 repoid=commit.repoid,
@@ -656,7 +656,7 @@ class TestUploadProcessorTask(object):
             {"url": "url", "what": "huh", "upload_pk": upload_1.id_},
             {"url": "url2", "extra_param": 45, "upload_pk": upload_2.id_},
         ]
-        result = await UploadProcessorTask().run_async(
+        result = UploadProcessorTask().run_impl(
             dbsession,
             {},
             repoid=commit.repoid,
@@ -844,7 +844,7 @@ class TestUploadProcessorTask(object):
             {"url": "url", "what": "huh", "upload_pk": upload_1.id_},
             {"url": "url2", "extra_param": 45, "upload_pk": upload_2.id_},
         ]
-        result = await UploadProcessorTask().run_async(
+        result = UploadProcessorTask().run_impl(
             dbsession,
             {},
             repoid=commit.repoid,
@@ -933,7 +933,7 @@ class TestUploadProcessorTask(object):
             {"url": "url", "what": "huh", "upload_pk": upload_1.id_},
             {"url": "url2", "extra_param": 45, "upload_pk": upload_2.id_},
         ]
-        result = await UploadProcessorTask().run_async(
+        result = UploadProcessorTask().run_impl(
             dbsession,
             {},
             repoid=commit.repoid,
@@ -1013,7 +1013,7 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         redis_queue = [{"url": "url", "what": "huh", "upload_pk": upload_1.id_}]
         with pytest.raises(celery.exceptions.SoftTimeLimitExceeded, match="banana"):
-            await UploadProcessorTask().run_async(
+            UploadProcessorTask().run_impl(
                 dbsession,
                 {},
                 repoid=commit.repoid,
@@ -1058,7 +1058,7 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         redis_queue = [{"url": "url", "what": "huh", "upload_pk": upload_1.id_}]
         with pytest.raises(celery.exceptions.Retry, match="banana"):
-            await UploadProcessorTask().run_async(
+            UploadProcessorTask().run_impl(
                 dbsession,
                 {},
                 repoid=commit.repoid,

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -820,7 +820,7 @@ class TestUploadTaskIntegration(object):
             commitid=commit.commitid,
             redis_connection=mock_redis,
         )
-        result = await UploadTask().run_async_within_lock(
+        result = await UploadTask().run_impl_within_lock(
             dbsession,
             upload_args,
         )
@@ -919,7 +919,7 @@ class TestUploadTaskIntegration(object):
             commitid=commit.commitid,
             redis_connection=mock_redis,
         )
-        result = await UploadTask().run_async_within_lock(
+        result = await UploadTask().run_impl_within_lock(
             dbsession,
             upload_args,
         )
@@ -1140,15 +1140,15 @@ class TestUploadTaskUnit(object):
         mocked_is_currently_processing = mocker.patch.object(
             UploadContext, "is_currently_processing", return_value=True
         )
-        mocked_run_async_within_lock = mocker.patch.object(
-            UploadTask, "run_async_within_lock", return_value=True
+        mocked_run_impl_within_lock = mocker.patch.object(
+            UploadTask, "run_impl_within_lock", return_value=True
         )
         task = UploadTask()
         task.request.retries = 0
         with pytest.raises(Retry):
             await task.run_async(dbsession, commit.repoid, commit.commitid)
         mocked_is_currently_processing.assert_called_with()
-        assert not mocked_run_async_within_lock.called
+        assert not mocked_run_impl_within_lock.called
 
     @pytest.mark.asyncio
     async def test_run_async_currently_processing_second_retry(
@@ -1160,14 +1160,14 @@ class TestUploadTaskUnit(object):
         mocked_is_currently_processing = mocker.patch.object(
             UploadContext, "is_currently_processing", return_value=True
         )
-        mocked_run_async_within_lock = mocker.patch.object(
-            UploadTask, "run_async_within_lock", return_value={"some": "value"}
+        mocked_run_impl_within_lock = mocker.patch.object(
+            UploadTask, "run_impl_within_lock", return_value={"some": "value"}
         )
         task = UploadTask()
         task.request.retries = 1
         result = await task.run_async(dbsession, commit.repoid, commit.commitid)
         mocked_is_currently_processing.assert_called_with()
-        assert mocked_run_async_within_lock.called
+        assert mocked_run_impl_within_lock.called
         assert result == {"some": "value"}
 
     def test_is_currently_processing(self, mock_redis):
@@ -1495,4 +1495,4 @@ class TestUploadTaskUnit(object):
             redis_connection=mock_redis,
         )
         with pytest.raises(Retry):
-            await task.run_async_within_lock(dbsession, upload_args)
+            await task.run_impl_within_lock(dbsession, upload_args)

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -102,8 +102,7 @@ def mock_redis(mocker):
 
 @pytest.mark.integration
 class TestUploadTaskIntegration(object):
-    @pytest.mark.asyncio
-    async def test_upload_task_call(
+    def test_upload_task_call(
         self,
         mocker,
         mock_configuration,
@@ -198,8 +197,7 @@ class TestUploadTaskIntegration(object):
         ]
         mock_checkpoint_submit.assert_has_calls(calls)
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_bundle_analysis(
+    def test_upload_task_call_bundle_analysis(
         self,
         mocker,
         mock_configuration,
@@ -267,8 +265,7 @@ class TestUploadTaskIntegration(object):
         )
         chain.assert_called_with(processor_sig, notify_sig)
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_test_results(
+    def test_upload_task_call_test_results(
         self,
         mocker,
         mock_configuration,
@@ -338,8 +335,7 @@ class TestUploadTaskIntegration(object):
 
         chord.assert_called_with([processor_sig], notify_sig)
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_no_jobs(
+    def test_upload_task_call_no_jobs(
         self,
         mocker,
         mock_configuration,
@@ -373,8 +369,7 @@ class TestUploadTaskIntegration(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
 
-    @pytest.mark.asyncio
-    async def test_upload_task_upload_processing_delay_not_enough_delay(
+    def test_upload_task_upload_processing_delay_not_enough_delay(
         self,
         mocker,
         mock_configuration,
@@ -420,8 +415,7 @@ class TestUploadTaskIntegration(object):
         assert mock_redis.exists(f"uploads/{commit.repoid}/{commit.commitid}")
         assert not mock_possibly_update_commit_from_provider_info.called
 
-    @pytest.mark.asyncio
-    async def test_upload_task_upload_processing_delay_enough_delay(
+    def test_upload_task_upload_processing_delay_enough_delay(
         self,
         mocker,
         mock_configuration,
@@ -468,8 +462,7 @@ class TestUploadTaskIntegration(object):
         assert not mock_redis.exists(f"uploads/{commit.repoid}/{commit.commitid}")
         mocked_chain.assert_called_with(mocker.ANY, mocker.ANY)
 
-    @pytest.mark.asyncio
-    async def test_upload_task_upload_processing_delay_upload_is_none(
+    def test_upload_task_upload_processing_delay_upload_is_none(
         self,
         mocker,
         mock_configuration,
@@ -511,8 +504,7 @@ class TestUploadTaskIntegration(object):
         assert not mock_redis.exists(f"uploads/{commit.repoid}/{commit.commitid}")
         mocked_chain.assert_called_with(mocker.ANY, mocker.ANY)
 
-    @pytest.mark.asyncio
-    async def test_upload_task_call_multiple_processors(
+    def test_upload_task_call_multiple_processors(
         self,
         mocker,
         mock_configuration,
@@ -611,8 +603,7 @@ class TestUploadTaskIntegration(object):
             timeout=300,
         )
 
-    @pytest.mark.asyncio
-    async def test_upload_task_proper_parent(
+    def test_upload_task_proper_parent(
         self,
         mocker,
         mock_configuration,
@@ -671,8 +662,7 @@ class TestUploadTaskIntegration(object):
             timeout=300,
         )
 
-    @pytest.mark.asyncio
-    async def test_upload_task_no_bot(
+    def test_upload_task_no_bot(
         self,
         mocker,
         mock_configuration,
@@ -724,8 +714,7 @@ class TestUploadTaskIntegration(object):
         )
         assert not mocked_fetch_yaml.called
 
-    @pytest.mark.asyncio
-    async def test_upload_task_bot_no_permissions(
+    def test_upload_task_bot_no_permissions(
         self,
         mocker,
         mock_configuration,
@@ -778,8 +767,7 @@ class TestUploadTaskIntegration(object):
         )
         assert not mocked_fetch_yaml.called
 
-    @pytest.mark.asyncio
-    async def test_upload_task_bot_unauthorized(
+    def test_upload_task_bot_unauthorized(
         self,
         mocker,
         mock_configuration,
@@ -852,8 +840,7 @@ class TestUploadTaskIntegration(object):
             mocker.ANY,
         )
 
-    @pytest.mark.asyncio
-    async def test_upload_task_upload_already_created(
+    def test_upload_task_upload_already_created(
         self,
         mocker,
         mock_configuration,
@@ -1098,8 +1085,7 @@ class TestUploadTaskUnit(object):
         )
         mocked_chain.assert_called_with(t1, t2)
 
-    @pytest.mark.asyncio
-    async def test_run_impl_unobtainable_lock_no_pending_jobs(
+    def test_run_impl_unobtainable_lock_no_pending_jobs(
         self, dbsession, mocker, mock_redis
     ):
         commit = CommitFactory.create()
@@ -1113,8 +1099,7 @@ class TestUploadTaskUnit(object):
             "was_updated": False,
         }
 
-    @pytest.mark.asyncio
-    async def test_run_impl_unobtainable_lock_too_many_retries(
+    def test_run_impl_unobtainable_lock_too_many_retries(
         self, dbsession, mocker, mock_redis
     ):
         commit = CommitFactory.create()
@@ -1132,8 +1117,7 @@ class TestUploadTaskUnit(object):
             "reason": "too_many_retries",
         }
 
-    @pytest.mark.asyncio
-    async def test_run_impl_currently_processing(self, dbsession, mocker, mock_redis):
+    def test_run_impl_currently_processing(self, dbsession, mocker, mock_redis):
         commit = CommitFactory.create()
         dbsession.add(commit)
         dbsession.flush()
@@ -1150,8 +1134,7 @@ class TestUploadTaskUnit(object):
         mocked_is_currently_processing.assert_called_with()
         assert not mocked_run_impl_within_lock.called
 
-    @pytest.mark.asyncio
-    async def test_run_impl_currently_processing_second_retry(
+    def test_run_impl_currently_processing_second_retry(
         self, dbsession, mocker, mock_redis
     ):
         commit = CommitFactory.create()
@@ -1188,10 +1171,7 @@ class TestUploadTaskUnit(object):
         )
         assert not upload_args.is_currently_processing()
 
-    @pytest.mark.asyncio
-    async def test_run_impl_unobtainable_lock_retry(
-        self, dbsession, mocker, mock_redis
-    ):
+    def test_run_impl_unobtainable_lock_retry(self, dbsession, mocker, mock_redis):
         commit = CommitFactory.create()
         dbsession.add(commit)
         dbsession.flush()
@@ -1202,8 +1182,7 @@ class TestUploadTaskUnit(object):
         with pytest.raises(Retry):
             task.run_impl(dbsession, commit.repoid, commit.commitid)
 
-    @pytest.mark.asyncio
-    async def test_fetch_commit_yaml_and_possibly_store_only_commit_yaml(
+    def test_fetch_commit_yaml_and_possibly_store_only_commit_yaml(
         self, dbsession, mocker, mock_configuration
     ):
         commit = CommitFactory.create()
@@ -1228,7 +1207,7 @@ class TestUploadTaskUnit(object):
             get_source=mock.AsyncMock(return_value=get_source_result),
         )
 
-        result = await UploadTask().fetch_commit_yaml_and_possibly_store(
+        result = UploadTask().fetch_commit_yaml_and_possibly_store(
             commit, repository_service
         )
         expected_result = {"codecov": {"notify": {}, "require_ci_to_pass": True}}
@@ -1238,8 +1217,7 @@ class TestUploadTaskUnit(object):
         )
         repository_service.list_top_level_files.assert_called_with(commit.commitid)
 
-    @pytest.mark.asyncio
-    async def test_fetch_commit_yaml_and_possibly_store_commit_yaml_and_base_yaml(
+    def test_fetch_commit_yaml_and_possibly_store_commit_yaml_and_base_yaml(
         self, dbsession, mock_configuration, mocker
     ):
         mock_configuration.set_params({"site": {"coverage": {"precision": 14}}})
@@ -1261,7 +1239,7 @@ class TestUploadTaskUnit(object):
             get_source=mock.AsyncMock(return_value=get_source_result),
         )
 
-        result = await UploadTask().fetch_commit_yaml_and_possibly_store(
+        result = UploadTask().fetch_commit_yaml_and_possibly_store(
             commit, repository_service
         )
         expected_result = {
@@ -1274,8 +1252,7 @@ class TestUploadTaskUnit(object):
         )
         repository_service.list_top_level_files.assert_called_with(commit.commitid)
 
-    @pytest.mark.asyncio
-    async def test_fetch_commit_yaml_and_possibly_store_commit_yaml_and_repo_yaml(
+    def test_fetch_commit_yaml_and_possibly_store_commit_yaml_and_repo_yaml(
         self, dbsession, mock_configuration, mocker
     ):
         mock_configuration.set_params({"site": {"coverage": {"precision": 14}}})
@@ -1301,7 +1278,7 @@ class TestUploadTaskUnit(object):
             get_source=mock.AsyncMock(return_value=get_source_result),
         )
 
-        result = await UploadTask().fetch_commit_yaml_and_possibly_store(
+        result = UploadTask().fetch_commit_yaml_and_possibly_store(
             commit, repository_service
         )
         expected_result = {
@@ -1317,8 +1294,7 @@ class TestUploadTaskUnit(object):
         )
         repository_service.list_top_level_files.assert_called_with(commit.commitid)
 
-    @pytest.mark.asyncio
-    async def test_fetch_commit_yaml_and_possibly_store_commit_yaml_no_commit_yaml(
+    def test_fetch_commit_yaml_and_possibly_store_commit_yaml_no_commit_yaml(
         self, dbsession, mock_configuration, mocker
     ):
         mock_configuration.set_params({"site": {"coverage": {"round": "up"}}})
@@ -1334,7 +1310,7 @@ class TestUploadTaskUnit(object):
             )
         )
 
-        result = await UploadTask().fetch_commit_yaml_and_possibly_store(
+        result = UploadTask().fetch_commit_yaml_and_possibly_store(
             commit, repository_service
         )
         expected_result = {
@@ -1344,8 +1320,7 @@ class TestUploadTaskUnit(object):
         assert result.to_dict() == expected_result
         assert commit.repository.yaml == {"codecov": {"max_report_age": "1y ago"}}
 
-    @pytest.mark.asyncio
-    async def test_fetch_commit_yaml_and_possibly_store_commit_yaml_invalid_commit_yaml(
+    def test_fetch_commit_yaml_and_possibly_store_commit_yaml_invalid_commit_yaml(
         self, dbsession, mock_configuration, mocker
     ):
         mock_configuration.set_params({"site": {"comment": {"behavior": "new"}}})
@@ -1373,7 +1348,7 @@ class TestUploadTaskUnit(object):
             get_source=mock.AsyncMock(return_value=get_source_result),
         )
 
-        result = await UploadTask().fetch_commit_yaml_and_possibly_store(
+        result = UploadTask().fetch_commit_yaml_and_possibly_store(
             commit, repository_service
         )
         expected_result = {
@@ -1384,8 +1359,7 @@ class TestUploadTaskUnit(object):
         assert result.to_dict() == expected_result
         assert commit.repository.yaml == {"codecov": {"max_report_age": "1y ago"}}
 
-    @pytest.mark.asyncio
-    async def test_possibly_setup_webhooks_public_repo(
+    def test_possibly_setup_webhooks_public_repo(
         self, mocker, mock_configuration, mock_repo_provider
     ):
         mock_configuration.set_params({"github": {"bot": {"key": "somekey"}}})
@@ -1396,7 +1370,7 @@ class TestUploadTaskUnit(object):
         task = UploadTask()
         mock_repo_provider.data = mocker.MagicMock()
         mock_repo_provider.service = "github"
-        res = await task.possibly_setup_webhooks(commit, mock_repo_provider)
+        res = task.possibly_setup_webhooks(commit, mock_repo_provider)
         assert res is True
         mock_repo_provider.post_webhook.assert_called_with(
             "Codecov Webhook. None",
@@ -1406,8 +1380,7 @@ class TestUploadTaskUnit(object):
             token=None,
         )
 
-    @pytest.mark.asyncio
-    async def test_possibly_setup_webhooks_owner_has_ghapp(
+    def test_possibly_setup_webhooks_owner_has_ghapp(
         self, mocker, dbsession, mock_configuration, mock_repo_provider
     ):
         mock_configuration.set_params({"github": {"bot": {"key": "somekey"}}})
@@ -1425,12 +1398,11 @@ class TestUploadTaskUnit(object):
         task = UploadTask()
         mock_repo_provider.data = mocker.MagicMock()
         mock_repo_provider.service = "github"
-        res = await task.possibly_setup_webhooks(commit, mock_repo_provider)
+        res = task.possibly_setup_webhooks(commit, mock_repo_provider)
         assert res is False
         mock_repo_provider.post_webhook.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_possibly_setup_webhooks_gitlab(
+    def test_possibly_setup_webhooks_gitlab(
         self, dbsession, mocker, mock_configuration
     ):
         mock_configuration.set_params({"gitlab": {"bot": {"key": "somekey"}}})
@@ -1450,7 +1422,7 @@ class TestUploadTaskUnit(object):
         gitlab_provider.service = "gitlab"
 
         task = UploadTask()
-        res = await task.possibly_setup_webhooks(commit, gitlab_provider)
+        res = task.possibly_setup_webhooks(commit, gitlab_provider)
         assert res is True
 
         assert repository.webhook_secret is not None
@@ -1472,8 +1444,7 @@ class TestUploadTaskUnit(object):
             token=None,
         )
 
-    @pytest.mark.asyncio
-    async def test_upload_not_ready_to_build_report(
+    def test_upload_not_ready_to_build_report(
         self, dbsession, mocker, mock_configuration, mock_repo_provider, mock_redis
     ):
         mock_configuration.set_params({"github": {"bot": {"key": "somekey"}}})

--- a/tasks/timeseries_backfill.py
+++ b/tasks/timeseries_backfill.py
@@ -21,7 +21,7 @@ log = logging.getLogger(__name__)
 class TimeseriesBackfillCommitsTask(
     BaseCodecovTask, name="app.tasks.timeseries.backfill_commits"
 ):
-    async def run_async(
+    def run_impl(
         self,
         db_session: Session,
         *,
@@ -58,7 +58,7 @@ class TimeseriesBackfillDatasetTask(BaseCodecovTask):
     # TODO: add name to `shared.celery_config`
     name = "app.tasks.timeseries.backfill_dataset"
 
-    async def run_async(
+    def run_impl(
         self,
         db_session: Session,
         *,

--- a/tasks/timeseries_delete.py
+++ b/tasks/timeseries_delete.py
@@ -13,7 +13,7 @@ log = logging.getLogger(__name__)
 
 
 class TimeseriesDeleteTask(BaseCodecovTask, name=timeseries_delete_task_name):
-    async def run_async(
+    def run_impl(
         self,
         db_session: Session,
         *,

--- a/tasks/trial_expiration.py
+++ b/tasks/trial_expiration.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 
 class TrialExpirationTask(BaseCodecovTask, name=trial_expiration_task_name):
-    async def run_async(self, db_session, ownerid, *args, **kwargs):
+    def run_impl(self, db_session, ownerid, *args, **kwargs):
         owner = db_session.query(Owner).get(ownerid)
         log_extra = dict(
             owner_id=ownerid,

--- a/tasks/trial_expiration_cron.py
+++ b/tasks/trial_expiration_cron.py
@@ -18,7 +18,7 @@ class TrialExpirationCronTask(CodecovCronTask, name=trial_expiration_cron_task_n
     def get_min_seconds_interval_between_executions(cls):
         return 86100  # 23 hours and 55 minutes
 
-    async def run_cron_task(self, db_session, *args, **kwargs):
+    def run_cron_task(self, db_session, *args, **kwargs):
         log.info("Doing trial expiration check")
         now = get_utc_now()
 

--- a/tasks/update_branches.py
+++ b/tasks/update_branches.py
@@ -11,7 +11,7 @@ log = logging.getLogger(__name__)
 
 
 class UpdateBranchesTask(BaseCodecovTask, name=update_branches_task_name):
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         *args,

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -233,7 +233,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
 
     """
 
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         repoid,
@@ -288,7 +288,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 timeout=max(300, self.hard_time_limit_task),
                 blocking_timeout=5,
             ):
-                return await self.run_async_within_lock(
+                return await self.run_impl_within_lock(
                     db_session,
                     upload_context,
                     *args,
@@ -338,7 +338,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             upload_context.prepare_kwargs_for_retry(kwargs)
             self.retry(max_retries=3, countdown=retry_countdown, kwargs=kwargs)
 
-    async def run_async_within_lock(
+    def run_impl_within_lock(
         self,
         db_session,
         upload_context: UploadContext,

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from json import loads
 from typing import Any, List, Mapping, Optional
 
+from asgiref.sync import async_to_sync
 from celery import chain, chord
 from redis import Redis
 from redis.exceptions import LockError
@@ -288,7 +289,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 timeout=max(300, self.hard_time_limit_task),
                 blocking_timeout=5,
             ):
-                return await self.run_impl_within_lock(
+                return self.run_impl_within_lock(
                     db_session,
                     upload_context,
                     *args,
@@ -412,10 +413,10 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         was_updated, was_setup = False, False
         try:
             repository_service = get_repo_provider_service(repository, commit)
-            was_updated = await possibly_update_commit_from_provider_info(
+            was_updated = async_to_sync(possibly_update_commit_from_provider_info)(
                 commit, repository_service
             )
-            was_setup = await self.possibly_setup_webhooks(commit, repository_service)
+            was_setup = self.possibly_setup_webhooks(commit, repository_service)
         except RepositoryWithoutValidBotError:
             save_commit_error(
                 commit,
@@ -439,7 +440,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 exc_info=True,
             )
         if repository_service:
-            commit_yaml = await self.fetch_commit_yaml_and_possibly_store(
+            commit_yaml = self.fetch_commit_yaml_and_possibly_store(
                 commit, repository_service
             )
         else:
@@ -470,7 +471,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                     report_code=report_code,
                 ),
             )
-            commit_report = await report_service.initialize_and_save_report(
+            commit_report = async_to_sync(report_service.initialize_and_save_report)(
                 commit,
                 report_code,
             )
@@ -514,14 +515,14 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             )
         return {"was_setup": was_setup, "was_updated": was_updated}
 
-    async def fetch_commit_yaml_and_possibly_store(self, commit, repository_service):
+    def fetch_commit_yaml_and_possibly_store(self, commit, repository_service):
         repository = commit.repository
         try:
             log.info(
                 "Fetching commit yaml from provider for commit",
                 extra=dict(repoid=commit.repoid, commit=commit.commitid),
             )
-            commit_yaml = await fetch_commit_yaml_from_provider(
+            commit_yaml = async_to_sync(fetch_commit_yaml_from_provider)(
                 commit, repository_service
             )
             save_repo_yaml_to_database_if_needed(commit, commit_yaml)
@@ -755,7 +756,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         )
         return None
 
-    async def possibly_setup_webhooks(self, commit, repository_service):
+    def possibly_setup_webhooks(self, commit, repository_service):
         repository = commit.repository
         repo_data = repository_service.data
 
@@ -793,7 +794,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 else:
                     # service-level config value will be used instead in this case
                     webhook_secret = None
-                hook_result = await create_webhook_on_provider(
+                hook_result = async_to_sync(create_webhook_on_provider)(
                     repository_service, webhook_secret=webhook_secret
                 )
                 hookid = hook_result["id"]

--- a/tasks/upload_clean_labels_index.py
+++ b/tasks/upload_clean_labels_index.py
@@ -46,9 +46,7 @@ class CleanLabelsIndexTask(
     BaseCodecovTask,
     name=task_name,
 ):
-    async def run_async(
-        self, db_session, repoid, commitid, report_code=None, *args, **kwargs
-    ):
+    def run_impl(self, db_session, repoid, commitid, report_code=None, *args, **kwargs):
         redis_connection = get_redis_connection()
         repoid = int(repoid)
         lock_name = UPLOAD_PROCESSING_LOCK_NAME(repoid, commitid)
@@ -78,7 +76,7 @@ class CleanLabelsIndexTask(
                 timeout=max(300, self.hard_time_limit_task),
                 blocking_timeout=5,
             ):
-                return await self.run_async_within_lock(
+                return await self.run_impl_within_lock(
                     db_session,
                     read_only_args,
                     *args,
@@ -98,7 +96,7 @@ class CleanLabelsIndexTask(
         _prepare_kwargs_for_retry(repoid, commitid, report_code, kwargs)
         self.retry(max_retries=3, countdown=retry_countdown, kwargs=kwargs)
 
-    async def run_async_within_lock(
+    def run_impl_within_lock(
         self,
         read_only_args: ReadOnlyArgs,
         *args,

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -43,7 +43,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         - Invalidating whatever cache is done
     """
 
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         processing_results,

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -83,7 +83,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 db_session.commit()
                 commit.notified = False
                 db_session.commit()
-                result = await self.finish_reports_processing(
+                result = self.finish_reports_processing(
                     db_session,
                     commit,
                     commit_yaml,
@@ -116,7 +116,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 ),
             )
 
-    async def finish_reports_processing(
+    def finish_reports_processing(
         self,
         db_session,
         commit,

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -69,7 +69,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         retry_in = FIRST_RETRY_DELAY * 3**self.request.retries
         self.retry(max_retries=max_retries, countdown=retry_in)
 
-    async def run_async(
+    def run_impl(
         self,
         db_session,
         previous_results,

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from typing import Optional
 
 import sentry_sdk
+from asgiref.sync import async_to_sync
 from celery.exceptions import CeleryError, SoftTimeLimitExceeded
 from redis.exceptions import LockError
 from shared.celery_config import upload_processor_task_name
@@ -105,7 +106,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 blocking_timeout=5,
             ):
                 actual_arguments_list = deepcopy(arguments_list)
-                return await self.process_async_within_lock(
+                return self.process_impl_within_lock(
                     db_session=db_session,
                     previous_results=previous_results,
                     repoid=repoid,
@@ -131,7 +132,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             )
             self.retry(max_retries=5, countdown=retry_in)
 
-    async def process_async_within_lock(
+    def process_impl_within_lock(
         self,
         *,
         db_session,
@@ -241,7 +242,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 ),
             )
             with metrics.timer(f"{self.metrics_prefix}.save_report_results"):
-                results_dict = await self.save_report_results(
+                results_dict = self.save_report_results(
                     db_session,
                     report_service,
                     repository,
@@ -394,7 +395,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             archive_service = report_service.get_archive_service(commit.repository)
             archive_service.write_file(archive_url, raw_report.content().getvalue())
 
-    async def save_report_results(
+    def save_report_results(
         self,
         db_session,
         report_service,
@@ -415,7 +416,9 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         commitid = commit.commitid
         try:
             repository_service = get_repo_provider_service(repository, commit)
-            report.apply_diff(await repository_service.get_commit_diff(commitid))
+            report.apply_diff(
+                async_to_sync(repository_service.get_commit_diff)(commitid)
+            )
         except TorngitError:
             # When this happens, we have that commit.totals["diff"] is not available.
             # Since there is no way to calculate such diff without the git commit,


### PR DESCRIPTION
tl;dr: remove most of the `async`/`await` from worker tasks. where async functions remain (e.g. functions in shared) run them with `async_to_sync`. https://github.com/codecov/worker/pull/305 is a faster unblock until we can follow through on this change if preferred

our use of async in worker is mostly spurious. it's basically:
```
async def run_async():
    await foo()
    await bar()
    await baz()

asyncio.run(run_async())
```
when `run_async()` runs `await foo()`, it can yield control to some other task. but there's no other task going on in the event loop, and `run_async()` can't continue to start `bar()` until after `foo()` totally completes. so there's nothing else to run and we wind up running `foo()`, `bar()`, and `baz()` synchronously

django is unhappy with us if we try to use its ORM from inside an async event loop. since our base task runs everything in an async function, it'll be unhappy quite a lot. this PR removes that top-level async and most of the async throughout tasks.

it's possible we _could_ benefit from `async`/`await`, but we would have to use it more like the following pattern:
```
def run_impl():
    yaml_future = get_commit_yaml()
    pr_info_future = get_pr_info()
    yaml, pr = async_to_sync(asyncio.gather)(yaml_future, pr_info_future)
```
we would have to move logic around so that all of our async functions are ready to be run at the same time and then use asyncio to run them concurrently.

### useful commands for updating/recreating this PR
run from root of worker repo
i recommend installing `watch` and `rg` with `brew install watch ripgrep`

```
# replace all `async def` with `def`
find tasks -type f -name '*.py' -exec sed -E -i '' 's/async def/def/' {} +

# delete all `@pytest.mark.asyncio` lines in tests
find tasks/tests -type f -name '*.py' -exec sed -E -i '' '/@pytest.mark.asyncio/d' {} +

# rename `run_async` to `run_impl`
find tasks -type f -name '*.py' -exec sed -E -i '' 's/run_async/run_impl/' {} +

# rename `process_async` to `process_impl`
find tasks -type f -name '*.py' -exec sed -E -i '' 's/run_async/run_impl/' {} +

# replace `await self.` with `self.`
find tasks -type f -name '*.py' -exec sed -E -i '' 's/await self\./self./' {} +

# display a list of all usages of "await", auto-updated every 2 seconds
watch -c -n 2 "rg -j1 'await' tasks --color always | less -R"

# print first usage of `async_to_sync` in every file
# useful to find all files which use it without importing it in one go
find tasks -type f -name '*.py' -exec awk 's != FILENAME && /async_to_sync/{print FILENAME; print; s=FILENAME}' {} +
```

process was basically:
- run the commands starting with `find` to get rid of most async usage in worker + tests
- run the `watch` command in a separate terminal to view a live-updating list of places that still have `await`s
- changed all the `await`s to use `async_to_sync`
- ran the tests, fixed whatever came up

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.