### PR TITLE
chore: make test_result metrics more consistent

### DIFF
--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -132,7 +132,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             # every processor errored, nothing to notify on
             metrics.incr(
                 "test_results.finisher",
-                tags={"status": "failure", "reason": "no_success"},
+                tags={"status": "failure", "reason": "no_successful_processing"},
             )
             return {"notify_attempted": False, "notify_succeeded": False}
 
@@ -191,7 +191,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         if self.check_if_no_failures(test_instances):
             metrics.incr(
                 "test_results.finisher",
-                tags={"status": "success", "reason": "no_failures"},
+                tags={"status": "normal_notify_called", "reason": "all_tests_passed"},
             )
             self.app.tasks[notify_task_name].apply_async(
                 args=None,
@@ -201,11 +201,14 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             )
             return {"notify_attempted": False, "notify_succeeded": False}
 
-        metrics.incr("test_results.finisher", tags={"status": "failures_exist"})
+        metrics.incr(
+            "test_results.finisher",
+            tags={"status": "success", "reason": "tests_failed"},
+        )
 
         notifier = TestResultsNotifier(commit, commit_yaml, test_instances)
         with metrics.timing("test_results.finisher.notification"):
-            success = async_to_sync(notifier.notify)(
+            success, reason = async_to_sync(notifier.notify)(
                 failures, passed_tests, skipped_tests, failed_tests
             )
 
@@ -222,8 +225,8 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
 
         # using a var as a tag here will be fine as it's a boolean
         metrics.incr(
-            "test_results.finisher",
-            tags={"status": success, "reason": "notified"},
+            "test_results.finisher.test_result_notifier",
+            tags={"status": success, "reason": reason},
         )
         return {"notify_attempted": True, "notify_succeeded": success}
 

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -366,10 +366,13 @@ class TestUploadTestFinisherTask(object):
 
         mock_metrics.incr.assert_has_calls(
             [
-                call("test_results.finisher", tags={"status": "failures_exist"}),
                 call(
                     "test_results.finisher",
-                    tags={"status": True, "reason": "notified"},
+                    tags={"status": "success", "reason": "tests_failed"},
+                ),
+                call(
+                    "test_results.finisher.test_result_notifier",
+                    tags={"status": True, "reason": "comment_posted"},
                 ),
             ]
         )
@@ -545,7 +548,10 @@ class TestUploadTestFinisherTask(object):
             [
                 call(
                     "test_results.finisher",
-                    tags={"status": "success", "reason": "no_failures"},
+                    tags={
+                        "status": "normal_notify_called",
+                        "reason": "all_tests_passed",
+                    },
                 ),
             ]
         )
@@ -713,7 +719,7 @@ class TestUploadTestFinisherTask(object):
             [
                 call(
                     "test_results.finisher",
-                    tags={"status": "failure", "reason": "no_success"},
+                    tags={"status": "failure", "reason": "no_successful_processing"},
                 ),
             ]
         )
@@ -1033,10 +1039,13 @@ class TestUploadTestFinisherTask(object):
 
         mock_metrics.incr.assert_has_calls(
             [
-                call("test_results.finisher", tags={"status": "failures_exist"}),
                 call(
                     "test_results.finisher",
-                    tags={"status": False, "reason": "notified"},
+                    tags={"status": "success", "reason": "tests_failed"},
+                ),
+                call(
+                    "test_results.finisher.test_result_notifier",
+                    tags={"status": False, "reason": "torngit_error"},
                 ),
             ]
         )


### PR DESCRIPTION
When you group metrics of the test_result.finisher grouped by "reason" and "status"
the options currently are:

| reason      | status         |
|-------------|----------------|
| no_success  | failure        |
| notified    | False          |
| no_failures | success        |
| None        | failures_exist |
| notified    | True           |

These options are not very consistent and it's also not immediately clear
what is happening in all of the cases.

These changes alter the tags associated with the metrics to make them more
consistent.
Changes are:
( no_success, failure ) --> ( no_successful_processing, failure )
( no_failures, success ) --> ( all_tests_passed, normal_notify_called )
( None, failures_exist ) --> ( tests_failed, success )

For the `notified` reason, those actually capture the outcome of calling the
`TestResultNotifier`, so the metric was modified to `"test_results.finisher.test_result_notifier"`.
The reason was also changed to be sent from the notifier.
Failure reasons include "no_pull" and "torngit_error".
Success reason is "comment_posted"
Status is still True / False

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.