### PR TITLE
Integrate flaky test detection into test results finisher

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -5,6 +5,8 @@ from database.models import Owner, Repository
 # Declare the feature variants and parameters via Django Admin
 LIST_REPOS_GENERATOR_BY_OWNER_ID = Feature("list_repos_generator")
 
+FLAKY_TEST_DETECTION = Feature("flaky_test_detection")
+
 # Eventually we want all repos to use this
 # This flag will just help us with the rollout process
 USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = Feature(

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -7,7 +7,7 @@ from shared.torngit.exceptions import TorngitClientError
 from shared.yaml import UserYaml
 from sqlalchemy import desc
 
-from database.enums import ReportType
+from database.enums import FlakeSymptomType, ReportType
 from database.models import Commit, CommitReport, RepositoryFlag, TestInstance, Upload
 from services.report import BaseReportService
 from services.repository import (
@@ -120,11 +120,18 @@ class TestResultsNotificationFailure:
 
 
 @dataclass
+class TestResultsNotificationFlake:
+    flake_type: list[FlakeSymptomType]
+    is_new_flake: bool
+
+
+@dataclass
 class TestResultsNotificationPayload:
     failed: int
     passed: int
     skipped: int
     failures: List[TestResultsNotificationFailure]
+    flaky_tests: dict[str, TestResultsNotificationFlake] | None = None
 
 
 class TestResultsNotifier:
@@ -164,24 +171,53 @@ class TestResultsNotifier:
     def generate_test_description(
         self,
         fail: TestResultsNotificationFailure,
+        flake: TestResultsNotificationFlake | None = None,
     ):
         envs = [f"- {env}" for env in fail.envs] or ["- default"]
         env_section = "<br>".join(envs)
         test_description = (
-            f"Testsuite:<br>{fail.testsuite}<br>"
-            f"Test name:<br>{fail.testname}<br>"
-            f"Envs:<br>{env_section}<br>"
+            "<pre>"
+            f"**Testsuite:**<br>{fail.testsuite}<br><br>"
+            f"**Test name:**<br>{fail.testname}<br><br>"
+            f"**Envs:**<br>{env_section}<br>"
+            "</pre>"
         )
+
+        if flake is not None:
+            if flake.is_new_flake:
+                test_description = f":snowflake::card_index_dividers: **Newly Detected Flake**<br>{test_description}"
+            else:
+                test_description = f":snowflake::card_index_dividers: **Known Flaky Test**<br>{test_description}"
+
         return test_description
 
     def generate_failure_info(
         self,
         fail: TestResultsNotificationFailure,
+        flake: TestResultsNotificationFlake | None = None,
     ):
         if fail.failure_message is not None:
-            return fail.failure_message
+            failure_message = fail.failure_message
         else:
-            return "No failure message available"
+            failure_message = "No failure message available"
+
+        if flake is not None:
+
+            flake_messages = []
+            if FlakeSymptomType.FAILED_IN_DEFAULT_BRANCH in flake.flake_type:
+                flake_messages.append("Failure on default branch")
+            if FlakeSymptomType.CONSECUTIVE_DIFF_OUTCOMES in flake.flake_type:
+                flake_messages.append("Differing outcomes on the same commit")
+            if FlakeSymptomType.UNRELATED_MATCHING_FAILURES in flake.flake_type:
+                flake_messages.append("Matching failures on unrelated branches")
+            flake_section = "".join(
+                [
+                    f":snowflake: :card_index_dividers: **{msg}**<br>"
+                    for msg in flake_messages
+                ]
+            )
+            return f"{flake_section}<pre>{failure_message}</pre>"
+        return f"<pre>{failure_message}</pre>"
 
     def build_message(self, payload: TestResultsNotificationPayload) -> str:
         message = []
@@ -193,9 +229,38 @@ class TestResultsNotifier:
         ]
 
         completed = payload.failed + payload.passed + payload.skipped
-        results = f"Completed {completed} tests with **`{payload.failed} failed`**, {payload.passed} passed and {payload.skipped} skipped."
+        if payload.flaky_tests:
+            new_flakes = 0
+            existing_flakes = 0
 
-        message.append(results)
+            for failure in payload.failures:
+                flake = payload.flaky_tests.get(failure.test_id, None)
+                if flake is not None:
+                    if flake.is_new_flake:
+                        new_flakes += 1
+                    else:
+                        existing_flakes += 1
+            existing_flake_section = (
+                f"{existing_flakes} known flaky" if existing_flakes else ""
+            )
+            comma_section = ", " if new_flakes and existing_flakes else ""
+            new_flake_section = (
+                f"{new_flakes} newly detected flaky" if new_flakes else ""
+            )
+            flake_section = (
+                f"({existing_flake_section}{comma_section}{new_flake_section})"
+                if (existing_flakes or new_flakes)
+                else ""
+            )
+
+            results = [
+                f"Completed {completed} tests with **`{payload.failed} failed`**{flake_section}, {payload.passed} passed and {payload.skipped} skipped.",
+                f"- Total :snowflake:**{len(payload.flaky_tests)} flaky tests.**",
+            ]
+            message += results
+        else:
+            results = f"Completed {completed} tests with **`{payload.failed} failed`**, {payload.passed} passed and {payload.skipped} skipped."
+            message.append(results)
 
         details = [
             "<details><summary>View the full list of failed tests</summary>",
@@ -207,12 +272,12 @@ class TestResultsNotifier:
         message += details
 
         for fail in payload.failures:
-
-            test_description = self.generate_test_description(fail)
-            failure_information = self.generate_failure_info(fail)
-            single_test_row = (
-                f"| <pre>{test_description}</pre> | <pre>{failure_information}</pre> |"
-            )
+            flake = None
+            if payload.flaky_tests is not None:
+                flake = payload.flaky_tests.get(fail.test_id, None)
+            test_description = self.generate_test_description(fail, flake)
+            failure_information = self.generate_failure_info(fail, flake)
+            single_test_row = f"| {test_description} | {failure_information} |"
             message.append(single_test_row)
 
         return "\n".join(message)

--- a/services/tests/test_flake_detector.py
+++ b/services/tests/test_flake_detector.py
@@ -161,6 +161,32 @@ def test_flake_consecutive_differing_outcomes_no_main_branch_specified(dbsession
     assert flaky_tests[test_id] == {FlakeSymptomType.CONSECUTIVE_DIFF_OUTCOMES}
 
 
+def test_flake_consecutive_differing_outcomes_no_main_branch_specified(dbsession):
+    repoid = create_repo(
+        dbsession,
+    )
+    commitid = create_commit(dbsession, repoid, "not_main")
+    reportid = create_report(dbsession, commitid)
+    reportid2 = create_report(dbsession, commitid)
+    uploadid = create_upload(dbsession, reportid)
+    uploadid2 = create_upload(dbsession, reportid2)
+    test_id = create_test(dbsession, repoid)
+    ti1 = create_test_instance(
+        dbsession, test_id, uploadid, str(Outcome.Failure), "failure message"
+    )
+    _ = create_test_instance(dbsession, test_id, uploadid2, str(Outcome.Pass), None)
+
+    dbfd = DefaultBranchFailureDetector(dbsession, repoid)
+    umd = UnrelatedMatchesDetector()
+    dod = DiffOutcomeDetector()
+
+    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd], None)
+    flaky_tests = fd.detect_flakes()
+
+    assert test_id in flaky_tests
+    assert flaky_tests[test_id] == {FlakeSymptomType.CONSECUTIVE_DIFF_OUTCOMES}
+
+
 def test_flake_matching_failures_on_unrelated_branches(dbsession):
     repoid = create_repo(
         dbsession,

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -1,0 +1,244 @@
+import mock
+import pytest
+from shared.torngit.exceptions import TorngitClientError
+
+from database.enums import FlakeSymptomType
+from database.models.core import Commit
+from services.test_results import (
+    TestResultsNotificationFailure,
+    TestResultsNotificationFlake,
+    TestResultsNotificationPayload,
+    TestResultsNotifier,
+    generate_flags_hash,
+    generate_test_id,
+)
+
+
+@pytest.fixture
+def tn():
+    commit = Commit()
+    tn = TestResultsNotifier(commit=commit, commit_yaml=None)
+    return tn
+
+
+@pytest.mark.asyncio
+async def test_send_to_provider(tn):
+    tn.pull = mock.AsyncMock()
+    tn.pull.database_pull.commentid = None
+    tn.repo_service = mock.AsyncMock()
+    m = dict(id=1)
+    tn.repo_service.post_comment.return_value = m
+
+    res = await tn.send_to_provider("hello world")
+
+    assert res == True
+
+    tn.repo_service.post_comment.assert_called_with(
+        tn.pull.database_pull.pullid, "hello world"
+    )
+    assert tn.pull.database_pull.commentid == 1
+
+
+@pytest.mark.asyncio
+async def test_send_to_provider_edit(tn):
+    tn.pull = mock.AsyncMock()
+    tn.pull.database_pull.commentid = 1
+    tn.repo_service = mock.AsyncMock()
+    m = dict(id=1)
+    tn.repo_service.edit_comment.return_value = m
+
+    res = await tn.send_to_provider("hello world")
+
+    assert res == True
+    tn.repo_service.edit_comment.assert_called_with(
+        tn.pull.database_pull.pullid, 1, "hello world"
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_to_provider_fail(tn):
+    tn.pull = mock.AsyncMock()
+    tn.pull.database_pull.commentid = 1
+    tn.repo_service = mock.AsyncMock()
+    m = dict(id=1)
+    tn.repo_service.edit_comment.side_effect = TorngitClientError
+
+    res = await tn.send_to_provider("hello world")
+
+    assert res == False
+
+
+def test_generate_test_description(tn):
+    flags_hash = generate_flags_hash([])
+    test_id = generate_test_id(1, "testsuite", "testname", flags_hash)
+    fail = TestResultsNotificationFailure(
+        "hello world", "testsuite", "testname", [], test_id
+    )
+    res = tn.generate_test_description(fail)
+    assert (
+        res
+        == "<pre>**Testsuite:**<br>testsuite<br><br>**Test name:**<br>testname<br><br>**Envs:**<br>- default<br></pre>"
+    )
+
+
+@pytest.mark.parametrize(
+    "is_new_flake,flake_header",
+    [(False, "Known Flaky Test"), (True, "Newly Detected Flake")],
+)
+def test_generate_test_description_with_flake(tn, is_new_flake, flake_header):
+    flags_hash = generate_flags_hash([])
+    test_id = generate_test_id(1, "testsuite", "testname", flags_hash)
+    fail = TestResultsNotificationFailure(
+        "hello world", "testsuite", "testname", [], test_id
+    )
+    flake = TestResultsNotificationFlake(
+        [],
+        is_new_flake,
+    )
+    res = tn.generate_test_description(fail, flake)
+    assert (
+        res
+        == f":snowflake::card_index_dividers: **{flake_header}**<br><pre>**Testsuite:**<br>testsuite<br><br>**Test name:**<br>testname<br><br>**Envs:**<br>- default<br></pre>"
+    )
+
+
+def test_generate_failure_info(tn):
+    flags_hash = generate_flags_hash([])
+    test_id = generate_test_id(1, "testsuite", "testname", flags_hash)
+    fail = TestResultsNotificationFailure(
+        "hello world", "testsuite", "testname", [], test_id
+    )
+
+    res = tn.generate_failure_info(fail)
+
+    assert res == "<pre>hello world</pre>"
+
+
+@pytest.mark.parametrize(
+    "flake_symptoms,message",
+    [
+        (
+            [FlakeSymptomType.FAILED_IN_DEFAULT_BRANCH],
+            ":snowflake: :card_index_dividers: **Failure on default branch**<br><pre>hello world</pre>",
+        ),
+        (
+            [
+                FlakeSymptomType.FAILED_IN_DEFAULT_BRANCH,
+                FlakeSymptomType.UNRELATED_MATCHING_FAILURES,
+            ],
+            ":snowflake: :card_index_dividers: **Failure on default branch**<br>:snowflake: :card_index_dividers: **Matching failures on unrelated branches**<br><pre>hello world</pre>",
+        ),
+    ],
+)
+def test_generate_failure_info_with_flake(tn, flake_symptoms, message):
+    flags_hash = generate_flags_hash([])
+    test_id = generate_test_id(1, "testsuite", "testname", flags_hash)
+    fail = TestResultsNotificationFailure(
+        "hello world", "testsuite", "testname", [], test_id
+    )
+    flake = TestResultsNotificationFlake(flake_symptoms, True)
+
+    res = tn.generate_failure_info(fail, flake)
+    assert res == message
+
+
+def test_build_message(tn):
+    flags_hash = generate_flags_hash([])
+    test_id = generate_test_id(1, "testsuite", "testname", flags_hash)
+    fail = TestResultsNotificationFailure(
+        "hello world", "testsuite", "testname", [], test_id
+    )
+    payload = TestResultsNotificationPayload(1, 2, 3, [fail], None)
+    res = tn.build_message(payload)
+
+    assert (
+        res
+        == """**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.
+
+### :x: Failed Test Results: 
+Completed 6 tests with **`1 failed`**, 2 passed and 3 skipped.
+<details><summary>View the full list of failed tests</summary>
+
+| **Test Description** | **Failure message** |
+| :-- | :-- |
+| <pre>**Testsuite:**<br>testsuite<br><br>**Test name:**<br>testname<br><br>**Envs:**<br>- default<br></pre> | <pre>hello world</pre> |"""
+    )
+
+
+def test_build_message_with_flake(tn):
+    flags_hash = generate_flags_hash([])
+    test_id = generate_test_id(1, "testsuite", "testname", flags_hash)
+    fail = TestResultsNotificationFailure(
+        "hello world", "testsuite", "testname", [], test_id
+    )
+    flake = TestResultsNotificationFlake(
+        [FlakeSymptomType.FAILED_IN_DEFAULT_BRANCH],
+        True,
+    )
+    payload = TestResultsNotificationPayload(1, 2, 3, [fail], {test_id: flake})
+    res = tn.build_message(payload)
+
+    assert (
+        res
+        == """**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.
+
+### :x: Failed Test Results: 
+Completed 6 tests with **`1 failed`**(1 newly detected flaky), 2 passed and 3 skipped.
+- Total :snowflake:**1 flaky tests.**
+<details><summary>View the full list of failed tests</summary>
+
+| **Test Description** | **Failure message** |
+| :-- | :-- |
+| :snowflake::card_index_dividers: **Newly Detected Flake**<br><pre>**Testsuite:**<br>testsuite<br><br>**Test name:**<br>testname<br><br>**Envs:**<br>- default<br></pre> | :snowflake: :card_index_dividers: **Failure on default branch**<br><pre>hello world</pre> |"""
+    )
+
+
+@pytest.mark.asyncio
+async def test_notify(mocker, tn):
+    mocker.patch(
+        "services.test_results.get_repo_provider_service", return_value=mock.AsyncMock()
+    )
+    mocker.patch(
+        "services.test_results.fetch_and_update_pull_request_information_from_commit",
+        return_value=mock.AsyncMock(),
+    )
+    tn.build_message = mock.Mock()
+    tn.send_to_provider = mock.AsyncMock()
+
+    success, reason = await tn.notify(None)
+    assert success == True
+    assert reason == "comment_posted"
+
+
+@pytest.mark.asyncio
+async def test_notify_fail_torngit_error(mocker, tn):
+    mocker.patch(
+        "services.test_results.get_repo_provider_service", return_value=mock.AsyncMock()
+    )
+    mocker.patch(
+        "services.test_results.fetch_and_update_pull_request_information_from_commit",
+        return_value=mock.AsyncMock(),
+    )
+    tn.build_message = mock.Mock()
+    tn.send_to_provider = mock.AsyncMock(return_value=False)
+
+    success, reason = await tn.notify(None)
+    assert success == False
+    assert reason == "torngit_error"
+
+
+@pytest.mark.asyncio
+async def test_notify_fail_no_pull(mocker, tn):
+    mocker.patch(
+        "services.test_results.get_repo_provider_service", return_value=mock.AsyncMock()
+    )
+    mocker.patch(
+        "services.test_results.fetch_and_update_pull_request_information_from_commit",
+        return_value=None,
+    )
+    tn.build_message = mock.Mock()
+    tn.send_to_provider = mock.AsyncMock(return_value=False)
+
+    success, reason = await tn.notify(None)
+    assert success == False
+    assert reason == "no_pull"

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict
+from dataclasses import dataclass
 from typing import Any, Dict
 
 from asgiref.sync import async_to_sync
@@ -8,16 +9,27 @@ from shared.yaml import UserYaml
 from test_results_parser import Outcome
 
 from app import celery_app
-from database.enums import ReportType
-from database.models import Commit, TestResultReportTotals
+from database.enums import FlakeSymptomType, ReportType
+from database.models import Commit, Test, TestResultReportTotals
 from helpers.string import EscapeEnum, Replacement, StringEscaper, shorten_file_paths
+from rollouts import FLAKY_TEST_DETECTION
+from services.failure_normalizer import FailureNormalizer
+from services.flake_detection import (
+    DefaultBranchFailureDetector,
+    DiffOutcomeDetector,
+    FlakeDetectionEngine,
+    FlakeDetectionResult,
+    UnrelatedMatchesDetector,
+)
 from services.lock_manager import LockManager, LockRetry, LockType
 from services.test_results import (
     TestResultsNotificationFailure,
+    TestResultsNotificationFlake,
     TestResultsNotificationPayload,
     TestResultsNotifier,
     latest_test_instances_for_a_given_commit,
 )
+from services.yaml import read_yaml_field
 from tasks.base import BaseCodecovTask
 from tasks.notify import notify_task_name
 
@@ -35,6 +47,13 @@ ESCAPE_FAILURE_MESSAGE_DEFN = [
     Replacement(["\n"], "<br>", EscapeEnum.REPLACE),
 ]
 QUEUE_NOTIFY_KEY = "queue_notify"
+
+
+@dataclass
+class FlakeUpdateInfo:
+    new_flake_ids: list[str]
+    old_flake_ids: list[str]
+    newly_calculated_flakes: dict[str, set[FlakeSymptomType]]
 
 
 class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_name):
@@ -212,12 +231,15 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             "test_results.finisher",
             tags={"status": "success", "reason": "tests_failed"},
         )
+        flaky_tests = None
+        if FLAKY_TEST_DETECTION.check_value(repo_id=repoid):
+            flaky_tests = dict()
 
         notifier = TestResultsNotifier(commit, commit_yaml)
 
         failures = sorted(failures, key=lambda x: x.testsuite + x.testname)
         payload = TestResultsNotificationPayload(
-            failed_tests, passed_tests, skipped_tests, failures
+            failed_tests, passed_tests, skipped_tests, failures, flaky_tests
         )
 
         with metrics.timing("test_results.finisher.notification"):
@@ -239,11 +261,86 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             "test_results.finisher.test_result_notifier",
             tags={"status": success, "reason": reason},
         )
