### PR TITLE
hotfix: avoid double inserts when sync_repos

### DIFF
--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -174,17 +174,9 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
         async for repo_data in git.get_repos_from_nodeids_generator(
             repos_to_search, owner.username
         ):
-            # Insert those repos
-            new_repo = Repository(
-                service_id=repo_data["service_id"],
-                name=repo_data["name"],
-                language=repo_data["language"],
-                private=repo_data["private"],
-                branch=repo_data["branch"],
-                using_integration=True,
-            )
+            # Get or create owner
             if repo_data["owner"]["is_expected_owner"]:
-                new_repo.ownerid = owner.ownerid
+                new_repo_ownerid = owner.ownerid
             else:
                 upserted_owner_id = self.upsert_owner(
                     db_session,
@@ -192,10 +184,18 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
                     repo_data["owner"]["service_id"],
                     repo_data["owner"]["username"],
                 )
-                new_repo.ownerid = upserted_owner_id
-            db_session.add(new_repo)
-            db_session.flush()
-            repoids_added.append(new_repo.repoid)
+                new_repo_ownerid = upserted_owner_id
+            # Get or create repo
+            # Yes we had issues trying to insert a repeated repo at this point.
+            # Maybe race condition?
+            repoid = self.upsert_repo(
+                db_session=db_session,
+                service=git.service,
+                ownerid=new_repo_ownerid,
+                repo_data={**repo_data, "service_id": str(repo_data["service_id"])},
+                using_integration=True,
+            )
+            repoids_added.append(repoid)
         return repoids_added
 
     def _possibly_update_ghinstallation_covered_repos(


### PR DESCRIPTION
Sync_repos when the repos affected are knows is acting up.
Unsure if it's the filtering logic OR a race condition OR if something else
is inserting the repo.

We will be moving to `upsert_repo` to avoid this issue.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.