### PR TITLE
fix: make it usable without timeseries

### DIFF
--- a/django_scaffold/settings.py
+++ b/django_scaffold/settings.py
@@ -9,7 +9,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 ALLOWED_HOSTS = []
 
 DATABASES["default"]["AUTOCOMMIT"] = False
-DATABASES["timeseries"]["AUTOCOMMIT"] = False
+if "timeseries" in DATABASES:
+    DATABASES["timeseries"]["AUTOCOMMIT"] = False
 
 IS_DEV = os.getenv("RUN_ENV") == "DEV"
 

--- a/helpers/telemetry.py
+++ b/helpers/telemetry.py
@@ -7,7 +7,7 @@ from shared.django_apps.ts_telemetry.models import SimpleMetric as TsSimpleMetri
 
 from database.engine import get_db_session
 from database.models.core import Commit, Owner, Repository
-
+from .timeseries import timeseries_enabled
 
 def fire_and_forget(fn):
     """
@@ -123,14 +123,15 @@ class MetricContext:
             commit_id=self.commit_id,
         )
 
-        TsSimpleMetric.objects.create(
-            timestamp=timestamp,
-            name=name,
-            value=value,
-            repo_slug=self.repo_slug,
-            owner_slug=self.owner_slug,
-            commit_slug=self.commit_slug,
-        )
+        if timeseries_enabled():
+            TsSimpleMetric.objects.create(
+                timestamp=timestamp,
+                name=name,
+                value=value,
+                repo_slug=self.repo_slug,
+                owner_slug=self.owner_slug,
+                commit_slug=self.commit_slug,
+            )
 
     @fire_and_forget
     async def attempt_log_simple_metric(self, name: str, value: float):

--- a/helpers/telemetry.py
+++ b/helpers/telemetry.py
@@ -9,6 +9,7 @@ from database.engine import get_db_session
 from database.models.core import Commit, Owner, Repository
 from .timeseries import timeseries_enabled
 
+
 def fire_and_forget(fn):
     """
     Decorator for an async function that will throw it in the asyncio queue and

--- a/helpers/telemetry.py
+++ b/helpers/telemetry.py
@@ -7,6 +7,7 @@ from shared.django_apps.ts_telemetry.models import SimpleMetric as TsSimpleMetri
 
 from database.engine import get_db_session
 from database.models.core import Commit, Owner, Repository
+
 from .timeseries import timeseries_enabled
 
 


### PR DESCRIPTION
currently its not possible to run worker without "timeseries" database handler. This PR makes it possible to run codecov without that.

fixes https://github.com/codecov/feedback/issues/318

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.