### PR TITLE
hotfix: sync_repos using integration when the repo services is known is acting strange

### DIFF
--- a/services/repository.py
+++ b/services/repository.py
@@ -87,9 +87,11 @@ def get_repo_provider_service(
             secret=get_config(service, "client_secret"),
         ),
         on_token_refresh=get_token_refresh_callback(token_owner),
-        fallback_installations=installation_info.get("fallback_installations")
-        if installation_info
-        else None,
+        fallback_installations=(
+            installation_info.get("fallback_installations")
+            if installation_info
+            else None
+        ),
     )
     return _get_repo_provider_service_instance(repository.service, **adapter_params)
 

--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -260,14 +260,14 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
 
         # Here comes the actual function
         received_repos = False
-        if repository_service_ids:
-            # This flow is different from the ones below because the API already informed us the repos affected
-            # So we can update those values directly
-            repoids_added = await self.sync_repos_affected_repos_known(
-                db_session, git, owner, repository_service_ids
-            )
-            repoids = repoids_added
-        elif await LIST_REPOS_GENERATOR_BY_OWNER_ID.check_value_async(
+        # if repository_service_ids:
+        #     # This flow is different from the ones below because the API already informed us the repos affected
+        #     # So we can update those values directly
+        #     repoids_added = await self.sync_repos_affected_repos_known(
+        #         db_session, git, owner, repository_service_ids
+        #     )
+        #     repoids = repoids_added
+        if await LIST_REPOS_GENERATOR_BY_OWNER_ID.check_value_async(
             owner_id=ownerid, default=False
         ):
             with metrics.timer(

--- a/tasks/tests/unit/test_sync_repos_task.py
+++ b/tasks/tests/unit/test_sync_repos_task.py
@@ -1002,162 +1002,162 @@ class TestSyncReposTaskUnit(object):
 
         mocked_app.tasks[sync_repo_languages_task_name].apply_async.assert_not_called()
 
-    def test_sync_repos_using_integration_affected_repos_known(
-        self,
-        mocker,
-        dbsession,
-        mock_owner_provider,
-        mock_redis,
-    ):
+    # def test_sync_repos_using_integration_affected_repos_known(
+    #     self,
+    #     mocker,
+    #     dbsession,
+    #     mock_owner_provider,
+    #     mock_redis,
+    # ):
 
-        user = OwnerFactory.create(
-            organizations=[],
-            service="github",
-            username="1nf1n1t3l00p",
-            unencrypted_oauth_token="sometesttoken",
-            permission=[],
-            service_id="45343385",
-        )
-        dbsession.add(user)
+    #     user = OwnerFactory.create(
+    #         organizations=[],
+    #         service="github",
+    #         username="1nf1n1t3l00p",
+    #         unencrypted_oauth_token="sometesttoken",
+    #         permission=[],
+    #         service_id="45343385",
+    #     )
+    #     dbsession.add(user)
 
-        mocked_app = mocker.patch.object(
-            SyncRepoLanguagesGQLTask,
-            "app",
-            tasks={
-                sync_repo_languages_gql_task_name: mocker.MagicMock(),
-            },
-        )
-        repository_service_ids = [
-            ("460565350", "R_kgDOG3OrZg"),
-            ("665728948", "R_kgDOJ643tA"),
-            ("553624697", "R_kgDOIP-keQ"),
-            ("631985885", "R_kgDOJatW3Q"),  # preseeded
-            ("623359086", "R_kgDOJSe0bg"),  # preseeded
-        ]
-        service_ids = [x[0] for x in repository_service_ids]
-        service_ids_to_add = service_ids[:3]
+    #     mocked_app = mocker.patch.object(
+    #         SyncRepoLanguagesGQLTask,
+    #         "app",
+    #         tasks={
+    #             sync_repo_languages_gql_task_name: mocker.MagicMock(),
+    #         },
+    #     )
+    #     repository_service_ids = [
+    #         ("460565350", "R_kgDOG3OrZg"),
+    #         ("665728948", "R_kgDOJ643tA"),
+    #         ("553624697", "R_kgDOIP-keQ"),
+    #         ("631985885", "R_kgDOJatW3Q"),  # preseeded
+    #         ("623359086", "R_kgDOJSe0bg"),  # preseeded
+    #     ]
+    #     service_ids = [x[0] for x in repository_service_ids]
+    #     service_ids_to_add = service_ids[:3]
 
-        def repo_obj(service_id, name, language, private, branch, using_integration):
-            return {
-                "owner": {
-                    "service_id": "test-owner-service-id",
-                    "username": "test-owner-username",
-                },
-                "repo": {
-                    "service_id": service_id,
-                    "name": name,
-                    "language": language,
-                    "private": private,
-                    "branch": branch,
-                },
-                "_using_integration": using_integration,
-            }
+    #     def repo_obj(service_id, name, language, private, branch, using_integration):
+    #         return {
+    #             "owner": {
+    #                 "service_id": "test-owner-service-id",
+    #                 "username": "test-owner-username",
+    #             },
+    #             "repo": {
+    #                 "service_id": service_id,
+    #                 "name": name,
+    #                 "language": language,
+    #                 "private": private,
+    #                 "branch": branch,
+    #             },
+    #             "_using_integration": using_integration,
+    #         }
 
-        preseeded_repos = [
-            repo_obj("631985885", "example-python", "python", False, "main", True),
-            repo_obj("623359086", "sentry", "python", False, "main", True),
-        ]
+    #     preseeded_repos = [
+    #         repo_obj("631985885", "example-python", "python", False, "main", True),
+    #         repo_obj("623359086", "sentry", "python", False, "main", True),
+    #     ]
 
-        for repo in preseeded_repos:
-            new_repo = RepositoryFactory.create(
-                private=repo["repo"]["private"],
-                name=repo["repo"]["name"],
-                using_integration=repo["_using_integration"],
-                service_id=repo["repo"]["service_id"],
-                owner=user,
-            )
-            dbsession.add(new_repo)
-        dbsession.flush()
+    #     for repo in preseeded_repos:
+    #         new_repo = RepositoryFactory.create(
+    #             private=repo["repo"]["private"],
+    #             name=repo["repo"]["name"],
+    #             using_integration=repo["_using_integration"],
+    #             service_id=repo["repo"]["service_id"],
+    #             owner=user,
+    #         )
+    #         dbsession.add(new_repo)
+    #     dbsession.flush()
 
-        # These are the repos we're supposed to query from the service provider
-        async def side_effect(*args, **kwargs):
-            results = [
-                {
-                    "branch": "main",
-                    "language": "python",
-                    "name": "codecov-cli",
-                    "owner": {
-                        "is_expected_owner": False,
-                        "node_id": "MDEyOk9yZ2FuaXphdGlvbjgyMjYyMDU=",
-                        "service_id": "8226205",
-                        "username": "codecov",
-                    },
-                    "service_id": "460565350",
-                    "private": False,
-                },
-                {
-                    "branch": "main",
-                    "language": "python",
-                    "name": "worker",
-                    "owner": {
-                        "is_expected_owner": False,
-                        "node_id": "MDEyOk9yZ2FuaXphdGlvbjgyMjYyMDU=",
-                        "service_id": "8226205",
-                        "username": "codecov",
-                    },
-                    "service_id": "665728948",
-                    "private": False,
-                },
-                {
-                    "branch": "main",
-                    "language": "python",
-                    "name": "components-demo",
-                    "owner": {
-                        "is_expected_owner": True,
-                        "node_id": "U_kgDOBfIxWg",
-                        "username": "giovanni-guidini",
-                    },
-                    "service_id": "553624697",
-                    "private": False,
-                },
-            ]
-            for r in results:
-                yield r
+    #     # These are the repos we're supposed to query from the service provider
+    #     async def side_effect(*args, **kwargs):
+    #         results = [
+    #             {
+    #                 "branch": "main",
+    #                 "language": "python",
+    #                 "name": "codecov-cli",
+    #                 "owner": {
+    #                     "is_expected_owner": False,
+    #                     "node_id": "MDEyOk9yZ2FuaXphdGlvbjgyMjYyMDU=",
+    #                     "service_id": "8226205",
+    #                     "username": "codecov",
+    #                 },
+    #                 "service_id": "460565350",
+    #                 "private": False,
+    #             },
+    #             {
+    #                 "branch": "main",
+    #                 "language": "python",
+    #                 "name": "worker",
+    #                 "owner": {
+    #                     "is_expected_owner": False,
+    #                     "node_id": "MDEyOk9yZ2FuaXphdGlvbjgyMjYyMDU=",
+    #                     "service_id": "8226205",
+    #                     "username": "codecov",
+    #                 },
+    #                 "service_id": "665728948",
+    #                 "private": False,
+    #             },
+    #             {
+    #                 "branch": "main",
+    #                 "language": "python",
+    #                 "name": "components-demo",
+    #                 "owner": {
+    #                     "is_expected_owner": True,
+    #                     "node_id": "U_kgDOBfIxWg",
+    #                     "username": "giovanni-guidini",
+    #                 },
+    #                 "service_id": "553624697",
+    #                 "private": False,
+    #             },
+    #         ]
+    #         for r in results:
+    #             yield r
 
-        mock_owner_provider.get_repos_from_nodeids_generator.side_effect = side_effect
-        mock_owner_provider.service = "github"
+    #     mock_owner_provider.get_repos_from_nodeids_generator.side_effect = side_effect
+    #     mock_owner_provider.service = "github"
 
-        SyncReposTask().run_impl(
-            dbsession,
-            ownerid=user.ownerid,
-            using_integration=True,
-            repository_service_ids=repository_service_ids,
-        )
-        dbsession.commit()
+    #     SyncReposTask().run_impl(
+    #         dbsession,
+    #         ownerid=user.ownerid,
+    #         using_integration=True,
+    #         repository_service_ids=repository_service_ids,
+    #     )
+    #     dbsession.commit()
 
-        mock_owner_provider.get_repos_from_nodeids_generator.assert_called_with(
-            ["R_kgDOG3OrZg", "R_kgDOJ643tA", "R_kgDOIP-keQ"], user.username
-        )
+    #     mock_owner_provider.get_repos_from_nodeids_generator.assert_called_with(
+    #         ["R_kgDOG3OrZg", "R_kgDOJ643tA", "R_kgDOIP-keQ"], user.username
+    #     )
 
-        repos = (
-            dbsession.query(Repository)
-            .filter(Repository.service_id.in_(service_ids))
-            .all()
-        )
-        repos_added = list(
-            filter(lambda repo: repo.service_id in service_ids_to_add, repos)
-        )
-        assert len(repos) == 5
+    #     repos = (
+    #         dbsession.query(Repository)
+    #         .filter(Repository.service_id.in_(service_ids))
+    #         .all()
+    #     )
+    #     repos_added = list(
+    #         filter(lambda repo: repo.service_id in service_ids_to_add, repos)
+    #     )
+    #     assert len(repos) == 5
 
-        mocked_app.tasks[sync_repo_languages_gql_task_name].apply_async.calls(
-            [
-                call(
-                    kwargs={
-                        "current_owner_id": user.ownerid,
-                        "org_username": user.ownerid,
-                    }
-                )
-                for repo in repos_added
-            ]
-        )
+    #     mocked_app.tasks[sync_repo_languages_gql_task_name].apply_async.calls(
+    #         [
+    #             call(
+    #                 kwargs={
+    #                     "current_owner_id": user.ownerid,
+    #                     "org_username": user.ownerid,
+    #                 }
+    #             )
+    #             for repo in repos_added
+    #         ]
+    #     )
 
-        upserted_owner = (
-            dbsession.query(Owner)
-            .filter(Owner.service == "github", Owner.service_id == "8226205")
-            .first()
-        )
-        assert upserted_owner is not None
-        assert upserted_owner.username == "codecov"
+    #     upserted_owner = (
+    #         dbsession.query(Owner)
+    #         .filter(Owner.service == "github", Owner.service_id == "8226205")
+    #         .first()
+    #     )
+    #     assert upserted_owner is not None
+    #     assert upserted_owner.username == "codecov"
 
     @pytest.mark.django_db(databases={"default"})
     def test_sync_repos_with_feature_flag_django_call(


### PR DESCRIPTION
These changes:

* fix a bug in the sync_repos with integration when the list of repos affected is known.
* makes the previous behavior (of listing all repos) active again even in case we have the list of affected repos. This is so that the app can fix itself if we have difference between the repos we think the installation covers and the repos we can acutally list using it.
