### PR TITLE
Update test instances to use local commitid and branch fields

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -113,6 +113,7 @@ trial_expiration_task_name = "app.tasks.plan.TrialExpirationTask"
 trial_expiration_cron_task_name = "app.cron.plan.TrialExpirationCronTask"
 
 update_branches_task_name = "app.cron.branches.UpdateBranchesTask"
+update_branches_task_name = "app.cron.test_instances.BackfillTestInstancesTask"
 
 
 def _beat_schedule():

--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -303,6 +303,8 @@ class TestInstance(CodecovBaseModel, MixinBaseClass):
     upload_id = Column(types.Integer, ForeignKey("reports_upload.id"))
     upload = relationship("Upload", backref=backref("testinstances"))
     failure_message = Column(types.Text)
+    branch = Column(types.Text, nullable=True)
+    commitid = Column(types.Text, nullable=True)
 
 
 class TestResultReportTotals(CodecovBaseModel, MixinBaseClass):

--- a/tasks/backfill_test_instances.py
+++ b/tasks/backfill_test_instances.py
@@ -1,0 +1,53 @@
+import logging
+
+from shared.django_apps.reports.models import TestInstance
+from sqlalchemy import desc
+
+from app import celery_app
+from celery_config import backfill_test_instances_task_name
+from tasks.base import BaseCodecovTask
+
+log = logging.getLogger(__name__)
+
+
+class BackfillTestInstancesTask(
+    BaseCodecovTask, name=backfill_test_instances_task_name
+):
+    def run_impl(self, *args, dry_run=True, **kwargs):
+        log.info(
+            "Updating test instances",
+        )
+
+        test_instance_filter = TestInstance.objects.select_related(
+            "upload__report__commit"
+        ).filter(
+            branch=None,
+            commitid=None,
+        )
+        num_test_instances = test_instance_filter.count()
+        all_test_instances = test_instance_filter.all()
+
+        chunk_size = 1000
+
+        chunks = [
+            all_test_instances[i : i + chunk_size]
+            for i in range(0, num_test_instances, chunk_size)
+        ]
+
+        for chunk in chunks:
+            for test_instance in chunk:
+                test_instance.branch = test_instance.upload.report.commit.branch
+                test_instance.commitid = test_instance.upload.report.commit.commitid
+            TestInstance.objects.bulk_update(chunk, ["branch", "commit"])
+
+        log.info(
+            "Done updating test instances",
+        )
+
+        return {"successful": True}
+
+
+RegisteredTrialExpirationCronTask = celery_app.register_task(
+    BackfillTestInstancesTask()
+)
+backfill_test_instances_task = celery_app.tasks[BackfillTestInstancesTask.name]

--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -101,7 +101,9 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
         self,
         db_session: Session,
         repoid: int,
+        commitid: str,
         upload_id: int,
+        branch: str,
         parsed_testruns: List[Testrun],
         flags_hash: str,
     ):
@@ -136,6 +138,8 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
                         duration_seconds=duration_seconds,
                         outcome=outcome,
                         failure_message=failure_message,
+                        commitid=commitid,
+                        branch=branch,
                     )
                 )
 
@@ -185,8 +189,9 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
             }
         flags_hash = generate_flags_hash(upload_obj.flag_names)
         upload_id = upload_obj.id
+        branch = upload_obj.report.commit.branch
         self._bulk_write_tests_to_db(
-            db_session, repoid, upload_id, parsed_testruns, flags_hash
+            db_session, repoid, commitid, upload_id, branch, parsed_testruns, flags_hash
         )
 
         return {


### PR DESCRIPTION
We want to move the commitid and branch information for a test instance to directly on the object, so that when we query we don't have to join with the commits table.