+
+        if FLAKY_TEST_DETECTION.check_value(repo_id=repoid):
+            with metrics.timing("test_results.finisher.run_flaky_test_detection"):
+                success, reason = self.run_flaky_test_detection(
+                    db_session, repoid, notifier, payload
+                )
+
+            metrics.incr(
+                "test_results.finisher.flaky_test_detection",
+                tags={"status": success, "reason": reason},
+            )
+
         return {
             "notify_attempted": True,
             "notify_succeeded": success,
             QUEUE_NOTIFY_KEY: False,
         }
+
+    def run_flaky_test_detection(
+        self,
+        db_session,
+        repoid,
+        notifier: TestResultsNotifier,
+        payload: TestResultsNotificationPayload,
+    ):
+        ignore_predefined = read_yaml_field(
+            "test_analytics", "ignore_predefined", _else=False
+        )
+
+        user_normalization_regex = read_yaml_field(
+            "test_analytics", "normalization_regex", _else=dict()
+        )
+
+        failure_normalizer = FailureNormalizer(
+            user_normalization_regex, ignore_predefined
+        )
+
+        default_branch_failure_detector = DefaultBranchFailureDetector(
+            db_session, repoid, "main"
+        )
+        unrelated_matches_detector = UnrelatedMatchesDetector()
+        diff_outcome_detector = DiffOutcomeDetector()
+
+        flake_detection_engine = FlakeDetectionEngine(
+            db_session,
+            repoid,
+            [
+                default_branch_failure_detector,
+                unrelated_matches_detector,
+                diff_outcome_detector,
+            ],
+            failure_normalizer,
+        )
+
+        current_state_of_repo_flakes = flake_detection_engine.detect_flakes()
+
+        for test_id, symptoms in current_state_of_repo_flakes.items():
+            payload.flaky_tests[test_id] = TestResultsNotificationFlake(
+                list(symptoms),
+                True,
+            )
+            db_session.flush()
+
+        success, reason = async_to_sync(notifier.notify)(payload)
+
+        return success, reason
+
+    def get_flake_diff(
+        self,
+        newly_calculated_flakes: FlakeDetectionResult,
+        existing_flakes_from_db: dict[str, TestResultsNotificationFlake],
+    ):
+        newly_discovered_flakes = set(newly_calculated_flakes.keys()) - set(
+            existing_flakes_from_db.keys()
+        )
+        no_longer_flakes = set(existing_flakes_from_db.keys()) - set(
+            newly_calculated_flakes.keys()
+        )
+
+        return list(newly_discovered_flakes), list(no_longer_flakes)
 
     def check_if_no_success(self, previous_result):
         return all(

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -60,7 +60,11 @@ def test_results_setup(mocker, dbsession):
         repository__owner__service="github",
         repository__name="codecov-demo",
     )
