### PR TITLE
chore: extend UploadFlow with new ending

### DIFF
--- a/helpers/checkpoint_logger/flows.py
+++ b/helpers/checkpoint_logger/flows.py
@@ -19,7 +19,11 @@ from helpers.checkpoint_logger import (
     "NOTIF_ERROR_NO_REPORT",
 )
 @success_events(
-    "SKIPPING_NOTIFICATION", "NOTIFIED", "NO_PENDING_JOBS", "NOTIF_STALE_HEAD"
+    "SKIPPING_NOTIFICATION",
+    "NOTIFIED",
+    "NO_PENDING_JOBS",
+    "NOTIF_STALE_HEAD",
+    "NO_REPORTS_FOUND",
 )
 @subflows(
     ("time_before_processing", "UPLOAD_TASK_BEGIN", "PROCESSING_BEGIN"),
@@ -36,6 +40,7 @@ from helpers.checkpoint_logger import (
 class UploadFlow(BaseFlow):
     UPLOAD_TASK_BEGIN = auto()
     NO_PENDING_JOBS = auto()
+    NO_REPORTS_FOUND = auto()
     TOO_MANY_RETRIES = auto()
     PROCESSING_BEGIN = auto()
     INITIAL_PROCESSING_COMPLETE = auto()

--- a/services/lock_manager.py
+++ b/services/lock_manager.py
@@ -87,7 +87,7 @@ class LockManager:
                 )
         except LockError:
             max_retry = 200 * 3**retry_num
-            countdown = min(random.randint(max_retry / 2, max_retry), 60 * 60 * 5)
+            countdown = min(random.randint(max_retry // 2, max_retry), 60 * 60 * 5)
 
             log.warning(
                 "Unable to acquire lock",

--- a/tasks/tests/unit/test_save_commit_measurements.py
+++ b/tasks/tests/unit/test_save_commit_measurements.py
@@ -23,8 +23,8 @@ class TestSaveCommitMeasurements(object):
         assert task.run_impl(
             dbsession, commitid=commit.commitid, repoid=commit.repoid
         ) == {"successful": True}
-        assert save_commit_measurements_mock.called_with(
-            commitid=commit.commitid, dataset_names=None
+        save_commit_measurements_mock.assert_called_with(
+            commit=commit, dataset_names=None
         )
 
     def test_save_commit_measurements_no_commit(self, dbsession):

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime, timedelta
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import mock
 import pytest
@@ -1057,16 +1058,24 @@ class TestUploadTaskUnit(object):
         assert b"Some weird value" == content
 
     @pytest.mark.django_db(databases={"default"})
-    def test_schedule_task_with_no_tasks(self, dbsession):
+    def test_schedule_task_with_no_tasks(self, dbsession, mocker):
         commit = CommitFactory.create()
         commit_yaml = UserYaml({})
         argument_list = []
         dbsession.add(commit)
         dbsession.flush()
+        mock_checkpoints = MagicMock(name="checkpoints")
         result = UploadTask().schedule_task(
-            commit, commit_yaml, argument_list, ReportFactory.create(), None, dbsession
+            commit,
+            commit_yaml,
+            argument_list,
+            ReportFactory.create(),
+            None,
+            dbsession,
+            checkpoints=mock_checkpoints,
         )
         assert result is None
+        mock_checkpoints.log.assert_called_with(UploadFlow.NO_REPORTS_FOUND)
 
     @pytest.mark.django_db(databases={"default"})
     def test_schedule_task_with_one_task(self, dbsession, mocker):

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -660,6 +660,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         for i in range(0, len(argument_list), chunk_size):
             chunk = argument_list[i : i + chunk_size]
             if chunk:
+                is_final = i == ceil(len(argument_list) / chunk_size) - 1
                 sig = upload_processor_task.signature(
                     args=({},) if i == 0 else (),
                     kwargs=dict(
@@ -669,11 +670,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                         arguments_list=chunk,
                         report_code=commit_report.code,
                         in_parallel=False,
-                        is_final=(
-                            True
-                            if i == ceil(len(argument_list) / chunk_size) - 1
-                            else False
-                        ),
+                        is_final=is_final,
                     ),
                 )
                 processing_tasks.append(sig)


### PR DESCRIPTION
It was a suspition that we might be overcounting beginnings in the UploadFlow.
I believe one of the exit paths was not being covered in the `Upload` task.

These changes add a new ending to the UploadFlow. Namely, for the scenario where
an UploadTask finishes without enqueuing other tasks because there are no reports
waiting to be processed.

Also updating the `getutcnow` function that is deprecated and fixing some typos.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.