### PR TITLE
fix: avoid crashing when analyzing sqlalchemy errors

### DIFF
--- a/tasks/base.py
+++ b/tasks/base.py
@@ -204,14 +204,18 @@ class BaseCodecovTask(celery_app.Task):
         try:
             import psycopg2
 
-            if isinstance(exception.orig, psycopg2.errors.DeadlockDetected):
+            if exception.orig and isinstance(
+                exception.orig, psycopg2.errors.DeadlockDetected
+            ):
                 log.exception(
                     "Deadlock while talking to database",
                     extra=dict(task_args=args, task_kwargs=kwargs),
                     exc_info=True,
                 )
                 return
-            elif isinstance(exception.orig, psycopg2.OperationalError):
+            elif exception.orig and isinstance(
+                exception.orig, psycopg2.OperationalError
+            ):
                 log.warning(
                     "Database seems to be unavailable",
                     extra=dict(task_args=args, task_kwargs=kwargs),

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -204,7 +204,7 @@ class BaseCodecovTask(celery_app.Task):
         try:
             import psycopg2
 
-            if exception.orig and isinstance(
+            if hasattr(exception, "orig") and isinstance(
                 exception.orig, psycopg2.errors.DeadlockDetected
             ):
                 log.exception(
@@ -213,7 +213,7 @@ class BaseCodecovTask(celery_app.Task):
                     exc_info=True,
                 )
                 return
-            elif exception.orig and isinstance(
+            elif hasattr(exception, "orig") and isinstance(
                 exception.orig, psycopg2.OperationalError
             ):
                 log.warning(


### PR DESCRIPTION
there are errors in sentry because we try to access `exception.orig` when the property does not exist

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.