+    commit.branch = "main"
     dbsession.add(commit)
+    dbsession.flush()
+
+    commit.repository.branch = "main"
     dbsession.flush()
 
     repoid = commit.repoid
@@ -208,6 +212,9 @@ class TestUploadTestFinisherTask(object):
         mock_repo_provider_comments,
         test_results_setup,
     ):
+        mock_feature = mocker.patch("tasks.test_results_finisher.FLAKY_TEST_DETECTION")
+        mock_feature.check_value.return_value = False
+
         repoid, commit, pull, _ = test_results_setup
 
         result = TestResultsFinisherTask().run_impl(
@@ -229,7 +236,7 @@ class TestUploadTestFinisherTask(object):
         assert expected_result == result
         mock_repo_provider_comments.post_comment.assert_called_with(
             pull.pullid,
-            f"**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 4 tests with **`4 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **Test Description** | **Failure message** |\n| :-- | :-- |\n| <pre>Testsuite:<br>test_testsuite<br>Test name:<br>test_name0<br>Envs:<br>- 0<br></pre> | <pre>&lt;pre&gt;Fourth <br><br>&lt;/pre&gt; | test  | instance |</pre> |\n| <pre>Testsuite:<br>test_testsuite<br>Test name:<br>test_name1<br>Envs:<br>- 1<br></pre> | <pre>Shared failure message</pre> |\n| <pre>Testsuite:<br>test_testsuite<br>Test name:<br>test_name2<br>Envs:<br>- default<br></pre> | <pre>Shared failure message</pre> |\n| <pre>Testsuite:<br>test_testsuite<br>Test name:<br>test_name3<br>Envs:<br>- 0<br></pre> | <pre>No failure message available</pre> |",
+            f"**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 4 tests with **`4 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **Test Description** | **Failure message** |\n| :-- | :-- |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name0<br><br>**Envs:**<br>- 0<br></pre> | <pre>&lt;pre&gt;Fourth <br><br>&lt;/pre&gt; | test  | instance |</pre> |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name1<br><br>**Envs:**<br>- 1<br></pre> | <pre>Shared failure message</pre> |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name2<br><br>**Envs:**<br>- default<br></pre> | <pre>Shared failure message</pre> |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name3<br><br>**Envs:**<br>- 0<br></pre> | <pre>No failure message available</pre> |",
         )
 
         mock_metrics.incr.assert_has_calls(
@@ -266,6 +273,9 @@ class TestUploadTestFinisherTask(object):
         mock_repo_provider_comments,
         test_results_setup,
     ):
+        mock_feature = mocker.patch("tasks.test_results_finisher.FLAKY_TEST_DETECTION")
+        mock_feature.check_value.return_value = False
+
         repoid, commit, _, test_instances = test_results_setup
 
         for instance in test_instances:
@@ -332,6 +342,9 @@ class TestUploadTestFinisherTask(object):
         mock_repo_provider_comments,
         test_results_setup,
     ):
