### PR TITLE
allow django in async code, re-enable disabled feature + set env in tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -26,6 +26,7 @@ def pytest_configure(config):
     file after command line options have been parsed.
     """
     os.environ["CURRENT_ENVIRONMENT"] = "local"
+    os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
     _get_cached_current_env.cache_clear()
     initialize_logging()
 

--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -10,20 +10,7 @@ LIST_REPOS_GENERATOR_BY_OWNER_ID = Feature(
 
 # Eventually we want all repos to use this
 # This flag will just help us with the rollout process
-# USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = Feature(
-#     "use_label_index_in_report_processing",
-#     0.0,
-# )
-
-
-class TempFeature:
-    def __init__(self):
-        pass
-
-    def check_value(self, id, default=False):
-        if id == 16621196 or id == 16273544:
-            return True
-        return False
-
-
-USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = TempFeature()
+USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = Feature(
+    "use_label_index_in_report_processing",
+    0.0,
+)


### PR DESCRIPTION
https://docs.djangoproject.com/en/5.0/topics/async/#envvar-DJANGO_ALLOW_ASYNC_UNSAFE

django gets mad at us for using its ORM in an async event loop, but we can disable its warning

i believe the `async`/`await` in `worker` is mostly spurious and doesn't result in any concurrency. i remove most of it in https://github.com/codecov/worker/pull/304, and this would appease django, but that change is enormous

assuming i am right that most of the async in worker is not really doing anything, then it should be safe to disable the safety check until we can follow through on the mega-PR

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.