### PR TITLE
feat: add message when test_result is setup

### DIFF
--- a/services/notification/__init__.py
+++ b/services/notification/__init__.py
@@ -16,7 +16,7 @@ from shared.yaml import UserYaml
 
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
 from helpers.metrics import metrics
-from services.comparison.types import Comparison
+from services.comparison import ComparisonProxy
 from services.decoration import Decoration
 from services.license import is_properly_licensed
 from services.notification.commit_notifications import (
@@ -186,7 +186,7 @@ class NotificationService(object):
         for component_status in self._get_component_statuses(current_flags):
             yield component_status
 
-    async def notify(self, comparison: Comparison) -> List[NotificationResult]:
+    async def notify(self, comparison: ComparisonProxy) -> List[NotificationResult]:
         if not is_properly_licensed(comparison.head.commit.get_db_session()):
             log.warning(
                 "Not sending notifications because the system is not properly licensed"
@@ -218,7 +218,7 @@ class NotificationService(object):
         return results
 
     async def notify_individual_notifier(
-        self, notifier, comparison
+        self, notifier: AbstractBaseNotifier, comparison: ComparisonProxy
     ) -> NotificationResult:
         commit = comparison.head.commit
         base_commit = comparison.project_coverage_base.commit

--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -103,6 +103,13 @@ class NewFooterSectionWriter(BaseSectionWriter):
 
 
 class NewHeaderSectionWriter(BaseSectionWriter):
+    def _possibly_include_test_result_setup_confirmation(self, comparison):
+        if comparison.all_tests_passed():
+            yield ("")
+            yield (
+                ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:"
+            )
+
     async def do_write_section(self, comparison, diff, changes, links, behind_by=None):
         yaml = self.current_yaml
         base_report = comparison.project_coverage_base.report
@@ -126,6 +133,10 @@ class NewHeaderSectionWriter(BaseSectionWriter):
 
         hide_project_coverage = self.settings.get("hide_project_coverage", False)
         if hide_project_coverage:
+            for msg in self._possibly_include_test_result_setup_confirmation(
+                comparison
+            ):
+                yield msg
             return
 
         if base_report and head_report:
@@ -196,6 +207,9 @@ class NewHeaderSectionWriter(BaseSectionWriter):
                 yield (
                     "Changes have been made to critical files, which contain lines commonly executed in production. [Learn more](https://docs.codecov.com/docs/impact-analysis)"
                 )
+
+        for msg in self._possibly_include_test_result_setup_confirmation(comparison):
+            yield msg
 
 
 class HeaderSectionWriter(BaseSectionWriter):
@@ -302,6 +316,12 @@ class HeaderSectionWriter(BaseSectionWriter):
                 yield (
                     "Changes have been made to critical files, which contain lines commonly executed in production. [Learn more](https://docs.codecov.com/docs/impact-analysis)"
                 )
+
+        if comparison.all_tests_passed():
+            yield ("")
+            yield (
+                ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:"
+            )
 
 
 class AnnouncementSectionWriter(BaseSectionWriter):

--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -107,7 +107,7 @@ class NewHeaderSectionWriter(BaseSectionWriter):
         if comparison.all_tests_passed():
             yield ("")
             yield (
-                ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:"
+                ":white_check_mark: All tests successful. No failed tests found :relaxed:"
             )
 
     async def do_write_section(self, comparison, diff, changes, links, behind_by=None):
@@ -320,7 +320,7 @@ class HeaderSectionWriter(BaseSectionWriter):
         if comparison.all_tests_passed():
             yield ("")
             yield (
-                ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:"
+                ":white_check_mark: All tests successful. No failed tests found :relaxed:"
             )
 
 

--- a/services/notification/notifiers/tests/integration/test_comment.py
+++ b/services/notification/notifiers/tests/integration/test_comment.py
@@ -360,7 +360,7 @@ class TestCommentNotifierIntegration(object):
             "> Project coverage is 60.00%. Comparing base [(`5b174c2`)](https://app.codecov.io/gh/joseph-sentry/codecov-demo/commit/5b174c2b40d501a70c479e91025d5109b1ad5c1b?dropdown=coverage&el=desc) to head [(`5601846`)](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/9?dropdown=coverage&src=pr&el=desc).",
             "> Report is 2 commits behind head on main.",
             "",
-            ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:",
+            ":white_check_mark: All tests successful. No failed tests found :relaxed:",
             "",
             ":exclamation: Your organization needs to install the [Codecov GitHub app](https://github.com/apps/codecov/installations/select_target) to enable full functionality.",
             "",

--- a/services/notification/notifiers/tests/integration/test_comment.py
+++ b/services/notification/notifiers/tests/integration/test_comment.py
@@ -4,7 +4,7 @@ import pytest
 from shared.reports.readonly import ReadOnlyReport
 
 from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
-from services.comparison import ComparisonProxy
+from services.comparison import ComparisonProxy, NotificationContext
 from services.comparison.types import Comparison, EnrichedPull, FullCommit
 from services.decoration import Decoration
 from services.notification.notifiers.comment import CommentNotifier
@@ -337,6 +337,7 @@ def sample_comparison_for_limited_upload(
 class TestCommentNotifierIntegration(object):
     @pytest.mark.asyncio
     async def test_notify(self, sample_comparison, codecov_vcr, mock_configuration):
+        sample_comparison.context = NotificationContext(all_tests_passed=True)
         mock_configuration._params["setup"] = {
             "codecov_url": None,
             "codecov_dashboard_url": None,
@@ -358,6 +359,8 @@ class TestCommentNotifierIntegration(object):
             "All modified and coverable lines are covered by tests :white_check_mark:",
             "> Project coverage is 60.00%. Comparing base [(`5b174c2`)](https://app.codecov.io/gh/joseph-sentry/codecov-demo/commit/5b174c2b40d501a70c479e91025d5109b1ad5c1b?dropdown=coverage&el=desc) to head [(`5601846`)](https://app.codecov.io/gh/joseph-sentry/codecov-demo/pull/9?dropdown=coverage&src=pr&el=desc).",
             "> Report is 2 commits behind head on main.",
+            "",
+            ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:",
             "",
             ":exclamation: Your organization needs to install the [Codecov GitHub app](https://github.com/apps/codecov/installations/select_target) to enable full functionality.",
             "",

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -4020,7 +4020,7 @@ class TestNewHeaderSectionWriter(object):
             "All modified and coverable lines are covered by tests :white_check_mark:",
             f"> Project coverage is 0%. Comparing base [(`{sample_comparison.project_coverage_base.commit.commitid[:7]}`)](urlurl?dropdown=coverage&el=desc) to head [(`{sample_comparison.head.commit.commitid[:7]}`)](urlurl?dropdown=coverage&src=pr&el=desc).",
             "",
-            ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:",
+            ":white_check_mark: All tests successful. No failed tests found :relaxed:",
         ]
 
     @pytest.mark.asyncio
@@ -4077,7 +4077,7 @@ class TestNewHeaderSectionWriter(object):
         assert res == [
             "All modified and coverable lines are covered by tests :white_check_mark:",
             "",
-            ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:",
+            ":white_check_mark: All tests successful. No failed tests found :relaxed:",
         ]
 
 

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -16,6 +16,7 @@ from shared.yaml import UserYaml
 
 from database.models.core import GithubAppInstallation
 from database.tests.factories import RepositoryFactory
+from services.comparison import NotificationContext
 from services.comparison.overlays.critical_path import CriticalPathOverlay
 from services.decoration import Decoration
 from services.notification.notifiers.base import NotificationResult
@@ -3992,6 +3993,37 @@ class TestNewHeaderSectionWriter(object):
         ]
 
     @pytest.mark.asyncio
+    async def test_new_header_section_writer_test_results_setup(
+        self, mocker, sample_comparison
+    ):
+        sample_comparison.context = NotificationContext(all_tests_passed=True)
+        writer = NewHeaderSectionWriter(
+            mocker.MagicMock(),
+            mocker.MagicMock(),
+            show_complexity=mocker.MagicMock(),
+            settings={},
+            current_yaml=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "services.notification.notifiers.mixins.message.sections.round_number",
+            return_value=Decimal(0),
+        )
+        res = list(
+            await writer.write_section(
+                sample_comparison,
+                None,
+                None,
+                links={"pull": "urlurl", "base": "urlurl"},
+            )
+        )
+        assert res == [
+            "All modified and coverable lines are covered by tests :white_check_mark:",
+            f"> Project coverage is 0%. Comparing base [(`{sample_comparison.project_coverage_base.commit.commitid[:7]}`)](urlurl?dropdown=coverage&el=desc) to head [(`{sample_comparison.head.commit.commitid[:7]}`)](urlurl?dropdown=coverage&src=pr&el=desc).",
+            "",
+            ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:",
+        ]
+
+    @pytest.mark.asyncio
     async def test_new_header_section_writer_no_project_coverage(
         self, mocker, sample_comparison
     ):
@@ -4016,6 +4048,36 @@ class TestNewHeaderSectionWriter(object):
         )
         assert res == [
             "All modified and coverable lines are covered by tests :white_check_mark:",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_new_header_section_writer_no_project_coverage_test_results_setup(
+        self, mocker, sample_comparison
+    ):
+        sample_comparison.context = NotificationContext(all_tests_passed=True)
+        writer = NewHeaderSectionWriter(
+            mocker.MagicMock(),
+            mocker.MagicMock(),
+            show_complexity=mocker.MagicMock(),
+            settings={"hide_project_coverage": True},
+            current_yaml=mocker.MagicMock(),
+        )
+        mocker.patch(
+            "services.notification.notifiers.mixins.message.sections.round_number",
+            return_value=Decimal(0),
+        )
+        res = list(
+            await writer.write_section(
+                sample_comparison,
+                None,
+                None,
+                links={"pull": "urlurl", "base": "urlurl"},
+            )
+        )
+        assert res == [
+            "All modified and coverable lines are covered by tests :white_check_mark:",
+            "",
+            ":heavy_check_mark: Test ingestion set up successfully. No failed tests found. :relaxed:",
         ]
 
 


### PR DESCRIPTION
To help users confirm that test_results is setup correctly we want to display
a message near the header saying that that is the case and all tests passed.

These changes accomplish that by creating a new `NotificationContext` in the
`ComparisonProxy` and carrying the info to the notifier.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.