### PR TITLE
add metric + experiment to see if longer CFF search range lowers errors

### DIFF
--- a/helpers/telemetry.py
+++ b/helpers/telemetry.py
@@ -2,6 +2,7 @@ import asyncio
 from datetime import datetime
 
 import django
+from asgiref.sync import sync_to_async
 from shared.django_apps.pg_telemetry.models import SimpleMetric as PgSimpleMetric
 from shared.django_apps.ts_telemetry.models import SimpleMetric as TsSimpleMetric
 
@@ -107,6 +108,10 @@ class MetricContext:
         )
 
         self.populated = True
+
+    @sync_to_async
+    def log_simple_metric_async(self, name: str, value: float):
+        self.log_simple_metric(name, value)
 
     def log_simple_metric(self, name: str, value: float):
         # Timezone-aware timestamp in UTC

--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -14,3 +14,5 @@ USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = Feature(
 )
 
 PARALLEL_UPLOAD_PROCESSING_BY_REPO = Feature("parallel_upload_processing")
+
+CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER = Feature("carryforward_base_search_range")

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -41,7 +41,11 @@ from helpers.exceptions import (
     RepositoryWithoutValidBotError,
 )
 from helpers.labels import get_labels_per_session
-from rollouts import PARALLEL_UPLOAD_PROCESSING_BY_REPO
+from helpers.telemetry import MetricContext
+from rollouts import (
+    CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER,
+    PARALLEL_UPLOAD_PROCESSING_BY_REPO,
+)
 from services.archive import ArchiveService
 from services.redis import (
     PARALLEL_UPLOAD_PROCESSING_SESSION_COUNTER_TTL,
@@ -617,10 +621,10 @@ class ReportService(BaseReportService):
         f"services.report.ReportService.get_appropriate_commit_to_carryforward_from"
     )
     def get_appropriate_commit_to_carryforward_from(
-        self, commit: Commit
+        self, commit: Commit, max_parenthood_deepness: int = 10
     ) -> Optional[Commit]:
+
         parent_commit = commit.get_parent_commit()
-        max_parenthood_deepness = 10
         parent_commit_tracking = []
         count = 1  # `parent_commit` is already the first parent
         while (
@@ -739,11 +743,30 @@ class ReportService(BaseReportService):
                 return Report()
             if not self.current_yaml.has_any_carryforward():
                 return Report()
-            parent_commit = self.get_appropriate_commit_to_carryforward_from(commit)
+
+            owner = commit.repository.owner
+            metric_context = MetricContext(
+                commit_sha=commit.commitid,
+                commit_id=commit.id,
+                repo_id=commit.repoid,
+                owner_id=owner.ownerid,
+            )
+            max_parenthood_deepness = (
+                await CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER.check_value_async(
+                    owner, default=10
+                )
+            )
+
+            parent_commit = self.get_appropriate_commit_to_carryforward_from(
+                commit, max_parenthood_deepness
+            )
             if parent_commit is None:
                 log.warning(
                     "Could not find parent for possible carryforward",
                     extra=dict(commit=commit.commitid, repoid=commit.repoid),
+                )
+                metric_context.attempt_log_simple_metric(
+                    "worker_service_report_carryforward_base_not_found", 1
                 )
                 return Report()
             parent_report = self.get_existing_report_for_commit(parent_commit)

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -746,16 +746,16 @@ class ReportService(BaseReportService):
             if not self.current_yaml.has_any_carryforward():
                 return Report()
 
-            owner = commit.repository.owner
+            repo = commit.repository
             metric_context = MetricContext(
                 commit_sha=commit.commitid,
                 commit_id=commit.id,
                 repo_id=commit.repoid,
-                owner_id=owner.ownerid,
+                owner_id=repo.ownerid,
             )
             max_parenthood_deepness = (
                 await CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER.check_value_async(
-                    owner, default=10
+                    owner_id=repo.ownerid, default=10
                 )
             )
 

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -821,6 +821,9 @@ class ReportService(BaseReportService):
             await self._possibly_shift_carryforward_report(
                 carryforward_report, parent_commit, commit
             )
+            metric_context.attempt_log_simple_metric(
+                "worker_service_report_carryforward_success", 1
+            )
             return carryforward_report
 
     @sentry_sdk.trace

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -857,6 +857,7 @@ class TestReportService(BaseTestCase):
         # notice we dont compare the diff since that one comes from git information we lost on the reset
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_for_commit(
         self,
         dbsession,
@@ -1926,6 +1927,7 @@ class TestReportService(BaseTestCase):
         assert expected_results == readable_report
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_for_commit_with_labels(
         self, dbsession, sample_commit_with_report_big_with_labels
     ):
@@ -2387,6 +2389,7 @@ class TestReportService(BaseTestCase):
         assert report == mocked_create_new_report_for_commit.return_value
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_build_report_from_commit_carriedforward_add_sessions(
         self, dbsession, sample_commit_with_report_big, mocker
     ):
@@ -2592,6 +2595,7 @@ class TestReportService(BaseTestCase):
         assert new_readable_report["report"]["sessions"]["3"] == newly_added_session
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_for_commit_with_path_filters(
         self, dbsession, sample_commit_with_report_big, mocker
     ):
@@ -3184,6 +3188,7 @@ class TestReportService(BaseTestCase):
         assert expected_results == readable_report
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_for_commit_no_parent(
         self, dbsession, sample_commit_with_report_big, mocker
     ):
@@ -3250,6 +3255,7 @@ class TestReportService(BaseTestCase):
         assert expected_results == readable_report
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_for_commit_parent_not_ready(
         self, dbsession, sample_commit_with_report_big, mocker
     ):
@@ -3454,6 +3460,7 @@ class TestReportService(BaseTestCase):
         assert expected_results_report == readable_report["report"]
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_for_commit_parent_not_ready_but_skipped(
         self, dbsession, sample_commit_with_report_big, mocker
     ):
@@ -3561,6 +3568,7 @@ class TestReportService(BaseTestCase):
         )
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_for_commit_too_many_ancestors_not_ready(
         self, dbsession, sample_commit_with_report_big, mocker
     ):
@@ -3596,6 +3604,7 @@ class TestReportService(BaseTestCase):
         assert expected_results_report == readable_report["report"]
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_parent_had_no_parent_and_pending(self, dbsession):
         current_commit = CommitFactory.create(parent_commit_id=None, state="pending")
         dbsession.add(current_commit)
@@ -3621,6 +3630,7 @@ class TestReportService(BaseTestCase):
             )
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_for_commit_potential_cf_but_not_real_cf(
         self, dbsession, sample_commit_with_report_big
     ):
@@ -3648,6 +3658,7 @@ class TestReportService(BaseTestCase):
         assert report.is_empty()
 
     @pytest.mark.asyncio
+    @pytest.mark.django_db(databases={"default", "timeseries"})
     async def test_create_new_report_for_commit_parent_has_no_report(
         self, mock_storage, dbsession
     ):


### PR DESCRIPTION
when looking for an ancestor commit to take our carryforward flag data from, we only search back 10 commits. if we go 10 commits without reports, or if the last 10 commits are still processing, CFF fails and the flags that were being CF'd will be dropped until they receive a new upload

this PR sets up an experiment to plug in different limits and see if any of them have an effect on carryforward success. it creates two metrics that we can watch:
- a "base not found" metric which should be lower in the test group
- a "carryforward success" metric which should be higher in the test group

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.