### PR TITLE
add logs + move experiment code to helpers

### DIFF
--- a/helpers/parallel_upload_processing.py
+++ b/helpers/parallel_upload_processing.py
@@ -1,0 +1,64 @@
+import copy
+
+from shared.utils.sessions import SessionType
+
+from database.models.reports import Upload
+
+
+# copied from shared/reports/resources.py Report.next_session_number()
+def next_session_number(session_dict):
+    start_number = len(session_dict)
+    while start_number in session_dict or str(start_number) in session_dict:
+        start_number += 1
+    return start_number
+
+
+# copied and cut down from worker/services/report/raw_upload_processor.py
+# this version stripped out all the ATS label stuff
+def _adjust_sessions(
+    original_sessions: dict,
+    to_merge_flags,
+    current_yaml,
+):
+    session_ids_to_fully_delete = []
+    flags_under_carryforward_rules = [
+        f for f in to_merge_flags if current_yaml.flag_has_carryfoward(f)
+    ]
+    if flags_under_carryforward_rules:
+        for sess_id, curr_sess in original_sessions.items():
+            if curr_sess.session_type == SessionType.carriedforward:
+                if curr_sess.flags:
+                    if any(
+                        f in flags_under_carryforward_rules for f in curr_sess.flags
+                    ):
+                        session_ids_to_fully_delete.append(sess_id)
+    if session_ids_to_fully_delete:
+        # delete sessions from dict
+        for id in session_ids_to_fully_delete:
+            original_sessions.pop(id, None)
+    return
+
+
+def get_parallel_session_ids(
+    sessions, argument_list, db_session, report_service, commit_yaml
+):
+    num_sessions = len(argument_list)
+
+    mock_sessions = copy.deepcopy(sessions)  # the sessions already in the report
+    get_parallel_session_ids = []
+
+    # iterate over all uploads, get the next session id, and adjust sessions (remove CFF logic)
+    for i in range(num_sessions):
+        next_session_id = next_session_number(mock_sessions)
+
+        upload_pk = argument_list[i]["upload_pk"]
+        upload = db_session.query(Upload).filter_by(id_=upload_pk).first()
+        to_merge_session = report_service.build_session(upload)
+        flags = upload.flag_names
+
+        mock_sessions[next_session_id] = to_merge_session
+        _adjust_sessions(mock_sessions, flags, commit_yaml)
+
+        get_parallel_session_ids.append(next_session_id)
+
+    return get_parallel_session_ids

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -919,7 +919,8 @@ class ReportService(BaseReportService):
                     parallel_idx=parallel_idx,
                 )
             log.info(
-                "Successfully processed report",
+                "Successfully processed report"
+                + (" (in parallel)" if parallel_idx is not None else ""),
                 extra=dict(
                     session=session.id,
                     ci=f"{session.provider}:{session.build}:{session.job}",

--- a/tasks/parallel_verification.py
+++ b/tasks/parallel_verification.py
@@ -36,7 +36,7 @@ class ParallelVerificationTask(BaseCodecovTask, name=parallel_verification_task_
         archive_service = report_service.get_archive_service(repository)
 
         log.info(
-            "Starting parallel upload processsing verification task",
+            "Starting parallel upload processing verification task",
             extra=dict(
                 repoid=repoid,
                 commitid=commitid,
@@ -117,7 +117,7 @@ class ParallelVerificationTask(BaseCodecovTask, name=parallel_verification_task_
 
         if verification_result == 1:
             log.info(
-                "Parallel upload processsing verification succeeded",
+                "Parallel upload processing verification succeeded",
                 extra=dict(
                     repoid=repoid,
                     commitid=commitid,
@@ -128,7 +128,7 @@ class ParallelVerificationTask(BaseCodecovTask, name=parallel_verification_task_
             )
         else:
             log.info(
-                f"Parallel upload processsing verification failed with {verification_result}",
+                f"Parallel upload processing verification failed with {verification_result}",
                 extra=dict(
                     repoid=repoid,
                     commitid=commitid,

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import re
 import uuid
@@ -17,7 +16,6 @@ from shared.torngit.exceptions import (
     TorngitObjectNotFoundError,
     TorngitRepoNotFoundError,
 )
-from shared.utils.sessions import SessionType
 from shared.validation.exceptions import InvalidYamlException
 from shared.yaml import UserYaml
 
@@ -25,12 +23,12 @@ from app import celery_app
 from database.enums import CommitErrorTypes, ReportType
 from database.models import Commit, CommitReport
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
-from database.models.reports import Upload
 from helpers.checkpoint_logger import _kwargs_key
 from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import UploadFlow
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.metrics import metrics
+from helpers.parallel_upload_processing import get_parallel_session_ids
 from helpers.save_commit_error import save_commit_error
 from rollouts import PARALLEL_UPLOAD_PROCESSING_BY_REPO
 from services.archive import ArchiveService
@@ -660,6 +658,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                     ),
                 )
                 processing_tasks.append(sig)
+
         if PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
             repo_id=commit.repository.repoid
         ):
@@ -681,6 +680,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                     max(sessions.keys()) + 1 if sessions.keys() else 0,
                 )
 
+            # https://github.com/codecov/worker/commit/7d9c1984b8bc075c9fa002ee15cab3419684f2d6
             # try to scrap the redis counter idea to fully mimic how session ids are allocated in the
             # serial flow. This change is technically less performant, and would not allow for concurrent
             # chords to be running at the same time. For now this is just a temporary change, just for
@@ -698,56 +698,20 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             #     name=redis_key,
             #     time=PARALLEL_UPLOAD_PROCESSING_SESSION_COUNTER_TTL,
             # )
+            original_session_ids = list(sessions.keys())
+            parallel_session_ids = get_parallel_session_ids(
+                sessions, argument_list, db_session, report_service, commit_yaml
+            )
 
-            # copied from shared/reports/resources.py Report.next_session_number()
-            def next_session_number(session_dict):
-                start_number = len(session_dict)
-                while start_number in session_dict or str(start_number) in session_dict:
-                    start_number += 1
-                return start_number
-
-            # copied and cut down from worker/services/report/raw_upload_processor.py
-            # this version stripped out all the ATS label stuff
-            def _adjust_sessions(
-                original_sessions: dict,
-                to_merge_flags,
-                current_yaml,
-            ):
-                session_ids_to_fully_delete = []
-                flags_under_carryforward_rules = [
-                    f for f in to_merge_flags if current_yaml.flag_has_carryfoward(f)
-                ]
-                if flags_under_carryforward_rules:
-                    for sess_id, curr_sess in original_sessions.items():
-                        if curr_sess.session_type == SessionType.carriedforward:
-                            if curr_sess.flags:
-                                if any(
-                                    f in flags_under_carryforward_rules
-                                    for f in curr_sess.flags
-                                ):
-                                    session_ids_to_fully_delete.append(sess_id)
-                if session_ids_to_fully_delete:
-                    # delete sessions from dict
-                    for id in session_ids_to_fully_delete:
-                        original_sessions.pop(id, None)
-                return
-
-            mock_sessions = copy.deepcopy(sessions)
-            session_ids_for_parallel_idx = []
-
-            # iterate over all uploads, get the next session id, and adjust sessions (remove CFF logic)
-            for i in range(num_sessions):
-                next_session_id = next_session_number(mock_sessions)
-
-                upload_pk = argument_list[i]["upload_pk"]
-                upload = db_session.query(Upload).filter_by(id_=upload_pk).first()
-                to_merge_session = report_service.build_session(upload)
-                flags = upload.flag_names
-
-                mock_sessions[next_session_id] = to_merge_session
-                _adjust_sessions(mock_sessions, flags, commit_yaml)
-
-                session_ids_for_parallel_idx.append(next_session_id)
+            log.info(
+                "Allocated the following session ids for parallel upload processing: "
+                + " ".join(str(id) for id in parallel_session_ids),
+                extra=dict(
+                    repoid=commit.repoid,
+                    commit=commit.commitid,
+                    original_session_ids=original_session_ids,
+                ),
+            )
 
             parallel_processing_tasks = []
             commit_yaml = commit_yaml.to_dict()
@@ -763,7 +727,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                             commit_yaml=commit_yaml,
                             arguments_list=chunk,
                             report_code=commit_report.code,
-                            parallel_idx=session_ids_for_parallel_idx[
+                            parallel_idx=parallel_session_ids[
                                 i
                             ],  # i + parallel_session_id,
                             in_parallel=True,

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -445,6 +445,10 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 None,
             )
         except FileNotInStorageError:  # there were no CFFs, so no report was stored in GCS
+            log.info(
+                "No base report found for parallel upload processing, using an empty report",
+                extra=dict(commit=commitid, repoid=repoid),
+            )
             report = Report()
 
         log.info(
@@ -521,7 +525,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
             ),
         )
         report = functools.reduce(merge_report, unmerged_reports, report)
-        return report  # TODO: should compute totals after all incremental reports get merged together
+        return report
 
 
 RegisteredUploadTask = celery_app.register_task(UploadFinisherTask())

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -88,7 +88,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         repoid = int(repoid)
         log.info(
             "Received upload processor task",
-            extra=dict(repoid=repoid, commit=commitid),
+            extra=dict(repoid=repoid, commit=commitid, in_parallel=in_parallel),
         )
 
         if (
@@ -217,7 +217,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         ):
             log.info(
                 "Creating empty report to store incremental result",
-                extra=dict(commit=commitid),
+                extra=dict(commit=commitid, repo=repoid),
             )
             report = Report()
         else:
@@ -249,6 +249,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                         commit_yaml=commit_yaml.to_dict(),
                         upload=upload_obj.id_,
                         parent_task=self.request.parent_id,
+                        in_parallel=in_parallel,
                     ),
                 )
                 individual_info = {"arguments": arguments.copy()}
@@ -299,6 +300,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                     repoid=repoid,
                     commit=commitid,
                     parent_task=self.request.parent_id,
+                    in_parallel=in_parallel,
                 ),
             )
 
@@ -318,6 +320,15 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                     )
                     parallel_incremental_result["upload_pk"] = arguments_list[0].get(
                         "upload_pk"
+                    )
+
+                    log.info(
+                        "Saved incremental report results to storage",
+                        extra=dict(
+                            repoid=repoid,
+                            commit=commitid,
+                            incremental_result_path=parallel_incremental_result,
+                        ),
                     )
             else:
                 with metrics.timer(f"{self.metrics_prefix}.save_report_results"):

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -240,8 +240,8 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                     .first()
                 )
                 log.info(
-                    "Processing individual report %s",
-                    arguments.get("reportid"),
+                    f"Processing individual report {arguments.get('reportid')}"
+                    + (" (in parallel)" if in_parallel else ""),
                     extra=dict(
                         repoid=repoid,
                         commit=commitid,
@@ -294,8 +294,8 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                     n_processed += 1
                 processings_so_far.append(individual_info)
             log.info(
-                "Finishing the processing of %d reports",
-                n_processed,
+                f"Finishing the processing of {n_processed} reports"
+                + (" (in parallel)" if in_parallel else ""),
                 extra=dict(
                     repoid=repoid,
                     commit=commitid,
@@ -362,14 +362,15 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 processed_individual_report.pop("upload_obj", None)
                 processed_individual_report.pop("raw_report", None)
             log.info(
-                "Processed %d reports",
-                n_processed,
+                f"Processed {n_processed} reports"
+                + (" (in parallel)" if in_parallel else ""),
                 extra=dict(
                     repoid=repoid,
                     commit=commitid,
                     commit_yaml=commit_yaml.to_dict(),
                     url=results_dict.get("url"),
                     parent_task=self.request.parent_id,
+                    in_parallel=in_parallel,
                 ),
             )
 


### PR DESCRIPTION
Adds more logging for the parallel upload processing experiment. Also refactors the code in `tasks/upload.py` for readability. 

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.