### PR TITLE
feat: ramp up process for ghapp installations

### DIFF
--- a/services/tests/test_bots.py
+++ b/services/tests/test_bots.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from freezegun import freeze_time
@@ -450,7 +450,7 @@ class TestBotsService(BaseTestCase):
     def test__get_installation_weight(
         self, time_edited_days, expected_weight, dbsession
     ):
-        time_diff = datetime.now(UTC) - timedelta(days=time_edited_days)
+        time_diff = datetime.now(timezone.utc) - timedelta(days=time_edited_days)
         owner = OwnerFactory(service="github", integration_id=12341234)
         installation = GithubAppInstallation(
             owner=owner,
@@ -474,8 +474,8 @@ class TestBotsService(BaseTestCase):
         installation_new should have a ~4% chance of being selected
         that is ~40 in 1000 selection we make.
         """
-        ten_days_ago = datetime.now(UTC) - timedelta(days=10)
-        two_days_ago = datetime.now(UTC) - timedelta(days=2)
+        ten_days_ago = datetime.now(timezone.utc) - timedelta(days=10)
+        two_days_ago = datetime.now(timezone.utc) - timedelta(days=2)
         owner = OwnerFactory(service="github", integration_id=12341234)
         installation_old = GithubAppInstallation(
             owner=owner,


### PR DESCRIPTION
These changes introduce a change in weight for installations recently updated.
Any change in a ghapp `updated_at` field will cause it to enter a "ramp up" phase
during which other suitable installations will be prefered for usage.

The idea is that changes to an installation can introduce config errors and cause
the ghapp to be unusable in it's current state. To avoid breaking the app we use
the ramp up process.

The rampup is based on `random.choices` and giving weights to installs based on how
long ago they were last updated. The rap up function is exponential and the whole
process stabilizes after 10 days (at which point all installations have the same
probability of being selected)

closes: codecov/engineering-team#1483

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.