### PR TITLE
fix: except LockRetry instead of LockError

### DIFF
--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -30,7 +30,7 @@ from services.commit_status import RepositoryCIFilter
 from services.comparison import ComparisonProxy, NotificationContext
 from services.comparison.types import Comparison, FullCommit
 from services.decoration import determine_decoration_details
-from services.lock_manager import LockManager, LockType
+from services.lock_manager import LockManager, LockRetry, LockType
 from services.notification import NotificationService
 from services.redis import Redis, get_redis_connection
 from services.report import ReportService
@@ -96,7 +96,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                     empty_upload=empty_upload,
                     **kwargs,
                 )
-        except LockError as err:
+        except LockRetry as err:
             log.info(
                 "Not notifying because there is another notification already happening",
                 extra=dict(

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -23,6 +23,7 @@ from helpers.checkpoint_logger import CheckpointLogger, _kwargs_key
 from helpers.checkpoint_logger.flows import UploadFlow
 from helpers.exceptions import RepositoryWithoutValidBotError
 from services.decoration import DecorationDetails
+from services.lock_manager import LockRetry
 from services.notification import NotificationService
 from services.notification.notifiers.base import (
     AbstractBaseNotifier,
@@ -837,7 +838,7 @@ class TestNotifyTask(object):
         current_yaml = {"codecov": {"require_ci_to_pass": True}}
         task = NotifyTask()
         m = mocker.MagicMock()
-        m.return_value.locked.return_value.__enter__.side_effect = LockError()
+        m.return_value.locked.return_value.__enter__.side_effect = LockRetry(60)
         mocker.patch("tasks.notify.LockManager", m)
 
         res = task.run_impl(


### PR DESCRIPTION
Fixes: https://codecov.sentry.io/issues/5057432400/?project=-1&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=1&utc=true

We should be excepting a `LockRetry` here because that is what `LockManager` throws when it hits an error when trying to acquire the lock