### PR TITLE
Reduce the number of runs for collecting profiles

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -128,7 +128,7 @@ def _beat_schedule():
         },
         "find_uncollected_profilings": {
             "task": profiling_finding_task_name,
-            "schedule": crontab(minute="0,15,30,45"),
+            "schedule": crontab(minute="15"),
             "kwargs": {
                 "cron_task_generation_time_iso": BeatLazyFunc(get_utc_now_as_iso_format)
             },


### PR DESCRIPTION
This is to reduce the number of times we run an unperformant query.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.