### PR TITLE
chore: add more logs

### DIFF
--- a/tasks/parallel_verification.py
+++ b/tasks/parallel_verification.py
@@ -94,8 +94,12 @@ class ParallelVerificationTask(BaseCodecovTask, name=parallel_verification_task_
         file_level_totals_match = True
         file_level_mismatched_files = []
 
-        # top level totals comparison
-        if parallel_report.totals.astuple() != serial_report.totals.astuple():
+        # top level totals comparison (ignoring session total, index 9)
+        parallel_tlt = list(parallel_report.totals.astuple())
+        parallel_tlt[9] = 0
+        serial_tlt = list(serial_report.totals.astuple())
+        serial_tlt[9] = 0
+        if parallel_tlt != serial_tlt:
             top_level_totals_match = False
 
         # file level totals comparison

--- a/tasks/parallel_verification.py
+++ b/tasks/parallel_verification.py
@@ -96,8 +96,10 @@ class ParallelVerificationTask(BaseCodecovTask, name=parallel_verification_task_
 
         # top level totals comparison (ignoring session total, index 9)
         parallel_tlt = list(parallel_report.totals.astuple())
-        parallel_tlt[9] = 0
         serial_tlt = list(serial_report.totals.astuple())
+        parallel_tlt[
+            9
+        ] = 0  # 9th index is session total for shared.reports.types.ReportTotals
         serial_tlt[9] = 0
         if parallel_tlt != serial_tlt:
             top_level_totals_match = False


### PR DESCRIPTION
<!-- Describe your PR here. -->

adds more logs so I can debug why verification failed [here](https://console.cloud.google.com/logs/query;query=--%20jsonPayload.message%3D~%22upload%20processing%20verification%22%0A--%20SEARCH%2528%22e57388b2215634015d8cab247af82539d537bc93%22%2529%0A--%20SEARCH%2528%22%60f6da0a27-7857-4ec0-814a-303bd84f7956%60%22%2529%0A--%20jsonPayload.task_id%3D%22a65dcacf-d044-40f0-83fd-762e05bcd72f%22%0ASEARCH%2528%22c234888b170f7fd2db0bb8fba6a93ba45b2a1d30%22%2529;summaryFields=:false:32:beginning;lfeCustomFields=labels%252F%2522k8s-pod%252Frollouts-pod-template-hash%2522,labels%252F%2522k8s-pod%252Fversion%2522;cursorTimestamp=2024-04-26T14:17:49.696863123Z;duration=PT1H?project=genuine-polymer-165712&rapt=AEjHL4MlnhLMl5L8I7Z65VM2i8ALk_F2WmI63QqvOVZttROSTbmOjDXfGg68YKZ1rbWh40UzHftqVStzdKOUWsj1vIX0qnx_tTO9q_uXZo4kqM_fAQNJxtU).

Also ignore the top-level sessions total when doing comparisons (we care about coverage)

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.