### PR TITLE
  Update `sqlparse` to 0.5.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ test.integration:
 
 
 update-requirements:
-	pip install pip-tools==6.1.0
+	pip install pip-tools==7.4.1
 	pip-compile requirements.in
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -363,9 +363,7 @@ requests==2.31.0
 respx==0.20.2
     # via -r requirements.in
 rfc3986[idna2008]==1.4.0
-    # via
-    #   httpx
-    #   rfc3986
+    # via httpx
 rsa==4.7.2
     # via google-auth
 s3transfer==0.3.4
@@ -402,7 +400,7 @@ sqlalchemy-utils==0.36.8
     # via
     #   -r requirements.in
     #   pytest-sqlalchemy
-sqlparse==0.4.4
+sqlparse==0.5.0
     # via django
 statsd==3.3.0
     # via


### PR DESCRIPTION
This fixes [https://github.com/advisories/GHSA-2m57-hf25-phgg](https://github.com/advisories/GHSA-2m57-hf25-phgg).

`requirements.txt` was auto-generated by running:

`pip-compile --upgrade-package sqlparse`

The only dependency, `django`, doesn't have `sqlparse` pinned, so we should be able to upgrade this.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.