### PR TITLE
fix: pass iterable into any() instead of lambda

### DIFF
--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -219,7 +219,8 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 )
             )
             rely_on_webhook_ghapp = ghapp_default_installations != [] and any(
-                lambda obj: obj.is_repo_covered_by_integration(commit.repository)
+                obj.is_repo_covered_by_integration(commit.repository)
+                for obj in ghapp_default_installations
             )
             rely_on_webhook_legacy = commit.repository.using_integration
             if (


### PR DESCRIPTION
`'function' object is not iterable` issue in sentry has been showing up for a few hours

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.