### PR TITLE
feat: make comparison session agnostic by only comparing the totals

### DIFF
--- a/tasks/parallel_verification.py
+++ b/tasks/parallel_verification.py
@@ -101,10 +101,14 @@ class ParallelVerificationTask(BaseCodecovTask, name=parallel_verification_task_
         # file level totals comparison
         for filename, file_summary in parallel_report._files.items():
             parallel_file_level_totals = file_summary.file_totals
-            serial_file_level_totals = serial_report._files[filename].file_totals
 
-            if serial_file_level_totals != parallel_file_level_totals:
-                file_level_mismatched_files.append(filename)
+            if filename in serial_report._files:
+                serial_file_level_totals = serial_report._files[filename].file_totals
+
+                if serial_file_level_totals != parallel_file_level_totals:
+                    file_level_mismatched_files.append(filename)
+                    file_level_totals_match = False
+            else:
                 file_level_totals_match = False
 
         if len(parallel_report._files) != len(serial_report._files):

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -486,7 +486,17 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
             incremental_report = obj["report"]
             parallel_idx = obj["parallel_idx"]
 
-            assert len(incremental_report.sessions) == 1
+            if len(incremental_report.sessions) != 1:
+                log.warn(
+                    f"Incremental report does not have 1 session, it has {len(incremental_report.sessions)}",
+                    extra=dict(
+                        repoid=repoid,
+                        commit=commitid,
+                        upload_pk=obj["upload_pk"],
+                        parallel_idx=obj["parallel_idx"],
+                    ),
+                )
+
             sessionid = next(iter(incremental_report.sessions))
             incremental_report.sessions[sessionid].id = sessionid
 
@@ -499,7 +509,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 cumulative_report, incremental_report, session, UserYaml(commit_yaml)
             )
             # ReportService.update_upload_with_processing_result should use this result
-            # to update the state of Upload. Once the experiement is finished, it should
+            # to update the state of Upload. Once the experiement is finished, Upload.state should
             # be set to: parallel_processed (instead of processed)
 
             cumulative_report.merge(incremental_report)


### PR DESCRIPTION
<!-- Describe your PR here. -->

For the parallel upload processing verification experiment, I am changing how the outputs of the parallel vs serial flow are compared. 

Instead of comparing exactly the report json and chunks.txt of our reports, I compare the top level totals of coverage, and the file level totals for each file instead. This way, even if the way we assign session ids to uploads in the parallel flow differs from the serial flow (which would've caused a diff in the old comparison method), the coverage totals should hopefully still be the same indicating that the processing was successful.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.