### PR TITLE
fix: Flake detection failure messages

### DIFF
--- a/services/flake_detection.py
+++ b/services/flake_detection.py
@@ -120,10 +120,10 @@ class TestDictObject:
 
 
 class UnrelatedMatchesDetector(BaseSymptomDetector):
-    def __init__(self, failure_normalizer=None):
+    def __init__(self, failure_normalizer: FailureNormalizer | None = None):
         self.state = defaultdict(lambda: defaultdict(TestDictObject))
         self.res = defaultdict(list)
-        self.failure_normalizer: FailureNormalizer | None = failure_normalizer
+        self.failure_normalizer = failure_normalizer
 
     def ingest(self, instance):
         outcome = instance.TestInstance.outcome

--- a/services/flake_detection.py
+++ b/services/flake_detection.py
@@ -11,6 +11,7 @@ from test_results_parser import Outcome
 from database.enums import FlakeSymptomType
 from database.models.core import Commit, Repository
 from database.models.reports import CommitReport, Test, TestInstance, Upload
+from services.failure_normalizer import FailureNormalizer
 
 log = getLogger(__name__)
 
@@ -119,19 +120,26 @@ class TestDictObject:
 
 
 class UnrelatedMatchesDetector(BaseSymptomDetector):
-    def __init__(self):
+    def __init__(self, failure_normalizer=None):
         self.state = defaultdict(lambda: defaultdict(TestDictObject))
         self.res = defaultdict(list)
+        self.failure_normalizer: FailureNormalizer | None = failure_normalizer
 
     def ingest(self, instance):
         outcome = instance.TestInstance.outcome
         if outcome == str(Outcome.Failure) or outcome == str(Outcome.Error):
-            test_id = instance.TestInstance.test_id
-            fail = instance.TestInstance.failure_message
-            branch = instance.branch
+            if instance.TestInstance.failure_message is not None:
+                test_id = instance.TestInstance.test_id
+                if self.failure_normalizer is not None:
+                    fail = self.failure_normalizer.normalize_failure_message(
+                        instance.TestInstance.failure_message
+                    )
+                else:
+                    fail = instance.TestInstance.failure_message
+                branch = instance.branch
 
-            self.state[test_id][fail].branches.add(branch)
-            self.state[test_id][fail].instances.append(instance.TestInstance)
+                self.state[test_id][fail].branches.add(branch)
+                self.state[test_id][fail].instances.append(instance.TestInstance)
 
     def detect(self):
         for test_id, test_dict in self.state.items():
@@ -157,11 +165,9 @@ class FlakeDetectionEngine:
         db_session,
         repoid,
         symptom_detectors: list[BaseSymptomDetector],
-        failure_normalizer=None,
     ):
         self.db_session = db_session
         self.repoid = repoid
-        self.failure_normalizer = failure_normalizer
         self.symptom_detectors = symptom_detectors
 
     @trace

--- a/services/tests/test_flake_detector.py
+++ b/services/tests/test_flake_detector.py
@@ -99,10 +99,10 @@ def test_flake_detector_failure_on_main(dbsession):
     )
 
     dbfd = DefaultBranchFailureDetector(dbsession, repoid, "main")
-    umd = UnrelatedMatchesDetector()
+    umd = UnrelatedMatchesDetector(None)
     dod = DiffOutcomeDetector()
 
-    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd], None)
+    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd])
     flaky_tests = fd.detect_flakes()
 
     assert test_id in flaky_tests
@@ -128,7 +128,7 @@ def test_flake_consecutive_differing_outcomes(dbsession):
     umd = UnrelatedMatchesDetector()
     dod = DiffOutcomeDetector()
 
-    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd], None)
+    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd])
     flaky_tests = fd.detect_flakes()
 
     assert test_id in flaky_tests
@@ -154,7 +154,7 @@ def test_flake_consecutive_differing_outcomes_no_main_branch_specified(dbsession
     umd = UnrelatedMatchesDetector()
     dod = DiffOutcomeDetector()
 
-    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd], None)
+    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd])
     flaky_tests = fd.detect_flakes()
 
     assert test_id in flaky_tests
@@ -180,7 +180,7 @@ def test_flake_consecutive_differing_outcomes_no_main_branch_specified(dbsession
     umd = UnrelatedMatchesDetector()
     dod = DiffOutcomeDetector()
 
-    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd], None)
+    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd])
     flaky_tests = fd.detect_flakes()
 
     assert test_id in flaky_tests
@@ -218,7 +218,7 @@ def test_flake_matching_failures_on_unrelated_branches(dbsession):
     umd = UnrelatedMatchesDetector()
     dod = DiffOutcomeDetector()
 
-    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd], None)
+    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd])
     flaky_tests = fd.detect_flakes()
 
     assert test_id in flaky_tests
@@ -259,7 +259,7 @@ def test_flake_matching_failures_on_related_branches(dbsession):
     umd = UnrelatedMatchesDetector()
     dod = DiffOutcomeDetector()
 
-    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd], None)
+    fd = FlakeDetectionEngine(dbsession, repoid, [dbfd, dod, umd])
     flaky_tests = fd.detect_flakes()
 
     assert len(flaky_tests) == 0

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -310,7 +310,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         default_branch_failure_detector = DefaultBranchFailureDetector(
             db_session, repoid, "main"
         )
-        unrelated_matches_detector = UnrelatedMatchesDetector()
+        unrelated_matches_detector = UnrelatedMatchesDetector(failure_normalizer)
         diff_outcome_detector = DiffOutcomeDetector()
 
         flake_detection_engine = FlakeDetectionEngine(
@@ -321,7 +321,6 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
                 unrelated_matches_detector,
                 diff_outcome_detector,
             ],
-            failure_normalizer,
         )
 
         log.info(


### PR DESCRIPTION
- If failure message is None ignore the test instance in the UnrelatedMatchesDetector, the information is just not there so we can't use this test instance

- Normalize failure messages in the ingest in UnrelatedMatchesDetector, we should have been doing this already
