### PR TITLE
Add task group to metrics

### DIFF
--- a/tasks/tests/unit/test_base.py
+++ b/tasks/tests/unit/test_base.py
@@ -20,10 +20,25 @@ from sqlalchemy.exc import (
 )
 
 from database.tests.factories.core import OwnerFactory, RepositoryFactory
-from tasks.base import BaseCodecovRequest, BaseCodecovTask
+from tasks.base import BaseCodecovRequest, BaseCodecovTask, _get_task_group_from_name
 from tasks.base import celery_app as base_celery_app
 
 here = Path(__file__)
+
+
+@pytest.mark.parametrize(
+    "task_name,output",
+    [
+        (None, None),
+        ("task_not_following_expected_pattern", None),
+        ("task_group.task_name", "task_group"),
+        ("app.task.task_group.task_name", "task_group"),
+        ("app.cron.daily.task_name", "daily"),
+        (f"app.tasks.test_results.TestResultsProcessor", "test_results"),
+    ],
+)
+def test__get_task_group_from_name(task_name, output):
+    assert _get_task_group_from_name(task_name) == output
 
 
 class MockDateTime(datetime):
@@ -422,7 +437,6 @@ class TestBaseCodecovTaskHooks(object):
 
 
 class TestBaseCodecovRequest(object):
-
     """
     All in all, this is a really weird class
 


### PR DESCRIPTION
We have task health metrics (success, failure, ...)
But we also have a lot of tasks. And the graphs in grafana don't look amazing with all those tasks there.
In particular I'd like to have general success / failure rates per task group.
"task_group" is the task_config_group (part of the task name).

This can be used so we know at any given time how's the general health for the group as a whole.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.