### PR TITLE
fallback to assuming repo is covered

### DIFF
--- a/services/bots.py
+++ b/services/bots.py
@@ -106,6 +106,14 @@ def get_owner_installation_id(
     # And might get out-of-sync soon
     ignore_installation: bool = False
 ) -> Optional[Dict]:
+    """Gets the installation information for an owner with the name specified and
+    guaranteeing that it covers the repository specified (if any).
+    EXCLUSIVE to GitHub and GitHub Enterprise owners.
+
+    Owner's GithubAppInstallation are created by the api in response to webhooks received from Github.
+
+    !raises: NoConfiguredAppsAvailable
+    """
 
     log.info(
         "Getting owner installation id",

--- a/services/repository.py
+++ b/services/repository.py
@@ -19,6 +19,7 @@ from database.models.core import (
     GITHUB_APP_INSTALLATION_DEFAULT_NAME,
     GithubAppInstallation,
 )
+from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.token_refresh import get_token_refresh_callback
 from services.bots import (
     get_owner_installation_id,
@@ -63,7 +64,35 @@ def get_repo_provider_service(
         ignore_installation=False,
         installation_name=installation_name_to_use,
     )
-    token, token_owner = get_repo_appropriate_bot_token(repository, installation_info)
+    print("INSTALLATION INFO", installation_info)
+    try:
+        token, token_owner = get_repo_appropriate_bot_token(
+            repository, installation_info
+        )
+    except RepositoryWithoutValidBotError:
+        installation_info_without_considering_repo = get_owner_installation_id(
+            repository.owner,
+            False,
+            repository=None,
+            ignore_installation=False,
+            installation_name=installation_name_to_use,
+        )
+        print("INSTALLATION INFO (no repo)", installation_info_without_considering_repo)
+
+        if installation_info_without_considering_repo:
+            log.warning(
+                "Got installation for owner without considering repo",
+                extra=dict(
+                    ownerid=repository.owner.ownerid,
+                    repoid=repository.repoid,
+                    installation_info=installation_info_without_considering_repo,
+                ),
+            )
+            token, token_owner = get_repo_appropriate_bot_token(
+                repository, installation_info_without_considering_repo
+            )
+            # for the fallback options
+            installation_info = installation_info_without_considering_repo
     adapter_params = dict(
         repo=dict(
             name=repository.name,
@@ -87,9 +116,11 @@ def get_repo_provider_service(
             secret=get_config(service, "client_secret"),
         ),
         on_token_refresh=get_token_refresh_callback(token_owner),
-        fallback_installations=installation_info.get("fallback_installations")
-        if installation_info
-        else None,
+        fallback_installations=(
+            installation_info.get("fallback_installations")
+            if installation_info
+            else None
+        ),
     )
     return _get_repo_provider_service_instance(repository.service, **adapter_params)
 


### PR DESCRIPTION
I suspect that we might have a little bug in some situations when syncing repos using integration.

Let's assume that suspicion is true and we might have repos not properly sinced in the installation.
These changes aim to not break the app in a specific scenario:
- Org installs Codecov App (not selecting all repos)
- Org admin logs in and sets up a new repo
- For some reason we fail to sync the repo and the installation list of repos. Maybe we missed a webhook? Would be the only possibility really... but maybe the admin logging in would actually make the repo appear in the DB, even missing the webhook.
- App is still broken cause the ORG never logged in, and the repo is not marked as "covered" by the installation

The changes here would fix that scenario by ignoring the repo when selecting the token to communicate with GH.
Ideally we fix the sync process and remove this fix, of course.

Notice that if the owner HAS a token or bot than we use that instead.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.