### PR TITLE
fix: always select fallback if available

### DIFF
--- a/services/bots.py
+++ b/services/bots.py
@@ -38,14 +38,17 @@ def _get_installation_weight(installation: GithubAppInstallation) -> int:
         return MAX_GITHUB_APP_SELECTION_WEIGHT
     seconds_in_hour = 3600
     age_hours = (age.seconds // seconds_in_hour) + age.days * 24
-    return age_hours + 2**age.days
+    # Prevent clock differences from making the weight negative
+    return max(1, age_hours + 2**age.days)
 
 
 def _get_apps_from_weighted_selection(
     owner: Owner, installation_name: str, repository: Optional[Repository]
 ) -> List[GithubAppInstallation]:
-    ghapp_installations_filter: List[GithubAppInstallation] = list(
-        filter(
+    # Map GithubAppInstallation.id --> GithubAppInstallation
+    ghapp_installations_filter: Dict[int, GithubAppInstallation] = {
+        obj.id: obj
+        for obj in filter(
             lambda obj: (
                 obj.name == installation_name
                 and obj.is_configured()
@@ -58,23 +61,33 @@ def _get_apps_from_weighted_selection(
             ),
             owner.github_app_installations or [],
         )
-    )
+    }
     # We assign weights to the apps based on how long ago they were created.
     # The idea is that there's a greater chance that a change misconfigured the app,
     # So apps recently created are selected less frequently than older apps
+    keys = list(ghapp_installations_filter.keys())
     weights = [
-        min(MAX_GITHUB_APP_SELECTION_WEIGHT, _get_installation_weight(obj))
-        for obj in ghapp_installations_filter
+        min(
+            MAX_GITHUB_APP_SELECTION_WEIGHT,
+            _get_installation_weight(ghapp_installations_filter[key]),
+        )
+        for key in keys
     ]
-    # Random selection of size 3.
-    # If all apps have roughly the same probability of being selected, the array would have different entries.
-    # If 1 app dominates the probability of selection than it would probably be that app repeated 3 times, BUT
-    # from time to time the less frequent one would be selected.
-    apps_to_consider = (
-        random.choices(ghapp_installations_filter, weights=weights, k=3)
-        if len(ghapp_installations_filter) > 0
-        else []
-    )
+    # We pick apps one by one until all apps have been selected
+    # Obviously apps with a higher weight have a higher change of being selected as the main app (1st selection)
+    # But it's important that others are also selected so we can use them as fallbacks
+    apps_to_consider = []
+    if keys:
+        while len(keys) > 1:
+            selected_app_id = random.choices(keys, weights, k=1)[0]
+            apps_to_consider.append(ghapp_installations_filter[selected_app_id])
+            # random.choices chooses with replacement
+            # which we are trying to avoid here. So we remove the key selected and its weight from the population.
+            key_idx = keys.index(selected_app_id)
+            keys.pop(key_idx)
+            weights.pop(key_idx)
+        # The app remaining is the last choice
+        apps_to_consider.append(ghapp_installations_filter[keys[0]])
     if installation_name != GITHUB_APP_INSTALLATION_DEFAULT_NAME:
         # Add the default app as the last fallback if the owner is using a different app for the task
         default_apps = filter(
@@ -83,15 +96,7 @@ def _get_apps_from_weighted_selection(
         )
         if default_apps:
             apps_to_consider.extend(default_apps)
-    # Now we de-duplicate the apps_to_consider list before returning
-    seen_ids = dict()
-    list_to_return = []
-    for app in apps_to_consider:
-        if seen_ids.get(app.id, False):
-            continue
-        seen_ids[app.id] = True
-        list_to_return.append(app)
-    return list_to_return
+    return apps_to_consider
 
 
 def get_owner_installation_id(

--- a/services/tests/test_bots.py
+++ b/services/tests/test_bots.py
@@ -594,6 +594,13 @@ class TestBotsService(BaseTestCase):
         for _ in range(1000):
             installation_dict = get_owner_installation_id(owner, False)
             assert installation_dict is not None
+            # Regardless of the app we choose we want the other one
+            # to be listed as a fallback option
+            assert installation_dict["fallback_installations"] != []
+            assert (
+                installation_dict["installation_id"]
+                != installation_dict["fallback_installations"][0]["installation_id"]
+            )
             id_chosen = installation_dict["installation_id"]
             choices[id_chosen] += 1
         # Assert that both apps can be selected


### PR DESCRIPTION
Because `random.choices` makes selections with replacement and we were making 3 selections only
there was a chance that an app would vanish from the choices (from not being selected).
This is bad because it hides this app as a possible fallbakc option.

Particularly if the choice is marked currently as "rate limited" we would fail with exception
instead of falling back in the other app. We want the fallback.

These changes go around this "choice with selection" by removing the selected app from the
population after each step. It's maybe slower (in practice the population will be small enough
that this doesn't really matter), but makes sure that we always select all available apps.
And still respectes the weighted selection.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.