### PR TITLE
fix: use serial session id allocation for parallel experiment

### DIFF
--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -723,6 +723,7 @@ class TestUploadTaskIntegration(object):
             commit.report,
             mocker.ANY,
             mocker.ANY,
+            mocker.ANY,
         )
         assert not mocked_fetch_yaml.called
 
@@ -775,6 +776,7 @@ class TestUploadTaskIntegration(object):
                 {"build": "part2", "url": "url2", "upload_pk": mocker.ANY},
             ],
             commit.report,
+            mocker.ANY,
             mocker.ANY,
             mocker.ANY,
         )
@@ -850,6 +852,7 @@ class TestUploadTaskIntegration(object):
                 {"build": "part2", "url": "url2", "upload_pk": second_session.id},
             ],
             commit.report,
+            mocker.ANY,
             mocker.ANY,
             mocker.ANY,
         )
@@ -941,6 +944,7 @@ class TestUploadTaskIntegration(object):
                 }
             ],
             report,
+            mocker.ANY,
             mocker.ANY,
             mocker.ANY,
         )
@@ -1056,11 +1060,7 @@ class TestUploadTaskUnit(object):
         dbsession.add(commit)
         dbsession.flush()
         result = UploadTask().schedule_task(
-            commit,
-            commit_yaml,
-            argument_list,
-            ReportFactory.create(),
-            None,
+            commit, commit_yaml, argument_list, ReportFactory.create(), None, dbsession
         )
         assert result is None
 
@@ -1074,11 +1074,7 @@ class TestUploadTaskUnit(object):
         dbsession.add(commit)
         dbsession.flush()
         result = UploadTask().schedule_task(
-            commit,
-            commit_yaml,
-            argument_list,
-            ReportFactory.create(),
-            None,
+            commit, commit_yaml, argument_list, ReportFactory.create(), None, dbsession
         )
         assert result == mocked_chain.return_value.apply_async.return_value
         t1 = upload_processor_task.signature(

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import re
 import uuid
@@ -16,6 +17,7 @@ from shared.torngit.exceptions import (
     TorngitObjectNotFoundError,
     TorngitRepoNotFoundError,
 )
+from shared.utils.sessions import SessionType
 from shared.validation.exceptions import InvalidYamlException
 from shared.yaml import UserYaml
 
@@ -23,6 +25,7 @@ from app import celery_app
 from database.enums import CommitErrorTypes, ReportType
 from database.models import Commit, CommitReport
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
+from database.models.reports import Upload
 from helpers.checkpoint_logger import _kwargs_key
 from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import UploadFlow
@@ -513,6 +516,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 argument_list,
                 commit_report,
                 upload_context,
+                db_session,
                 checkpoints,
             )
         else:
@@ -580,6 +584,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         argument_list,
         commit_report: CommitReport,
         upload_context: UploadContext,
+        db_session,
         checkpoints=None,
     ):
         commit_yaml = commit_yaml.to_dict()
@@ -595,6 +600,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 argument_list,
                 commit_report,
                 upload_context,
+                db_session,
                 checkpoints=checkpoints,
             )
         elif commit_report.report_type == ReportType.BUNDLE_ANALYSIS.value:
@@ -628,6 +634,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         argument_list,
         commit_report,
         upload_context: UploadContext,
+        db_session,
         checkpoints=None,
     ):
         chunk_size = CHUNK_SIZE
@@ -664,7 +671,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             )
             report_service = ReportService(commit_yaml)
             sessions = report_service.build_sessions(commit=commit)
-
+            commit_yaml = UserYaml(commit_yaml)
             # if session count expired due to TTL (which is unlikely for most cases), recalculate the
             # session ids used and set it in redis.
             if self.parallel_session_count_key_expired(
@@ -700,15 +707,53 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                     start_number += 1
                 return start_number
 
-            mock_sessions = set(sessions.keys())
+            # copied and cut down from worker/services/report/raw_upload_processor.py
+            # this version stripped out all the ATS label stuff
+            def _adjust_sessions(
+                original_sessions: dict,
+                to_merge_flags,
+                current_yaml,
+            ):
+                session_ids_to_fully_delete = []
+                flags_under_carryforward_rules = [
+                    f for f in to_merge_flags if current_yaml.flag_has_carryfoward(f)
+                ]
+                to_fully_overwrite_flags = [f for f in flags_under_carryforward_rules]
+                if to_fully_overwrite_flags:
+                    for sess_id, curr_sess in original_sessions.items():
+                        if curr_sess.session_type == SessionType.carriedforward:
+                            if curr_sess.flags:
+                                if any(
+                                    f in to_fully_overwrite_flags
+                                    for f in curr_sess.flags
+                                ):
+                                    session_ids_to_fully_delete.append(sess_id)
+                if session_ids_to_fully_delete:
+                    # delete sessions from dict
+                    for id in session_ids_to_fully_delete:
+                        original_sessions.pop(id, None)
+                return
+
+            mock_sessions = copy.deepcopy(sessions)
             session_ids_for_parallel_idx = []
 
+            # iterate over all uploads, get the next session id, and adjust sessions (remove CFF logic)
             for i in range(num_sessions):
-                next = next_session_number(mock_sessions)
-                mock_sessions.add(next)
-                session_ids_for_parallel_idx.append(next)
+                next_session_id = next_session_number(mock_sessions)
+
+                upload_pk = argument_list[i]["upload_pk"]
+                upload = db_session.query(Upload).filter_by(id_=upload_pk).first()
+                to_merge_session = report_service.build_session(upload)
+                flags = upload.flag_names
+
+                mock_sessions[next_session_id] = to_merge_session
+                _adjust_sessions(mock_sessions, flags, commit_yaml)
+
+                session_ids_for_parallel_idx.append(next_session_id)
 
             parallel_processing_tasks = []
+            commit_yaml = commit_yaml.to_dict()
+
             for i in range(0, num_sessions, parallel_chunk_size):
                 chunk = argument_list[i : i + parallel_chunk_size]
                 if chunk:

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -718,13 +718,12 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 flags_under_carryforward_rules = [
                     f for f in to_merge_flags if current_yaml.flag_has_carryfoward(f)
                 ]
-                to_fully_overwrite_flags = [f for f in flags_under_carryforward_rules]
-                if to_fully_overwrite_flags:
+                if flags_under_carryforward_rules:
                     for sess_id, curr_sess in original_sessions.items():
                         if curr_sess.session_type == SessionType.carriedforward:
                             if curr_sess.flags:
                                 if any(
-                                    f in to_fully_overwrite_flags
+                                    f in flags_under_carryforward_rules
                                     for f in curr_sess.flags
                                 ):
                                     session_ids_to_fully_delete.append(sess_id)


### PR DESCRIPTION
<!-- Describe your PR here. -->

Make the session id allocation for parallel flow exactly the same as how the serial flow allocates sessions. My previous version using redis makes the allocated sessions strictly increasing, while the old behaviour will reuse some values. 

This change alone probably isn't enough to fix the differences between what the serial flow and parallel flow generate, but makes my life easier investigating as there is less noise in the diffs. 

This is mainly just a temporary change for now for the experiment

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.