### PR TITLE
fix: metrics are no longer run in async

### DIFF
--- a/tasks/label_analysis.py
+++ b/tasks/label_analysis.py
@@ -419,7 +419,7 @@ class LabelAnalysisRequestProcessingTask(
     def calculate_final_result(
         self,
         *,
-        requested_labels: List[str],
+        requested_labels: Optional[List[str]],
         existing_labels: ExistingLabelSetsNotEncoded,
         commit_sha: str,
     ):
@@ -436,10 +436,10 @@ class LabelAnalysisRequestProcessingTask(
                 commit=commit_sha,
             ),
         )
-        self.metrics_context.attempt_log_simple_metric(
+        self.metrics_context.log_simple_metric(
             "label_analysis.tests_saved_count", len(all_report_labels)
         )
-        self.metrics_context.attempt_log_simple_metric(
+        self.metrics_context.log_simple_metric(
             "label_analysis.requests_with_requested_labels",
             float(requested_labels is not None),
         )
@@ -453,10 +453,10 @@ class LabelAnalysisRequestProcessingTask(
                 "absent_labels": sorted(requested_labels - all_report_labels),
                 "global_level_labels": sorted(global_level_labels & requested_labels),
             }
-            self.metrics_context.attempt_log_simple_metric(
+            self.metrics_context.log_simple_metric(
                 "label_analysis.requested_labels_count", len(requested_labels)
             )
-            self.metrics_context.attempt_log_simple_metric(
+            self.metrics_context.log_simple_metric(
                 "label_analysis.tests_to_run_count",
                 len(
                     ans["present_diff_labels"]
@@ -465,7 +465,7 @@ class LabelAnalysisRequestProcessingTask(
                 ),
             )
             return ans
-        self.metrics_context.attempt_log_simple_metric(
+        self.metrics_context.log_simple_metric(
             "label_analysis.tests_to_run_count",
             len(executable_lines_labels | global_level_labels),
         )

--- a/tasks/tests/unit/test_label_analysis.py
+++ b/tasks/tests/unit/test_label_analysis.py
@@ -511,13 +511,13 @@ def test_simple_call_without_requested_labels_then_with_requested_labels(
     mock_metrics_context.assert_called_with(
         repo_id=repository.repoid, commit_id=larf.head_commit.id
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 0.0
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 6
     )
     dbsession.flush()
@@ -555,16 +555,16 @@ def test_simple_call_without_requested_labels_then_with_requested_labels(
     mock_metrics.incr.assert_called_with(
         "label_analysis_task.already_calculated.new_result"
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 1.0
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.requested_labels_count", 4
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 3
     )
 
@@ -618,13 +618,13 @@ def test_simple_call_with_requested_labels(
     mock_metrics_context.assert_called_with(
         repo_id=larf.head_commit.repository.repoid, commit_id=larf.head_commit.id
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 1.0
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 3
     )
 

--- a/tasks/tests/unit/test_label_analysis_encoded_labels.py
+++ b/tasks/tests/unit/test_label_analysis_encoded_labels.py
@@ -527,13 +527,13 @@ def test_simple_call_without_requested_labels_then_with_requested_labels(
     mock_metrics_context.assert_called_with(
         repo_id=repository.repoid, commit_id=larf.head_commit.id
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 0.0
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 6
     )
     # It's zero because the report has the _labels_index already
@@ -575,16 +575,16 @@ def test_simple_call_without_requested_labels_then_with_requested_labels(
     mock_metrics.incr.assert_called_with(
         "label_analysis_task.already_calculated.new_result"
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 1.0
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.requested_labels_count", 4
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 3
     )
 
@@ -640,13 +640,13 @@ def test_simple_call_with_requested_labels(
     mock_metrics_context.assert_called_with(
         repo_id=larf.head_commit.repository.repoid, commit_id=larf.head_commit.id
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_saved_count", 9
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.requests_with_requested_labels", 1.0
     )
-    mock_metrics_context.return_value.attempt_log_simple_metric.assert_any_call(
+    mock_metrics_context.return_value.log_simple_metric.assert_any_call(
         "label_analysis.tests_to_run_count", 3
     )
 


### PR DESCRIPTION
Fix issue https://codecov.sentry.io/issues/5066637793

We're having RuntimeError from trying to emit metrics that think they are
in an async event loop from sync code.

These changes remove the asnyc call but keep the metrics emiting.
The metrics are now a blocking call, but impact should be minimal at this time.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.