### PR TITLE
Bundle Analysis: Add Sentry metrics for uploading

### DIFF
--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -6,6 +6,7 @@ from functools import cached_property
 from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 import sentry_sdk
+from sentry_sdk import metrics as sentry_metrics
 from shared.bundle_analysis import (
     BundleAnalysisComparison,
     BundleAnalysisReport,
@@ -85,6 +86,13 @@ class ProcessingResult:
             self.upload.state_id = UploadState.PROCESSED.db_id
             self.upload.order_number = self.session_id
 
+        sentry_metrics.incr(
+            "bundle_analysis_upload",
+            tags={
+                "result": "upload_error" if self.error else "processed",
+            },
+        )
+
         db_session.flush()
 
 
@@ -153,6 +161,16 @@ class BundleAnalysisReportService(BaseReportService):
                     is_retryable=True,
                 ),
             )
+        except Exception as e:
+            # Metrics to count number of parsing errors of bundle files by plugins
+            sentry_metrics.incr(
+                "bundle_analysis_upload",
+                tags={
+                    "result": "parser_error",
+                    "plugin_name": getattr(e, "bundle_analysis_plugin_name", "unknown"),
+                },
+            )
+            raise e
         finally:
             os.remove(local_path)
 

--- a/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -191,16 +191,13 @@ def test_bundle_analysis_process_upload_general_error(
     celery_app,
 ):
     storage_path = (
-        "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite"
+        f"v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite"
     )
     mock_storage.write_file(get_bucket_name(), storage_path, "test-content")
 
     mocker.patch.object(BundleAnalysisProcessorTask, "app", celery_app)
 
-    get_storage_client = mocker.patch("services.bundle_analysis.get_storage_client")
-    get_storage_client.side_effect = Exception()
-
-    commit = CommitFactory.create()
+    commit = CommitFactory.create(state="pending")
     dbsession.add(commit)
     dbsession.flush()
 
@@ -208,32 +205,48 @@ def test_bundle_analysis_process_upload_general_error(
     dbsession.add(commit_report)
     dbsession.flush()
 
-    upload = UploadFactory.create(
-        state="started",
-        storage_path="invalid-storage-path",
-        report=commit_report,
-    )
+    upload = UploadFactory.create(storage_path=storage_path, report=commit_report)
     dbsession.add(upload)
     dbsession.flush()
+
+    ingest = mocker.patch("shared.bundle_analysis.BundleAnalysisReport.ingest")
+    ingest.side_effect = Exception()
 
     task = BundleAnalysisProcessorTask()
     retry = mocker.patch.object(task, "retry")
 
-    with pytest.raises(Exception):
-        task.run_impl(
-            dbsession,
-            {"results": [{"previous": "result"}]},
-            repoid=commit.repoid,
-            commitid=commit.commitid,
-            commit_yaml={},
-            params={
-                "upload_pk": upload.id_,
-                "commit": commit.commitid,
-            },
-        )
+    result = BundleAnalysisProcessorTask().run_impl(
+        dbsession,
+        {"results": [{"previous": "result"}]},
+        repoid=commit.repoid,
+        commitid=commit.commitid,
+        commit_yaml={},
+        params={
+            "upload_pk": upload.id_,
+            "commit": commit.commitid,
+        },
+    )
 
-    assert upload.state == "error"
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": {
+                    "code": "parser_error",
+                    "params": {
+                        "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite",
+                        "plugin_name": "unknown",
+                    },
+                },
+                "session_id": None,
+                "upload_id": 1,
+            },
+        ],
+    }
+
     assert not retry.called
+    assert upload.state == "error"
+    assert commit.state == "error"
 
 
 def test_bundle_analysis_processor_task_locked(

--- a/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -239,7 +239,7 @@ def test_bundle_analysis_process_upload_general_error(
                     },
                 },
                 "session_id": None,
-                "upload_id": 1,
+                "upload_id": upload.id_,
             },
         ],
     }


### PR DESCRIPTION
Keep track of when failed to parse a bundle stats file during upload processing and what plugin was being ran at the time.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.