### PR TITLE
feat: add task gh_app_name override for more tasks

### DIFF
--- a/helpers/github_installation.py
+++ b/helpers/github_installation.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional
 
 from sqlalchemy.orm import Session
@@ -8,6 +9,8 @@ from database.models.core import (
     OwnerInstallationNameToUseForTask,
 )
 from helpers.cache import cache
+
+log = logging.getLogger(__file__)
 
 
 @cache.cache_function(ttl=86400)  # 1 day
@@ -23,5 +26,9 @@ def get_installation_name_for_owner_for_task(
         .first()
     )
     if config_for_owner:
+        log.info(
+            "Owner has dedicated app for this task",
+            extra=dict(this_task=task_name, ownerid=owner.ownerid),
+        )
         return config_for_owner.installation_name
     return GITHUB_APP_INSTALLATION_DEFAULT_NAME

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -23,6 +23,7 @@ from shared.yaml import UserYaml
 
 from database.enums import ReportType
 from database.models import Commit, CommitReport, Repository, Upload, UploadError
+from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
 from services.archive import ArchiveService
 from services.report import BaseReportService
 from services.repository import (
@@ -275,9 +276,17 @@ class BundleRows:
 
 
 class Notifier:
-    def __init__(self, commit: Commit, current_yaml: UserYaml):
+    def __init__(
+        self,
+        commit: Commit,
+        current_yaml: UserYaml,
+        gh_app_installation_name: str | None = None,
+    ):
         self.commit = commit
         self.current_yaml = current_yaml
+        self.gh_app_installation_name = (
+            gh_app_installation_name or GITHUB_APP_INSTALLATION_DEFAULT_NAME
+        )
 
     @cached_property
     def repository(self) -> Repository:
@@ -289,7 +298,10 @@ class Notifier:
 
     @cached_property
     def repository_service(self) -> TorngitBaseAdapter:
-        return get_repo_provider_service(self.commit.repository)
+        return get_repo_provider_service(
+            self.commit.repository,
+            installation_name_to_use=self.gh_app_installation_name,
+        )
 
     @cached_property
     def bundle_analysis_loader(self):

--- a/services/comparison/overlays/__init__.py
+++ b/services/comparison/overlays/__init__.py
@@ -8,5 +8,8 @@ class OverlayType(Enum):
 
 
 def get_overlay(overlay_type: OverlayType, comparison, **kwargs):
+    """
+    @param comparison: ComparisonProxy (not imported due to circular imports)
+    """
     if overlay_type == OverlayType.line_execution_count:
         return CriticalPathOverlay.init_from_comparison(comparison, **kwargs)

--- a/services/comparison/overlays/critical_path.py
+++ b/services/comparison/overlays/critical_path.py
@@ -83,7 +83,8 @@ class CriticalPathOverlay(object):
         current_yaml = self._comparison.comparison.current_yaml
         if current_yaml is None:
             repo = self._comparison.head.commit.repository
-            repo_provider = get_repo_provider_service(repo)
+            gh_app_installation_name = self._comparison.context.gh_app_installation_name
+            repo_provider = get_repo_provider_service(repo, gh_app_installation_name)
             current_yaml = await get_current_yaml(
                 self._comparison.head.commit, repo_provider
             )

--- a/services/notification/notifiers/tests/integration/test_comment.py
+++ b/services/notification/notifiers/tests/integration/test_comment.py
@@ -5,7 +5,7 @@ from shared.reports.readonly import ReadOnlyReport
 
 from database.enums import TestResultsProcessingError
 from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
-from services.comparison import ComparisonProxy, NotificationContext
+from services.comparison import ComparisonContext, ComparisonProxy
 from services.comparison.types import Comparison, EnrichedPull, FullCommit
 from services.decoration import Decoration
 from services.notification.notifiers.comment import CommentNotifier
@@ -338,7 +338,7 @@ def sample_comparison_for_limited_upload(
 class TestCommentNotifierIntegration(object):
     @pytest.mark.asyncio
     async def test_notify(self, sample_comparison, codecov_vcr, mock_configuration):
-        sample_comparison.context = NotificationContext(
+        sample_comparison.context = ComparisonContext(
             all_tests_passed=True, test_results_error=None
         )
         mock_configuration._params["setup"] = {
@@ -412,7 +412,7 @@ class TestCommentNotifierIntegration(object):
     async def test_notify_test_results_error(
         self, sample_comparison, codecov_vcr, mock_configuration
     ):
-        sample_comparison.context = NotificationContext(
+        sample_comparison.context = ComparisonContext(
             all_tests_passed=False,
             test_results_error=TestResultsProcessingError.NO_SUCCESS,
         )

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -20,7 +20,7 @@ from database.models.core import GithubAppInstallation, Pull
 from database.tests.factories import RepositoryFactory
 from database.tests.factories.core import CommitFactory, OwnerFactory, PullFactory
 from services.billing import BillingPlan
-from services.comparison import ComparisonProxy, NotificationContext
+from services.comparison import ComparisonContext, ComparisonProxy
 from services.comparison.overlays.critical_path import CriticalPathOverlay
 from services.comparison.types import Comparison, FullCommit
 from services.decoration import Decoration
@@ -4028,7 +4028,7 @@ class TestNewHeaderSectionWriter(object):
     async def test_new_header_section_writer_test_results_setup(
         self, mocker, sample_comparison
     ):
-        sample_comparison.context = NotificationContext(all_tests_passed=True)
+        sample_comparison.context = ComparisonContext(all_tests_passed=True)
         writer = NewHeaderSectionWriter(
             mocker.MagicMock(),
             mocker.MagicMock(),
@@ -4059,7 +4059,7 @@ class TestNewHeaderSectionWriter(object):
     async def test_new_header_section_writer_test_results_error(
         self, mocker, sample_comparison
     ):
-        sample_comparison.context = NotificationContext(
+        sample_comparison.context = ComparisonContext(
             all_tests_passed=False,
             test_results_error=TestResultsProcessingError.NO_SUCCESS,
         )
@@ -4120,7 +4120,7 @@ class TestNewHeaderSectionWriter(object):
     async def test_new_header_section_writer_no_project_coverage_test_results_setup(
         self, mocker, sample_comparison
     ):
-        sample_comparison.context = NotificationContext(all_tests_passed=True)
+        sample_comparison.context = ComparisonContext(all_tests_passed=True)
         writer = NewHeaderSectionWriter(
             mocker.MagicMock(),
             mocker.MagicMock(),
@@ -4150,7 +4150,7 @@ class TestNewHeaderSectionWriter(object):
     async def test_new_header_section_writer_no_project_coverage_test_results_error(
         self, mocker, sample_comparison
     ):
-        sample_comparison.context = NotificationContext(
+        sample_comparison.context = ComparisonContext(
             all_tests_passed=False,
             test_results_error=TestResultsProcessingError.NO_SUCCESS,
         )
@@ -4898,7 +4898,7 @@ class TestCommentNotifierInNewLayout(object):
         sample_comparison_coverage_carriedforward,
     ):
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
-        sample_comparison_coverage_carriedforward.context = NotificationContext(
+        sample_comparison_coverage_carriedforward.context = ComparisonContext(
             all_tests_passed=True
         )
         comparison = sample_comparison_coverage_carriedforward
@@ -4939,7 +4939,7 @@ class TestCommentNotifierInNewLayout(object):
         sample_comparison_coverage_carriedforward,
     ):
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
-        sample_comparison_coverage_carriedforward.context = NotificationContext(
+        sample_comparison_coverage_carriedforward.context = ComparisonContext(
             all_tests_passed=False,
             test_results_error=TestResultsProcessingError.NO_SUCCESS,
         )
@@ -4981,7 +4981,7 @@ class TestCommentNotifierInNewLayout(object):
         sample_comparison_coverage_carriedforward,
     ):
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
-        sample_comparison_coverage_carriedforward.context = NotificationContext(
+        sample_comparison_coverage_carriedforward.context = ComparisonContext(
             all_tests_passed=False,
             test_results_error=None,
         )

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -188,9 +188,12 @@ class BaseReportService:
 class ReportService(BaseReportService):
     metrics_prefix = "services.report"
 
-    def __init__(self, current_yaml: UserYaml):
+    def __init__(
+        self, current_yaml: UserYaml, gh_app_installation_name: str | None = None
+    ):
         super().__init__(current_yaml)
         self.flag_dict = None
+        self.gh_app_installation_name = gh_app_installation_name
 
     def has_initialized_report(self, commit: Commit) -> bool:
         """Says whether a commit has already initialized its report or not
@@ -693,14 +696,15 @@ class ReportService(BaseReportService):
         ):
             try:
                 provider_service = get_repo_provider_service(
-                    repository=head_commit.repository
+                    repository=head_commit.repository,
+                    installation_name_to_use=self.gh_app_installation_name,
                 )
                 diff = (
                     await provider_service.get_compare(
                         base=base_commit.commitid, head=head_commit.commitid
                     )
                 )["diff"]
-                # Volitile function, alters carryforward_report
+                # Volatile function, alters carryforward_report
                 carryforward_report.shift_lines_by_diff(diff)
             except (RepositoryWithoutValidBotError, OwnerWithoutValidBotError) as exp:
                 log.error(
@@ -898,7 +902,7 @@ class ReportService(BaseReportService):
     ) -> ProcessingResult:
         """
             Processes an upload on top of an existing report `master` and returns
-                a result, which could be succesful or not
+                a result, which could be successful or not
 
             Note that this function does not modify the `upload` object, as this should
                 be done by a separate function
@@ -1189,7 +1193,11 @@ class ReportService(BaseReportService):
 
         # Attempt to calculate diff of report (which uses commit info from the git provider), but it it fails to do so, it just moves on without such diff
         try:
-            repository_service = get_repo_provider_service(repository, commit)
+            repository_service = get_repo_provider_service(
+                repository,
+                commit,
+                installation_name_to_use=self.gh_app_installation_name,
+            )
             report.apply_diff(await repository_service.get_commit_diff(commitid))
         except TorngitError:
             # When this happens, we have that commit.totals["diff"] is not available.

--- a/tasks/bundle_analysis_notify.py
+++ b/tasks/bundle_analysis_notify.py
@@ -8,6 +8,7 @@ from shared.yaml import UserYaml
 from app import celery_app
 from database.enums import ReportType
 from database.models import Commit
+from helpers.github_installation import get_installation_name_for_owner_for_task
 from services.bundle_analysis import Notifier
 from services.lock_manager import LockManager, LockRetry, LockType
 from tasks.base import BaseCodecovTask
@@ -101,7 +102,12 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
 
         success = None
         if notify:
-            notifier = Notifier(commit, commit_yaml)
+            installation_name_to_use = get_installation_name_for_owner_for_task(
+                db_session, self.name, commit.repository.owner
+            )
+            notifier = Notifier(
+                commit, commit_yaml, gh_app_installation_name=installation_name_to_use
+            )
             success = async_to_sync(notifier.notify)()
 
         log.info(

--- a/tasks/commit_update.py
+++ b/tasks/commit_update.py
@@ -11,6 +11,7 @@ from shared.torngit.exceptions import (
 from app import celery_app
 from database.models import Commit
 from helpers.exceptions import RepositoryWithoutValidBotError
+from helpers.github_installation import get_installation_name_for_owner_for_task
 from services.repository import (
     get_repo_provider_service,
     possibly_update_commit_from_provider_info,
@@ -38,7 +39,12 @@ class CommitUpdateTask(BaseCodecovTask, name=commit_update_task_name):
         repository_service = None
         was_updated = False
         try:
-            repository_service = get_repo_provider_service(repository, commit)
+            installation_name_to_use = get_installation_name_for_owner_for_task(
+                db_session, self.name, repository.owner
+            )
+            repository_service = get_repo_provider_service(
+                repository, commit, installation_name_to_use=installation_name_to_use
+            )
             was_updated = async_to_sync(possibly_update_commit_from_provider_info)(
                 commit, repository_service
             )

--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -265,7 +265,9 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
     ):
         compare_commit = comparison.compare_commit
         base_commit = comparison.base_commit
-        report_service = ReportService(current_yaml)
+        report_service = ReportService(
+            current_yaml, gh_app_installation_name=installation_name_to_use
+        )
         base_report = report_service.get_existing_report_for_commit(
             base_commit, report_class=ReadOnlyReport
         )

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -28,7 +28,7 @@ from helpers.save_commit_error import save_commit_error
 from services.activation import activate_user
 from services.billing import BillingPlan
 from services.commit_status import RepositoryCIFilter
-from services.comparison import ComparisonProxy, NotificationContext
+from services.comparison import ComparisonContext, ComparisonProxy
 from services.comparison.types import Comparison, FullCommit
 from services.decoration import determine_decoration_details
 from services.lock_manager import LockManager, LockRetry, LockType
@@ -462,8 +462,10 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 patch_coverage_base_commitid=patch_coverage_base_commitid,
                 current_yaml=current_yaml,
             ),
-            context=NotificationContext(
-                all_tests_passed=all_tests_passed, test_results_error=test_results_error
+            context=ComparisonContext(
+                all_tests_passed=all_tests_passed,
+                test_results_error=test_results_error,
+                gh_app_installation_name=installation_name_to_use,
             ),
         )
 

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -293,7 +293,9 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 **kwargs,
             )
 
-        report_service = ReportService(current_yaml)
+        report_service = ReportService(
+            current_yaml, gh_app_installation_name=installation_name_to_use
+        )
         head_report = report_service.get_existing_report_for_commit(
             commit, report_class=ReadOnlyReport
         )

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -18,6 +18,7 @@ from shared.yaml.user_yaml import OwnerContext
 from app import celery_app
 from database.models import Commit, Pull, Repository
 from helpers.exceptions import RepositoryWithoutValidBotError
+from helpers.github_installation import get_installation_name_for_owner_for_task
 from helpers.metrics import metrics
 from services.comparison.changes import get_changes
 from services.redis import get_redis_connection
@@ -34,7 +35,6 @@ log = logging.getLogger(__name__)
 
 
 class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
-
     """
         This is the task that syncs pull with the information the Git Provider gives us
 
@@ -101,7 +101,12 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         repository = db_session.query(Repository).filter_by(repoid=repoid).first()
         assert repository
         try:
-            repository_service = get_repo_provider_service(repository)
+            installation_name_to_use = get_installation_name_for_owner_for_task(
+                db_session, self.name, repository.owner
+            )
+            repository_service = get_repo_provider_service(
+                repository, installation_name_to_use=installation_name_to_use
+            )
         except RepositoryWithoutValidBotError:
             log.warning(
                 "Could not sync pull because there is no valid bot found for that repo",

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -157,7 +157,9 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                 "reason": "not_in_provider",
             }
         self.trigger_ai_pr_review(enriched_pull, current_yaml)
-        report_service = ReportService(current_yaml)
+        report_service = ReportService(
+            current_yaml, gh_app_installation_name=installation_name_to_use
+        )
         head_commit = pull.get_head_commit()
         if head_commit is None:
             log.info(

--- a/tasks/sync_repo_languages.py
+++ b/tasks/sync_repo_languages.py
@@ -10,6 +10,7 @@ from app import celery_app
 from database.models.core import Repository
 from helpers.clock import get_utc_now
 from helpers.exceptions import RepositoryWithoutValidBotError
+from helpers.github_installation import get_installation_name_for_owner_for_task
 from services.repository import get_repo_provider_service
 from tasks.base import BaseCodecovTask
 
@@ -53,7 +54,12 @@ class SyncRepoLanguagesTask(BaseCodecovTask, name=sync_repo_languages_task_name)
                     repository_id=repository.repoid,
                 )
                 log.info("Syncing repository languages", extra=log_extra)
-                repository_service = get_repo_provider_service(repository)
+                installation_name_to_use = get_installation_name_for_owner_for_task(
+                    db_session, self.name, repository.owner
+                )
+                repository_service = get_repo_provider_service(
+                    repository, installation_name_to_use=installation_name_to_use
+                )
                 is_bitbucket_call = (
                     repository.owner.service == "bitbucket"
                     or repository.owner.service == "bitbucket_server"

--- a/tasks/tests/unit/test_preprocess_upload.py
+++ b/tasks/tests/unit/test_preprocess_upload.py
@@ -1,7 +1,6 @@
 import pytest
 from redis.exceptions import LockError
 from shared.reports.types import ReportTotals, SessionTotalsArray
-from shared.torngit.exceptions import TorngitClientError, TorngitRepoNotFoundError
 
 from database.models.reports import Upload
 from database.tests.factories.core import (
@@ -224,7 +223,7 @@ class TestPreProcessUpload(object):
         )
         mock_get_repo_service.side_effect = RepositoryWithoutValidBotError()
         commit = CommitFactory.create()
-        repo_provider = PreProcessUpload().get_repo_service(commit)
+        repo_provider = PreProcessUpload().get_repo_service(commit, None)
         assert repo_provider is None
 
     def test_preprocess_upload_fail_no_provider_service(self, dbsession, mocker):

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -473,7 +473,9 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
 
         if report_type == ReportType.COVERAGE:
             # TODO: consider renaming class to `CoverageReportService`
-            report_service = ReportService(commit_yaml)
+            report_service = ReportService(
+                commit_yaml, gh_app_installation_name=installation_name_to_use
+            )
         elif report_type == ReportType.BUNDLE_ANALYSIS:
             report_service = BundleAnalysisReportService(commit_yaml)
         elif report_type == ReportType.TEST_RESULTS:

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -25,6 +25,7 @@ from helpers.checkpoint_logger import _kwargs_key
 from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import UploadFlow
 from helpers.exceptions import RepositoryWithoutValidBotError
+from helpers.github_installation import get_installation_name_for_owner_for_task
 from helpers.metrics import metrics
 from helpers.parallel_upload_processing import get_parallel_session_ids
 from helpers.save_commit_error import save_commit_error
@@ -421,7 +422,12 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         repository_service = None
         was_updated, was_setup = False, False
         try:
-            repository_service = get_repo_provider_service(repository, commit)
+            installation_name_to_use = get_installation_name_for_owner_for_task(
+                db_session, self.name, repository.owner
+            )
+            repository_service = get_repo_provider_service(
+                repository, commit, installation_name_to_use=installation_name_to_use
+            )
             was_updated = async_to_sync(possibly_update_commit_from_provider_info)(
                 commit, repository_service
             )


### PR DESCRIPTION
This adds ability for more tasks to use the existing configuration options and
provide overrides for the GitHubAppInstallation name to be used for a given user.

Some of these usages have to be propagated through the task, as is the case with
ComputeComparison, for example.


<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.