### PR TITLE
reclaim Owner.createstamp

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -52,8 +52,7 @@ class Owner(CodecovBaseModel):
     plan_activated_users = Column(
         postgresql.ARRAY(types.Integer), server_default=FetchedValue()
     )
-    # createstamp seems to be used by legacy to track first login
-    # so we shouldn't touch this outside login
+
     createstamp = Column(types.DateTime, server_default=FetchedValue())
     admins = Column(postgresql.ARRAY(types.Integer), server_default=FetchedValue())
     permission = Column(postgresql.ARRAY(types.Integer), server_default=FetchedValue())

--- a/services/repository.py
+++ b/services/repository.py
@@ -284,6 +284,7 @@ def get_or_create_author(
             username=username,
             name=name,
             email=email,
+            createstamp=datetime.now(),
         )
         db_session.add(author)
         db_session.commit()

--- a/services/tests/test_repository_service.py
+++ b/services/tests/test_repository_service.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 import mock
 import pytest
+from freezegun import freeze_time
 from shared.encryption.oauth import get_encryptor_from_configuration
 from shared.torngit.base import TorngitBaseAdapter
 from shared.torngit.exceptions import (
@@ -602,6 +603,7 @@ class TestRepositoryServiceTestCase(object):
         )
         assert expected_result == result
 
+    @freeze_time("2024-03-28T00:00:00")
     def test_get_or_create_author_doesnt_exist(self, dbsession):
         service = "github"
         author_id = "123"
@@ -626,6 +628,7 @@ class TestRepositoryServiceTestCase(object):
         assert author.yaml is None
         assert author.oauth_token is None
         assert author.bot_id is None
+        assert author.createstamp.isoformat() == "2024-03-28T00:00:00"
 
     def test_get_or_create_author_already_exists(self, dbsession):
         owner = OwnerFactory.create(
@@ -661,6 +664,7 @@ class TestRepositoryServiceTestCase(object):
         assert author.yaml == {"a": ["12", "3"]}
         assert author.oauth_token == owner.oauth_token
         assert author.bot_id == owner.bot_id
+        assert owner.createstamp is None
 
     @pytest.mark.asyncio
     async def test_update_commit_from_provider_info_no_author_id(

--- a/tasks/github_marketplace.py
+++ b/tasks/github_marketplace.py
@@ -153,6 +153,7 @@ class SyncPlansTask(BaseCodecovTask, name=ghm_sync_plans_task_name):
             name=name,
             email=email,
             plan_provider="github",
+            createstamp=datetime.now(),
         )
         db_session.add(owner)
         db_session.flush()

--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -432,7 +432,12 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
             if (owner.username or "").lower() != username.lower():
                 owner.username = username
         else:
-            owner = Owner(service=service, service_id=service_id, username=username)
+            owner = Owner(
+                service=service,
+                service_id=service_id,
+                username=username,
+                createstamp=datetime.now(),
+            )
             db_session.add(owner)
             db_session.flush()
 

--- a/tasks/sync_teams.py
+++ b/tasks/sync_teams.py
@@ -92,6 +92,7 @@ class SyncTeamsTask(BaseCodecovTask, name=sync_teams_task_name):
                 email=data.get("email"),
                 avatar_url=data.get("avatar_url"),
                 parent_service_id=data.get("parent_service_id"),
+                createstamp=datetime.now(),
             )
             db_session.add(team)
             db_session.flush()

--- a/tasks/tests/unit/test_sync_repos_task.py
+++ b/tasks/tests/unit/test_sync_repos_task.py
@@ -7,6 +7,7 @@ import pytest
 import respx
 import vcr
 from celery.exceptions import SoftTimeLimitExceeded
+from freezegun import freeze_time
 from redis.exceptions import LockError
 from shared.celery_config import (
     sync_repo_languages_gql_task_name,
@@ -43,6 +44,7 @@ class TestSyncReposTaskUnit(object):
                 using_integration=False,
             )
 
+    @freeze_time("2024-03-28T00:00:00")
     def test_upsert_owner_add_new(self, mocker, mock_configuration, dbsession):
         service = "github"
         service_id = "123456"
@@ -66,7 +68,7 @@ class TestSyncReposTaskUnit(object):
         )
         assert new_entry is not None
         assert new_entry.username == username
-        assert new_entry.createstamp is None
+        assert new_entry.createstamp.isoformat() == "2024-03-28T00:00:00"
 
     def test_upsert_owner_update_existing(self, mocker, mock_configuration, dbsession):
         ownerid = 1

--- a/tasks/tests/unit/test_sync_teams_task.py
+++ b/tasks/tests/unit/test_sync_teams_task.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import pytest
+from freezegun import freeze_time
 
 from database.models import Owner
 from database.tests.factories import OwnerFactory
@@ -71,6 +72,7 @@ class TestSyncTeamsTaskUnit(object):
         assert old_team.name == "codecov"
         assert str(old_team.updatestamp) > last_updated
 
+    @freeze_time("2024-03-28T00:00:00")
     def test_gitlab_subgroups(
         self, mocker, mock_configuration, dbsession, codecov_vcr, caplog
     ):
@@ -132,5 +134,6 @@ class TestSyncTeamsTaskUnit(object):
             expected_data = expected_groups.get(service_id, {})
             assert g.username == expected_data.get("username")
             assert g.name == expected_data["name"]
+            assert g.createstamp.isoformat() == "2024-03-28T00:00:00"
             if expected_data["parent_service_id"]:
                 assert g.parent_service_id == expected_data["parent_service_id"]


### PR DESCRIPTION
These changes add a createstamp for Owners when they are created in more
scenarios than just logging in. This is a breaking behavior considering legacy
versions of Codecov.

The change itself if simple, but should be taken carefully since I'm directly
ignoring a comment in the code. So let's dive into the details.

Why are you doing this?

Context is codecov/engineering-team#1387.
We want to pin new behavior (patch-centric comment and statuses) only to new
users. new in this context mean "was created after a certain date".
To do that we need to know when users were created. Instead of creating another
column for created_at I am simply reusing this existing one.

Isn't it dangerous?

Well yes, there is a possibility that something unexpected will happen.
But the "legacy system" that the comment alluded to is no longer being used :D
(it was codecov-io). And I searched the current system and it doesn't seem to
be using the createdstamp for anything... so maybe we're fine.

Is there an alternative?

Well yes, creating a migration to have a repeated column.
Obviously it'd be a risky migration, so now we're just taking on a different risk.

related: https://github.com/codecov/codecov-api/pull/471