### PR TITLE
fix: copy raw reports for parallel experiment

### DIFF
--- a/helpers/parallel_upload_processing.py
+++ b/helpers/parallel_upload_processing.py
@@ -117,9 +117,10 @@ def save_final_serial_report_results(
         report_code,
         f"serial/chunks<latest_upload_pk:{latest_upload_pk}>",
     )
-    archive_service.write_parallel_experiment_file(
+    report_url = archive_service.write_parallel_experiment_file(
         commitid,
         files_and_sessions,
         report_code,
         f"serial/files_and_sessions<latest_upload_pk:{latest_upload_pk}>",
     )
+    return report_url

--- a/services/report/parser/__init__.py
+++ b/services/report/parser/__init__.py
@@ -3,9 +3,7 @@ from services.report.parser.legacy import LegacyReportParser
 from services.report.parser.version_one import VersionOneReportParser
 
 
-def get_proper_parser(upload: Upload, use_legacy=None):
-    if use_legacy:
-        return LegacyReportParser()
+def get_proper_parser(upload: Upload):
     if upload.upload_extras and upload.upload_extras.get("format_version") == "v1":
         return VersionOneReportParser()
     return LegacyReportParser()

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -555,7 +555,7 @@ class TestUploadProcessorTask(object):
         assert upload.state_id == UploadState.ERROR.db_id
         assert upload.state == "error"
         assert not mocked_3.called
-        mocked_4.assert_called_with(commit.repository, upload)
+        mocked_4.assert_called_with(commit.repository, upload, is_error_case=True)
         mocked_5.assert_called()
 
     @pytest.mark.django_db(databases={"default"})


### PR DESCRIPTION
<!-- Describe your PR here. -->

Explicitly make a copy of the raw reports so that the parallel pipeline can parse those raw reports instead of the ones that get rewritten by the serial flow (which are rewritten as the "legacy" format)

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.