+        mock_feature = mocker.patch("tasks.test_results_finisher.FLAKY_TEST_DETECTION")
+        mock_feature.check_value.return_value = False
+
         repoid, commit, _, _ = test_results_setup
 
         result = TestResultsFinisherTask().run_impl(
@@ -377,6 +390,9 @@ class TestUploadTestFinisherTask(object):
         mock_repo_provider_comments,
         test_results_setup,
     ):
+        mock_feature = mocker.patch("tasks.test_results_finisher.FLAKY_TEST_DETECTION")
+        mock_feature.check_value.return_value = False
+
         repoid, commit, pull, _ = test_results_setup
 
         pull.commentid = 1
@@ -401,7 +417,7 @@ class TestUploadTestFinisherTask(object):
         mock_repo_provider_comments.edit_comment.assert_called_with(
             pull.pullid,
             1,
-            "**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 4 tests with **`4 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **Test Description** | **Failure message** |\n| :-- | :-- |\n| <pre>Testsuite:<br>test_testsuite<br>Test name:<br>test_name0<br>Envs:<br>- 0<br></pre> | <pre>&lt;pre&gt;Fourth <br><br>&lt;/pre&gt; | test  | instance |</pre> |\n| <pre>Testsuite:<br>test_testsuite<br>Test name:<br>test_name1<br>Envs:<br>- 1<br></pre> | <pre>Shared failure message</pre> |\n| <pre>Testsuite:<br>test_testsuite<br>Test name:<br>test_name2<br>Envs:<br>- default<br></pre> | <pre>Shared failure message</pre> |\n| <pre>Testsuite:<br>test_testsuite<br>Test name:<br>test_name3<br>Envs:<br>- 0<br></pre> | <pre>No failure message available</pre> |",
+            "**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 4 tests with **`4 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **Test Description** | **Failure message** |\n| :-- | :-- |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name0<br><br>**Envs:**<br>- 0<br></pre> | <pre>&lt;pre&gt;Fourth <br><br>&lt;/pre&gt; | test  | instance |</pre> |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name1<br><br>**Envs:**<br>- 1<br></pre> | <pre>Shared failure message</pre> |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name2<br><br>**Envs:**<br>- default<br></pre> | <pre>Shared failure message</pre> |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name3<br><br>**Envs:**<br>- 0<br></pre> | <pre>No failure message available</pre> |",
         )
 
         assert expected_result == result
