### PR TITLE
fix: get_repo_appropriate_bot_token returning None

### DIFF
--- a/services/bots.py
+++ b/services/bots.py
@@ -208,6 +208,7 @@ def get_public_bot_token(repo):
     tokenless_bot_dict = get_config(
         repo.service, "bots", "tokenless", default=public_bot_dict
     )
+
     if tokenless_bot_dict and tokenless_bot_dict.get("key"):
         log.info(
             "Using tokenless bot as bot fallback",
@@ -215,6 +216,12 @@ def get_public_bot_token(repo):
         )
         # Once again token not owned by an Owner.
         return tokenless_bot_dict, None
+
+    log.error(
+        "No tokenless bot dict in get_public_bot_token",
+        extra=dict(repoid=repo.repoid),
+    )
+    raise RepositoryWithoutValidBotError()
 
 
 def get_repo_particular_bot_token(repo) -> Tuple[Dict, Owner]:


### PR DESCRIPTION
get_repo_appropriate_bot_token is returning None in some cases which is causing issues because it's expected to return a:
Tuple[Dict, Optional[Owner]].

I think the only way it can possibly return None is if get_public_token returns None, which is possible if we don't enter the if statement in get_public_token. So, if we don't enter it now, we now return a RepositoryWithoutValidBotError exception.