### PR TITLE
convert statsd report processor metrics to prometheus metrics

### DIFF
--- a/services/report/report_processor.py
+++ b/services/report/report_processor.py
@@ -6,10 +6,10 @@ from json import load
 from typing import Any, Optional, Tuple
 
 from lxml import etree
+from shared.metrics import Counter, Histogram
 from shared.reports.resources import Report
 
 from helpers.exceptions import CorruptRawReportError
-from helpers.metrics import metrics
 from services.report.languages import (
     BullseyeProcessor,
     CloverProcessor,
@@ -45,6 +45,20 @@ from services.report.parser.types import ParsedUploadedReportFile
 from services.report.report_builder import ReportBuilder
 
 log = logging.getLogger(__name__)
+
+
+RAW_REPORT_PROCESSOR_RUNTIME_SECONDS = Histogram(
+    "worker_services_report_raw_processor_duration_seconds",
+    "Time it takes (in seconds) for a raw report processor to run",
+    ["processor"],
+    buckets=[0.05, 0.1, 0.5, 1, 2, 5, 7.5, 10, 15, 20, 30, 60, 120, 180, 300, 600, 900],
+)
+
+RAW_REPORT_PROCESSOR_COUNTER = Counter(
+    "worker_services_report_raw_processor_runs",
+    "Number of times a raw report processor was run and with what result",
+    ["processor", "result"],
+)
 
 
 def report_type_matching(report: ParsedUploadedReportFile) -> Tuple[Any, Optional[str]]:
@@ -147,14 +161,15 @@ def process_report(
     processors = get_possible_processors_list(report_type)
     for processor in processors:
         if processor.matches_content(parsed_report, first_line, name):
-            with metrics.timer(
-                f"worker.services.report.processors.{processor.name}.run"
-            ):
+            processor_counter = RAW_REPORT_PROCESSOR_COUNTER.labels(
+                processor=processor.name
+            )
+            with RAW_REPORT_PROCESSOR_RUNTIME_SECONDS.labels(
+                processor=processor.name
+            ).time():
                 try:
                     res = processor.process(name, parsed_report, report_builder)
-                    metrics.incr(
-                        f"worker.services.report.processors.{processor.name}.success"
-                    )
+                    processor_counter.labels(result="success").inc()
                     return res
                 except CorruptRawReportError as e:
                     log.warning(
@@ -166,11 +181,10 @@ def process_report(
                         ),
                         exc_info=True,
                     )
+                    processor_counter.labels(result="corrupt_raw_report").inc()
                     return None
                 except Exception:
-                    metrics.incr(
-                        f"worker.services.report.processors.{processor.name}.failure"
-                    )
+                    processor_counter.labels(result="failure").inc()
                     raise
     log.warning(
         "File format could not be recognized",


### PR DESCRIPTION
i want a dashboard showing which processors are actually used and how long they take. could probably hack it together with statsd counters but we have to get rid of those eventually

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.