### PR TITLE
fix: propagate gh_installation name selection

### DIFF
--- a/services/notification/notifiers/base.py
+++ b/services/notification/notifiers/base.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from database.models import Repository
+from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
 from services.comparison.types import Comparison
 from services.decoration import Decoration
 
@@ -39,6 +40,7 @@ class AbstractBaseNotifier(object):
         notifier_site_settings: Mapping[str, Any],
         current_yaml: Mapping[str, Any],
         decoration_type: Decoration = None,
+        gh_installation_name_to_use: str = GITHUB_APP_INSTALLATION_DEFAULT_NAME,
     ):
         """
         :param repository: The repository notifications are being sent to.
@@ -48,6 +50,7 @@ class AbstractBaseNotifier(object):
         :param notifier_site_settings -> Contains the codecov yaml fields under the "notify" header
         :param current_yaml -> The complete codecov yaml used for this notification.
         :param decoration_type -> Indicates whether the user needs to upgrade their account before they can see the notification
+        :param gh_installation_name_to_use -> [GitHub exclusive] propagates choice of the installation_name in case of gh multi apps
         """
         self.repository = repository
         self.title = title
@@ -55,6 +58,7 @@ class AbstractBaseNotifier(object):
         self.site_settings = notifier_site_settings
         self.current_yaml = current_yaml
         self.decoration_type = decoration_type
+        self.gh_installation_name = gh_installation_name_to_use
 
     @property
     def name(self) -> str:

--- a/services/notification/notifiers/checks/base.py
+++ b/services/notification/notifiers/checks/base.py
@@ -347,7 +347,9 @@ class ChecksNotifier(StatusNotifier):
     @property
     def repository_service(self):
         if not self._repository_service:
-            self._repository_service = get_repo_provider_service(self.repository)
+            self._repository_service = get_repo_provider_service(
+                self.repository, installation_name_to_use=self.gh_installation_name
+            )
         return self._repository_service
 
     async def send_notification(self, comparison: Comparison, payload):

--- a/services/notification/notifiers/comment/__init__.py
+++ b/services/notification/notifiers/comment/__init__.py
@@ -31,7 +31,9 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
     @property
     def repository_service(self):
         if not self._repository_service:
-            self._repository_service = get_repo_provider_service(self.repository)
+            self._repository_service = get_repo_provider_service(
+                self.repository, installation_name_to_use=self.gh_installation_name
+            )
         return self._repository_service
 
     def store_results(self, comparison: Comparison, result: NotificationResult):

--- a/services/notification/notifiers/generics.py
+++ b/services/notification/notifiers/generics.py
@@ -41,7 +41,9 @@ class StandardNotifier(AbstractBaseNotifier):
     @property
     def repository_service(self):
         if not self._repository_service:
-            self._repository_service = get_repo_provider_service(self.repository)
+            self._repository_service = get_repo_provider_service(
+                self.repository, installation_name_to_use=self.gh_installation_name
+            )
         return self._repository_service
 
     def store_results(self, comparison: Comparison, result: NotificationResult) -> bool:

--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -108,7 +108,9 @@ class StatusNotifier(AbstractBaseNotifier):
     @property
     def repository_service(self):
         if not self._repository_service:
-            self._repository_service = get_repo_provider_service(self.repository)
+            self._repository_service = get_repo_provider_service(
+                self.repository, installation_name_to_use=self.gh_installation_name
+            )
         return self._repository_service
 
     def get_notifier_filters(self) -> dict:


### PR DESCRIPTION
After configuring multi-apps in staging we noticed the notificaitons were not coming
from the configured app. That is because each notifier uses its own `repo_service` instance.

These changes propagate the `gh_installation_name` selected by the Notify task
(the selection part is working properly) to the `NotificationService`.
The `NotificationService` in turn propagates the choice to the notifiers so that
when they get their own `repo_service` instances it will be from the correct installation.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.