### PR TITLE
chore: end the bulk insert experiment

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -5,8 +5,6 @@ from database.models import Owner, Repository
 # Declare the feature variants and parameters via Django Admin
 LIST_REPOS_GENERATOR_BY_OWNER_ID = Feature("list_repos_generator")
 
-BULK_INSERT_TEST_INSTANCES = Feature("bulk_insert_test_instances")
-
 # Eventually we want all repos to use this
 # This flag will just help us with the rollout process
 USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = Feature(

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -19,7 +19,6 @@ here = Path(__file__)
 
 
 class TestUploadTestProcessorTask(object):
-    @pytest.mark.parametrize("use_bulk_insert", [False, True])
     @pytest.mark.integration
     def test_upload_processor_task_call(
         self,
@@ -30,12 +29,7 @@ class TestUploadTestProcessorTask(object):
         mock_storage,
         mock_redis,
         celery_app,
-        use_bulk_insert,
     ):
-        mock_feature = mocker.patch(
-            "tasks.test_results_processor.BULK_INSERT_TEST_INSTANCES"
-        )
-        mock_feature.check_value.return_value = use_bulk_insert
 
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
@@ -109,21 +103,15 @@ class TestUploadTestProcessorTask(object):
                 )
             ]
         )
-        metrics_write_to_db_tags = {
-            "method": "bulk_insert" if use_bulk_insert else "simple_insert"
-        }
         calls = [
             call("test_results.processor"),
             call("test_results.processor.process_individual_arg"),
             call("test_results.processor.file_parsing"),
-            call(
-                key="test_results.processor.write_to_db", tags=metrics_write_to_db_tags
-            ),
+            call(key="test_results.processor.write_to_db"),
         ]
         for c in calls:
             assert c in mock_metrics.timing.mock_calls
 
-    @pytest.mark.parametrize("use_bulk_insert", [False, True])
     @pytest.mark.integration
     def test_upload_processor_task_call_pytest_reportlog(
         self,
@@ -134,12 +122,7 @@ class TestUploadTestProcessorTask(object):
         mock_storage,
         mock_redis,
         celery_app,
-        use_bulk_insert,
     ):
-        mock_feature = mocker.patch(
-            "tasks.test_results_processor.BULK_INSERT_TEST_INSTANCES"
-        )
-        mock_feature.check_value.return_value = use_bulk_insert
 
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
         with open(here.parent.parent / "samples" / "sample_pytest_reportlog.txt") as f:
@@ -195,7 +178,6 @@ class TestUploadTestProcessorTask(object):
         assert expected_result == result
         assert commit.message == "hello world"
 
-    @pytest.mark.parametrize("use_bulk_insert", [False, True])
     @pytest.mark.integration
     def test_upload_processor_task_call_vitest(
         self,
@@ -206,12 +188,7 @@ class TestUploadTestProcessorTask(object):
         mock_storage,
         mock_redis,
         celery_app,
-        use_bulk_insert,
     ):
-        mock_feature = mocker.patch(
-            "tasks.test_results_processor.BULK_INSERT_TEST_INSTANCES"
-        )
-        mock_feature.check_value.return_value = use_bulk_insert
 
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
         with open(here.parent.parent / "samples" / "sample_vitest.txt") as f:
@@ -408,7 +385,6 @@ class TestUploadTestProcessorTask(object):
         for c in calls:
             assert c in mock_metrics.timing.mock_calls
 
-    @pytest.mark.parametrize("use_bulk_insert", [False, True])
     @pytest.mark.integration
     def test_test_result_processor_task_delete_archive(
         self,
@@ -420,12 +396,7 @@ class TestUploadTestProcessorTask(object):
         mock_storage,
         mock_redis,
         celery_app,
-        use_bulk_insert,
     ):
-        mock_feature = mocker.patch(
-            "tasks.test_results_processor.BULK_INSERT_TEST_INSTANCES"
-        )
-        mock_feature.check_value.return_value = use_bulk_insert
 
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
         with open(here.parent.parent / "samples" / "sample_vitest.txt") as f:
@@ -537,7 +508,6 @@ class TestUploadTestProcessorTask(object):
         assert expected_result == result
         assert "File did not match any parser format" in caplog.text
 
-    @pytest.mark.parametrize("use_bulk_insert", [False, True])
     @pytest.mark.integration
     def test_upload_processor_task_call_existing_test(
         self,
@@ -548,12 +518,7 @@ class TestUploadTestProcessorTask(object):
         mock_storage,
         mock_redis,
         celery_app,
-        use_bulk_insert,
     ):
-        mock_feature = mocker.patch(
-            "tasks.test_results_processor.BULK_INSERT_TEST_INSTANCES"
-        )
-        mock_feature.check_value.return_value = use_bulk_insert
 
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
         with open(here.parent.parent / "samples" / "sample_test.txt") as f:
@@ -630,7 +595,6 @@ class TestUploadTestProcessorTask(object):
         assert expected_result == result
         assert commit.message == "hello world"
 
-    @pytest.mark.parametrize("use_bulk_insert", [False, True])
     @pytest.mark.integration
     def test_upload_processor_task_call_existing_test_diff_flags_hash(
         self,
@@ -641,12 +605,7 @@ class TestUploadTestProcessorTask(object):
         mock_storage,
         mock_redis,
         celery_app,
-        use_bulk_insert,
     ):
-        mock_feature = mocker.patch(
-            "tasks.test_results_processor.BULK_INSERT_TEST_INSTANCES"
-        )
-        mock_feature.check_value.return_value = use_bulk_insert
 
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
         with open(here.parent.parent / "samples" / "sample_test.txt") as f:


### PR DESCRIPTION
Ends the bulk insert experiment. Uses only the bulk insert method to write tests,
for the reduced time.
This comes at the cost of using extra memory (aux structures), but the time gains
are worth it. Especially because right now the time to write to DB dominates the
total time of this task.

Check graphs for comparison.
In the first graph we have time comparison of both methods. Notice that even the p90 of bulk_insert is generally lower than p50 of simple_insert.

Memory usage is 3x in average, which is not great, but the max so far was 50Kb, which is not going to be a problem anytime soon. I also believe we can explore ways to reduce memory usage further by changing the aux structures from lists to a dict for the `Test`, for example (reduce repeated tests).

<img width="1139" alt="Screenshot 2024-04-09 at 11 57 39" src="https://github.com/codecov/worker/assets/99758426/03c48efc-f5bb-40bf-b567-6da24cd06354">


<img width="1135" alt="Screenshot 2024-04-09 at 11 58 22" src="https://github.com/codecov/worker/assets/99758426/fd176dba-b5de-4239-a736-0ea82167063b">