@@ -421,6 +437,9 @@ class TestUploadTestFinisherTask(object):
         mock_repo_provider_comments,
         test_results_setup,
     ):
+        mock_feature = mocker.patch("tasks.test_results_finisher.FLAKY_TEST_DETECTION")
+        mock_feature.check_value.return_value = False
+
         repoid, commit, _, _ = test_results_setup
 
         mock_repo_provider_comments.post_comment.side_effect = TorngitClientError
@@ -452,6 +471,74 @@ class TestUploadTestFinisherTask(object):
                 call(
                     "test_results.finisher.test_result_notifier",
                     tags={"status": False, "reason": "torngit_error"},
+                ),
+            ]
+        )
+        calls = [
+            call("test_results.finisher.fetch_latest_test_instances"),
+            call("test_results.finisher.notification"),
+        ]
+        for c in calls:
+            assert c in mock_metrics.timing.mock_calls
+
+    @pytest.mark.integration
+    def test_upload_finisher_task_call_with_flaky(
+        self,
+        mocker,
+        mock_configuration,
+        dbsession,
+        codecov_vcr,
+        mock_storage,
+        mock_redis,
+        celery_app,
+        mock_metrics,
+        test_results_mock_app,
+        mock_repo_provider_comments,
+        test_results_setup,
+    ):
+        mock_feature = mocker.patch("tasks.test_results_finisher.FLAKY_TEST_DETECTION")
+        mock_feature.check_value.return_value = True
+
+        repoid, commit, pull, _ = test_results_setup
+
+        result = TestResultsFinisherTask().run_impl(
+            dbsession,
+            [
+                [{"successful": True}],
+            ],
+            repoid=repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": False}},
+        )
+
+        expected_result = {
+            "notify_attempted": True,
+            "notify_succeeded": True,
+            "queue_notify": False,
+        }
+
+        assert expected_result == result
+
+        mock_repo_provider_comments.post_comment.assert_called_with(
+            pull.pullid,
+            "**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 4 tests with **`4 failed`**, 0 passed and 0 skipped.\n<details><summary>View the full list of failed tests</summary>\n\n| **Test Description** | **Failure message** |\n| :-- | :-- |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name0<br><br>**Envs:**<br>- 0<br></pre> | <pre>&lt;pre&gt;Fourth <br><br>&lt;/pre&gt; | test  | instance |</pre> |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name1<br><br>**Envs:**<br>- 1<br></pre> | <pre>Shared failure message</pre> |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name2<br><br>**Envs:**<br>- default<br></pre> | <pre>Shared failure message</pre> |\n| <pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name3<br><br>**Envs:**<br>- 0<br></pre> | <pre>No failure message available</pre> |",
+        )
+
+        mock_repo_provider_comments.edit_comment.assert_called_with(
+            pull.pullid,
+            1,
+            "**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.\n\n### :x: Failed Test Results: \nCompleted 4 tests with **`4 failed`**(4 newly detected flaky), 0 passed and 0 skipped.\n- Total :snowflake:**4 flaky tests.**\n<details><summary>View the full list of failed tests</summary>\n\n| **Test Description** | **Failure message** |\n| :-- | :-- |\n| :snowflake::card_index_dividers: **Newly Detected Flake**<br><pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name0<br><br>**Envs:**<br>- 0<br></pre> | :snowflake: :card_index_dividers: **Failure on default branch**<br><pre>&lt;pre&gt;Fourth <br><br>&lt;/pre&gt; | test  | instance |</pre> |\n| :snowflake::card_index_dividers: **Newly Detected Flake**<br><pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name1<br><br>**Envs:**<br>- 1<br></pre> | :snowflake: :card_index_dividers: **Failure on default branch**<br><pre>Shared failure message</pre> |\n| :snowflake::card_index_dividers: **Newly Detected Flake**<br><pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name2<br><br>**Envs:**<br>- default<br></pre> | :snowflake: :card_index_dividers: **Failure on default branch**<br><pre>Shared failure message</pre> |\n| :snowflake::card_index_dividers: **Newly Detected Flake**<br><pre>**Testsuite:**<br>test_testsuite<br><br>**Test name:**<br>test_name3<br><br>**Envs:**<br>- 0<br></pre> | :snowflake: :card_index_dividers: **Failure on default branch**<br><pre>No failure message available</pre> |",
+        )
+
+        mock_metrics.incr.assert_has_calls(
+            [
+                call(
+                    "test_results.finisher",
+                    tags={"status": "success", "reason": "tests_failed"},
+                ),
+                call(
+                    "test_results.finisher.test_result_notifier",
+                    tags={"status": True, "reason": "comment_posted"},
                 ),
             ]
         )


### PR DESCRIPTION
Depends on:
https://github.com/codecov/shared/pull/184

This PR does not make any changes to the database: existing flakes won't be retrieved, new flakes won't be stored, flakes will be recalculated every time we run the test results finisher.

- Adds the flaky_status column to the Test object in the db
- Adds existing flaky tests to the PR comment (behind a feature flag)
- Runs flaky test detection at the end of the test results finisher (behind a feature flag)
- Updates comment and persists new results from flaky test detection to db