### PR TITLE
perf: experiment with bulk instert test results

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -5,7 +5,7 @@ from database.models import Owner, Repository
 # Declare the feature variants and parameters via Django Admin
 LIST_REPOS_GENERATOR_BY_OWNER_ID = Feature("list_repos_generator")
 
-BULK_INSERT_TEST_INSTANCES = Feature("bulk_insert_test_instances", 0.0)
+BULK_INSERT_TEST_INSTANCES = Feature("bulk_insert_test_instances")
 
 # Eventually we want all repos to use this
 # This flag will just help us with the rollout process

--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -8,6 +8,8 @@ LIST_REPOS_GENERATOR_BY_OWNER_ID = Feature(
     0.0,
 )
 
+BULK_INSERT_TEST_INSTANCES = Feature("bulk_insert_test_instances", 0.0)
+
 # Eventually we want all repos to use this
 # This flag will just help us with the rollout process
 USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = Feature(

--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -240,7 +240,7 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
             }
         flags_hash = generate_flags_hash(upload_obj.flag_names)
         upload_id = upload_obj.id
-        if BULK_INSERT_TEST_INSTANCES.check_value(repoid, default=False):
+        if BULK_INSERT_TEST_INSTANCES.check_value(repo_id=repoid, default=False):
             self._bulk_write_tests_to_db(
                 db_session, repoid, upload_id, parsed_testruns, flags_hash
             )


### PR DESCRIPTION
These changes have 2 obejctives:
1. (duh) try to speed up time of writing tests and test instances in the DB.
    This is inspired by https://docs.sqlalchemy.org/en/13/faq/performance.html#i-m-inserting-400-000-rows-with-the-orm-and-it-s-really-slow
    The idea is to bulk_update and let the DB handle the concurrency and the conflicts.

2. Test using Sentry metrics + Features for perf potential improvements.
    Although I suspect the time benefit will be enough for us to prefer the bulk_insert technique I don't know what the benefit is (potentially). And there's the drawback of using extra memory, which I'm also not sure how much extra memory it is.
    So I want to use this opportunity to explore this setup of running perf experiments :D

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.