### PR TITLE
fix: add repo_id kwarg for parallel upload processing

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/93ac35100e3e94cb29979e2147b8f9680a68368e.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/bf973edc6c0438ac4071dbefc08e055c87d720c8.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz#egg=test-results-parser
 boto3

--- a/requirements.txt
+++ b/requirements.txt
@@ -368,7 +368,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/93ac35100e3e94cb29979e2147b8f9680a68368e.tar.gz
+shared @ https://github.com/codecov/shared/archive/bf973edc6c0438ac4071dbefc08e055c87d720c8.tar.gz
     # via -r requirements.in
 six==1.15.0
     # via

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -291,7 +291,7 @@ class ReportService(BaseReportService):
                 # finisher can build off of it later. Makes the assumption that the CFFs occupy the first
                 # j to i session ids where i is the max id of the CFFs and j is some integer less than i.
                 if await PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value_async(
-                    commit.repository.repoid
+                    repo_id=commit.repository.repoid
                 ):
                     await self.save_parallel_report_to_archive(
                         commit, report, report_code

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -654,8 +654,9 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                     ),
                 )
                 processing_tasks.append(sig)
-
-        if PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(commit.repository.repoid):
+        if PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
+            repo_id=commit.repository.repoid
+        ):
             parallel_chunk_size = 1
             num_sessions = len(argument_list)
             redis_key = get_parallel_upload_processing_session_counter_redis_key(
@@ -729,7 +730,9 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             processing_tasks.append(finish_sig)
             serial_tasks = chain(*processing_tasks)
 
-            if PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(commit.repository.repoid):
+            if PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
+                repo_id=commit.repository.repoid
+            ):
                 parallel_tasks = chord(parallel_processing_tasks, finish_parallel_sig)
                 parallel_shadow_experiment = serial_tasks | parallel_tasks
                 res = parallel_shadow_experiment.apply_async()

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -93,7 +93,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         repository = commit.repository
 
         if (
-            PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repository.repoid)
+            PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repo_id=repository.repoid)
             and in_parallel
         ):
             actual_processing_results = {

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -91,7 +91,10 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             extra=dict(repoid=repoid, commit=commitid),
         )
 
-        if PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repoid) and in_parallel:
+        if (
+            PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repo_id=repoid)
+            and in_parallel
+        ):
             log.info(
                 "Using parallel upload processing, skip acquiring upload processing lock",
                 extra=dict(
@@ -179,7 +182,10 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         in_parallel=False,
         **kwargs,
     ):
-        if not PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repoid) and in_parallel:
+        if (
+            not PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repo_id=repoid)
+            and in_parallel
+        ):
             log.info(
                 "Obtained upload processing lock, starting",
                 extra=dict(
@@ -206,7 +212,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         report_service = ReportService(commit_yaml)
 
         if (
-            PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repository.repoid)
+            PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repo_id=repository.repoid)
             and in_parallel
         ):
             log.info(
@@ -299,7 +305,9 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             parallel_incremental_result = None
             results_dict = {}
             if (
-                PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repository.repoid)
+                PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
+                    repo_id=repository.repoid
+                )
                 and in_parallel
             ):
                 with metrics.timer(
@@ -328,7 +336,9 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 # the parallel flow runs second, it parses the human readable artifacts instead
                 # since the serial flow already rewrote it
                 if not (
-                    PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repository.repoid)
+                    PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
+                        repo_id=repository.repoid
+                    )
                     and in_parallel
                 ):
                     deleted_archive = self._possibly_delete_archive(
@@ -357,7 +367,9 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             }
 
             if (
-                PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(repository.repoid)
+                PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
+                    repo_id=repository.repoid
+                )
                 and in_parallel
             ):
                 result["parallel_incremental_result"] = parallel_incremental_result


### PR DESCRIPTION
Context: https://github.com/codecov/shared/pull/175

Add repoid keywords for parallel upload processing rollout. The other rollouts already use the keyword which is good.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.