### PR TITLE
fix: envs are UPPERCASE

### DIFF
--- a/worker.sh
+++ b/worker.sh
@@ -10,7 +10,7 @@ if [[ "$CODECOV_WORKER_QUEUES" ]]; then
   queues="--queue $CODECOV_WORKER_QUEUES"
 fi
 
-if [[ "$RUN_ENV" == "enterprise" ]] || [[ "$RUN_ENV" == "DEV" ]]; then
+if [[ "$RUN_ENV" == "ENTERPRISE" ]] || [[ "$RUN_ENV" == "DEV" ]]; then
     python manage.py migrate
     python manage.py migrate --database "timeseries"
 fi


### PR DESCRIPTION
If you look at https://github.com/codecov/worker/blob/14ffa91c4a8b7b2b509adb5e8744ea1534f1d97c/helpers/environment.py#L47 it says `ENTERPRISE`.

But the `worker.sh` script says `enterprise`.

So the worker is not running the timeseries migrations for enterprise envs.
(we had this issue with a customer)