### PR TITLE
shared function is async generator. We need to treat it as that

### DIFF
--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -144,7 +144,7 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
         repos_to_search = [
             x[1] for x in repository_service_ids if x[0] in missing_repo_service_ids
         ]
-        for repo_data in git.get_repos_from_nodeids_generator(
+        async for repo_data in git.get_repos_from_nodeids_generator(
             repos_to_search, owner.username
         ):
             # Insert those repos

--- a/tasks/tests/unit/test_sync_repos_task.py
+++ b/tasks/tests/unit/test_sync_repos_task.py
@@ -972,7 +972,7 @@ class TestSyncReposTaskUnit(object):
             kwargs={"repoid": new_repo_list[0].repoid, "manual_trigger": False}
         )
 
-    def test_sync_repos_usgin_integration_affected_repos_known(
+    def test_sync_repos_using_integration_affected_repos_known(
         self,
         mocker,
         dbsession,
@@ -1040,7 +1040,7 @@ class TestSyncReposTaskUnit(object):
         dbsession.flush()
 
         # These are the repos we're supposed to query from the service provider
-        def side_effect(*args, **kwargs):
+        async def side_effect(*args, **kwargs):
             results = [
                 {
                     "branch": "main",


### PR DESCRIPTION
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.