### PR TITLE
feat: retry notify if no apps are currently available

### DIFF
--- a/helpers/clock.py
+++ b/helpers/clock.py
@@ -2,8 +2,14 @@ from datetime import datetime, timezone
 
 
 def get_utc_now() -> datetime:
-    return datetime.utcnow().replace(tzinfo=timezone.utc)
+    return datetime.now(timezone.utc)
 
 
 def get_utc_now_as_iso_format() -> str:
     return get_utc_now().isoformat()
+
+
+def get_seconds_to_next_hour() -> int:
+    now = datetime.now(timezone.utc)
+    current_seconds = (now.minute * 60) + now.second
+    return 3600 - current_seconds

--- a/helpers/exceptions.py
+++ b/helpers/exceptions.py
@@ -14,8 +14,13 @@ class OwnerWithoutValidBotError(Exception):
     pass
 
 
-class CorruptRawReportError(Exception):
+class NoConfiguredAppsAvailable(Exception):
+    def __init__(self, apps_count: int, all_rate_limited: bool) -> None:
+        self.apps_count = apps_count
+        self.all_rate_limited = all_rate_limited
 
+
+class CorruptRawReportError(Exception):
     """Error indicated that report is somehow different than it should be
 
     Notice that this error should not be used to replace `matches_content` logic on each processor.

--- a/helpers/tests/unit/test_clock.py
+++ b/helpers/tests/unit/test_clock.py
@@ -1,6 +1,13 @@
 from datetime import datetime, timezone
 
-from helpers.clock import get_utc_now, get_utc_now_as_iso_format
+import pytest
+from freezegun import freeze_time
+
+from helpers.clock import (
+    get_seconds_to_next_hour,
+    get_utc_now,
+    get_utc_now_as_iso_format,
+)
 
 
 def test_get_utc_now():
@@ -13,3 +20,17 @@ def test_get_utc_now_as_iso_format():
     res = get_utc_now_as_iso_format()
     assert isinstance(res, str)
     assert isinstance(datetime.fromisoformat(res), datetime)
+
+
+@pytest.mark.parametrize(
+    "timestamp, expected",
+    [
+        ("2024-04-22T10:22:00", 38 * 60),
+        ("2024-04-22T10:22:59", 38 * 60 - 59),
+        ("2024-04-22T10:59:59", 1),
+        ("2024-04-22T10:59:00", 60),
+    ],
+)
+def test_get_seconds_to_next_hour(timestamp, expected):
+    with freeze_time(timestamp):
+        assert get_seconds_to_next_hour() == expected

--- a/services/bots.py
+++ b/services/bots.py
@@ -14,7 +14,11 @@ from database.models.core import (
     GithubAppInstallation,
 )
 from helpers.environment import is_enterprise
-from helpers.exceptions import OwnerWithoutValidBotError, RepositoryWithoutValidBotError
+from helpers.exceptions import (
+    NoConfiguredAppsAvailable,
+    OwnerWithoutValidBotError,
+    RepositoryWithoutValidBotError,
+)
 from services.encryption import encryptor
 from services.github import get_github_integration_token
 from services.redis import get_redis_connection
@@ -88,12 +92,6 @@ def _get_apps_from_weighted_selection(
         seen_ids[app.id] = True
         list_to_return.append(app)
     return list_to_return
-
-
-class NoConfiguredAppsAvailable(Exception):
-    def __init__(self, apps_count: int, all_rate_limited: bool) -> None:
-        self.apps_count = apps_count
-        self.all_rate_limited = all_rate_limited
 
 
 def get_owner_installation_id(

--- a/services/tests/test_bots.py
+++ b/services/tests/test_bots.py
@@ -8,8 +8,8 @@ from database.models.core import (
     GithubAppInstallation,
 )
 from database.tests.factories import OwnerFactory, RepositoryFactory
+from helpers.exceptions import NoConfiguredAppsAvailable
 from services.bots import (
-    NoConfiguredAppsAvailable,
     OwnerWithoutValidBotError,
     RepositoryWithoutValidBotError,
     TokenType,

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -3,6 +3,7 @@ from unittest.mock import call
 
 import pytest
 from celery.exceptions import MaxRetriesExceededError, Retry
+from freezegun import freeze_time
 from redis.exceptions import LockError
 from shared.celery_config import new_user_activated_task_name
 from shared.reports.resources import Report
@@ -21,7 +22,7 @@ from database.tests.factories import (
 )
 from helpers.checkpoint_logger import CheckpointLogger, _kwargs_key
 from helpers.checkpoint_logger.flows import UploadFlow
-from helpers.exceptions import RepositoryWithoutValidBotError
+from helpers.exceptions import NoConfiguredAppsAvailable, RepositoryWithoutValidBotError
 from services.decoration import DecorationDetails
 from services.lock_manager import LockRetry
 from services.notification import NotificationService
@@ -713,6 +714,35 @@ class TestNotifyTask(object):
             "reason": "no_valid_bot",
         }
         assert expected_result == res
+
+    @freeze_time("2024-04-22T11:15:00")
+    def test_notify_task_no_ghapp_available(self, dbsession, mocker):
+        get_repo_provider_service = mocker.patch(
+            "tasks.notify.get_repo_provider_service"
+        )
+        mock_retry = mocker.patch.object(NotifyTask, "retry", return_value=None)
+        get_repo_provider_service.side_effect = NoConfiguredAppsAvailable(
+            apps_count=2, all_rate_limited=True
+        )
+        commit = CommitFactory.create(
+            message="",
+            pullid=None,
+            branch="test-branch-1",
+            commitid="649eaaf2924e92dc7fd8d370ddb857033231e67a",
+            repository__using_integration=True,
+        )
+        dbsession.add(commit)
+        dbsession.flush()
+        current_yaml = {"codecov": {"require_ci_to_pass": True}}
+        task = NotifyTask()
+        res = task.run_impl_within_lock(
+            dbsession,
+            repoid=commit.repoid,
+            commitid=commit.commitid,
+            current_yaml=current_yaml,
+        )
+        assert res is None
+        mock_retry.assert_called_with(max_retries=10, countdown=45 * 60)
 
     def test_submit_third_party_notifications_exception(self, mocker, dbsession):
         current_yaml = {}


### PR DESCRIPTION
Catches `NoConfiguredAppsAvailable` exception in the notify task and
attempts to reschedule it at a later time.

The "later time" is in the next full hour, when the rate limits should reset.
Notice this only affects gh app installations, so tokenless should not fall unders this category.
(meaning we shouldn't have a terrible influx of tokenless notifs at the next hour).

Also updating the `get_utc_now` function because `datetime.utcnow` is deprecated.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.