### PR TITLE
fix: move django setup to before celery setup

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,8 @@
 import logging
 import logging.config
+import os
 
+import django
 from celery import Celery, signals
 
 import database.events
@@ -11,6 +13,30 @@ log = logging.getLogger(__name__)
 
 _config_dict = get_logging_config_dict()
 logging.config.dictConfig(_config_dict)
+
+# ALERT ALERT ALERT! This is not to be done lightly!
+# Django's ORM raises errors if run from within an asyncio event loop. Our
+# base celery task runs all task implementations via asyncio.run(), so when
+# we use Django's ORM in most of worker it'll get steamed. However, the base
+# task use of asyncio is actually superfluous. Consider the following:
+#
+#    async def run_async():
+#        await foo()
+#        await bar()
+#        await baz()
+#    asyncio.run(run_async())
+#
+# `run_async()` is effectively running `foo()`, `bar()`, and `baz()`
+# synchronously. When we `await foo()`, there's nothing else running in the
+# event loop that we could resume, and we can't start `bar()` until `foo()`
+# has completed. So... there's nothing to do but wait.
+#
+# With that in mind, we should be able to safely disable Django's
+# protections with this environment variable.
+os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_scaffold.settings")
+django.setup()
 
 celery_app = Celery("tasks")
 celery_app.config_from_object("celery_config:CeleryWorkerConfig")

--- a/app.py
+++ b/app.py
@@ -35,6 +35,9 @@ logging.config.dictConfig(_config_dict)
 # protections with this environment variable.
 os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
 
+# we're moving this before we create the Celery object
+# so that celery can detect Django is being used
+# using the Django fixup will help fix some database issues
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_scaffold.settings")
 django.setup()
 

--- a/main.py
+++ b/main.py
@@ -5,7 +5,6 @@ import sys
 import typing
 
 import click
-import django
 from celery.signals import worker_process_shutdown
 from prometheus_client import REGISTRY, CollectorRegistry, multiprocess
 from shared.celery_config import BaseCeleryConfig
@@ -61,30 +60,6 @@ def setup_worker():
         external_deps_folder = get_external_dependencies_folder()
         log.info(f"External dependencies folder configured to {external_deps_folder}")
         sys.path.append(external_deps_folder)
-
-    # ALERT ALERT ALERT! This is not to be done lightly!
-    # Django's ORM raises errors if run from within an asyncio event loop. Our
-    # base celery task runs all task implementations via asyncio.run(), so when
-    # we use Django's ORM in most of worker it'll get steamed. However, the base
-    # task use of asyncio is actually superfluous. Consider the following:
-    #
-    #    async def run_async():
-    #        await foo()
-    #        await bar()
-    #        await baz()
-    #    asyncio.run(run_async())
-    #
-    # `run_async()` is effectively running `foo()`, `bar()`, and `baz()`
-    # synchronously. When we `await foo()`, there's nothing else running in the
-    # event loop that we could resume, and we can't start `bar()` until `foo()`
-    # has completed. So... there's nothing to do but wait.
-    #
-    # With that in mind, we should be able to safely disable Django's
-    # protections with this environment variable.
-    os.environ.setdefault("DJANGO_ALLOW_ASYNC_UNSAFE", "true")
-
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_scaffold.settings")
-    django.setup()
 
     registry = REGISTRY
     if "PROMETHEUS_MULTIPROC_DIR" in os.environ:

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -220,7 +220,7 @@ class TestUploadTaskIntegration(object):
         commit = CommitFactory.create(
             message="",
             commitid="abf6d4df662c47e32460020ab14abf9303581429",
-            repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
+            repository__owner__oauth_token="GHTZB+Mi+kbl/ubudnSKTJYb/fgN4hRJVJYSIErtidEsCLDJBb8DZzkbXqLujHAnv28aKShXddE/OffwRuwKug==",
             repository__owner__username="ThiagoCodecov",
             repository__owner__service="github",
             repository__yaml={"codecov": {"max_report_age": "1y ago"}},


### PR DESCRIPTION
If the DJANGO_SETTINGS_MODULE and django app are setup after the celery app the celery app won't use the [django fixup](https://github.com/celery/celery/blob/main/celery/fixups/django.py) which [has some DB related code](https://github.com/celery/celery/blob/main/celery/fixups/django.py#L179-L210) (which may fix this "Django transaction failed to commit." that we're running into.)