### PR TITLE
fix: don't eager merge sessions into report

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -893,7 +893,7 @@ class ReportService(BaseReportService):
                 upload_obj=upload,
             )
         except ReportEmptyError:
-            log.info(
+            log.warning(
                 "Report %s is empty",
                 reportid,
                 extra=dict(repoid=commit.repoid, commit=commit.commitid),

--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -90,10 +90,14 @@ def process_raw_upload(
     else:
         ignored_file_lines = None
 
+    session = session or Session()
     # Get a sesisonid to merge into
     # anything merged into the original_report
     # will take on this sessionid
-    sessionid, session = original_report.add_session(session or Session())
+    # But we don't actually merge yet in case the report is empty.
+    # This is done to avoid garbage sessions to build up in the report
+    # How can you be sure this will be the sessionid used when you actually merge it? Remember that this piece of code runs inside a lock u.u
+    sessionid = original_report.next_session_number()
     session.id = sessionid
     if env:
         session.env = dict([e.split("=", 1) for e in env.split("\n") if "=" in e])
@@ -182,6 +186,10 @@ def process_raw_upload(
         # none of the reports processed contributed any new labels to it.
         # So we assume there are no labels and just reset the _labels_index of temporary_report
         temporary_report.labels_index = None
+    # Now we actually add the session to the original_report
+    # Because we know that the processing was successful
+    sessionid, session = original_report.add_session(session)
+    # Adjust sessions removed carryforward sessions that are being replaced
     session_manipulation_result = _adjust_sessions(
         original_report,
         temporary_report,

--- a/services/report/report_processor.py
+++ b/services/report/report_processor.py
@@ -172,7 +172,7 @@ def process_report(
                         f"worker.services.report.processors.{processor.name}.failure"
                     )
                     raise
-    log.info(
+    log.warning(
         "File format could not be recognized",
         extra=dict(
             report_filename=name, first_line=first_line[:100], report_type=report_type


### PR DESCRIPTION
context: https://l.codecov.dev/xvGZaM

Because we eagerly merge sessions when processing a report the following scenario can happen:
1. You upload an empty report with a flag set to carryforward
2. There will be a new session for that upload (even though it's empty)
3. In the next commit the session will be carried forward

If no real upload was made to clean up old carriedforward sessions from empty uploads
they would accumulate in the report (because `_adjust_sessions` only runs *after* the
processing is done, and *doesn't run* if it's an empty upload). What prompted this
investigation is that a customer was fund with thousands of carryforward session in
some of their commits.

So I'm exploiting the fact that merges into the report need to be made from within a lock
and getting the ID for the session _without_ actually adding it to the original report.

If the report is successful we add it and run `_adjust_sessions`. If the report was empty,
we just never add it to the report, as if it didn't existed.

OBS.: Even though I use the litle exploit I believe that passing the `sessionid` to
`ReportBuilder` is unecessary. We can likely not get a sessionid at all when processin the report
and it would still work. I decided to leave this for it's own change tho.

Also I decided to bump the severity of the messages that indicate a report is empty.
Users are not expected to upload empty reports, so it's at least sensible it should be
a warning.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.