### PR TITLE
chore: differentiate processing tasks in logs

### DIFF
--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -769,7 +769,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 res = serial_tasks.apply_async()
 
             log.info(
-                "Scheduling task for %s different reports",
+                "Scheduling coverage processing tasks for %s different reports",
                 len(argument_list),
                 extra=dict(
                     repoid=commit.repoid,
@@ -861,7 +861,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             ).apply_async()
 
             log.info(
-                "Scheduling task for %s different reports",
+                "Scheduling test results processing tasks for %s different reports",
                 len(argument_list),
                 extra=dict(
                     repoid=commit.repoid,
@@ -873,7 +873,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             )
             return res
         log.info(
-            "Not scheduling task because there were no reports to be processed found",
+            "Not scheduling test results processing tasks because there were no reports to be processed found",
             extra=dict(
                 repoid=commit.repoid,
                 commit=commit.commitid,


### PR DESCRIPTION
Adds the type of processing task is being scheduled to logs. It's annoying to look at the logs and not know which type of task is being scheduled.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.