### PR TITLE
fix: timeseries task name definition

### DIFF
--- a/tasks/timeseries_backfill.py
+++ b/tasks/timeseries_backfill.py
@@ -4,7 +4,11 @@ from typing import Iterable, Optional
 
 from celery import group
 from celery.canvas import Signature
-from shared.celery_config import timeseries_save_commit_measurements_task_name
+from shared.celery_config import (
+    timeseries_backfill_commits_task_name,
+    timeseries_backfill_dataset_task_name,
+    timeseries_save_commit_measurements_task_name,
+)
 from sqlalchemy.orm.session import Session
 
 from app import celery_app
@@ -17,9 +21,8 @@ from tasks.base import BaseCodecovTask
 log = logging.getLogger(__name__)
 
 
-# TODO: add name to `shared.celery_config`
 class TimeseriesBackfillCommitsTask(
-    BaseCodecovTask, name="app.tasks.timeseries.backfill_commits"
+    BaseCodecovTask, name=timeseries_backfill_commits_task_name
 ):
     def run_impl(
         self,
@@ -53,11 +56,9 @@ timeseries_backfill_commits_task = celery_app.tasks[
 ]
 
 
-class TimeseriesBackfillDatasetTask(BaseCodecovTask):
-
-    # TODO: add name to `shared.celery_config`
-    name = "app.tasks.timeseries.backfill_dataset"
-
+class TimeseriesBackfillDatasetTask(
+    BaseCodecovTask, name=timeseries_backfill_dataset_task_name
+):
     def run_impl(
         self,
         db_session: Session,


### PR DESCRIPTION
`TimeseriesBackfillDatasetTask` was not setting `name` correctly causing this task to not be reference-able by other callers. This led to "Enable Analytics" button in the app to not work.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.