### PR TITLE
feat: change to get new tokenless working

### DIFF
--- a/services/repository.py
+++ b/services/repository.py
@@ -253,9 +253,19 @@ async def update_commit_from_provider_info(repository_service, commit):
             # so we append the branch name with the fork slug
             branch_name = commit_updates["head"]["branch"]
             # TODO: 'slug' is in a `.get` because currently only GitHub returns that info
+
             if commit_updates["head"].get("slug") != commit_updates["base"].get("slug"):
-                branch_name = commit_updates["head"]["slug"] + ":" + branch_name
+                # get rid of repo name in head.slug
+                try:
+                    username = commit_updates["head"]["slug"].split("/")[0]
+                    branch_name = username + ":" + branch_name
+                except:
+                    log.error(
+                        "Error updating branch name for commit originating from fork",
+                        extra=dict(repoid=commit.repoid, commit=commit.commitid),
+                    )
             commit.branch = branch_name
+
             commit.merged = False
         else:
             possible_branches = await repository_service.get_best_effort_branches(

--- a/services/tests/test_repository_service.py
+++ b/services/tests/test_repository_service.py
@@ -994,7 +994,7 @@ class TestRepositoryServiceTestCase(object):
         assert commit.pullid == 1
         assert commit.totals is None
         assert commit.report_json == {}
-        assert commit.branch == "main"
+        assert commit.branch == "some-guy:main"
         assert commit.parent_commit_id == possible_parent_commit.commitid
         assert commit.state == "complete"
         assert commit.author is not None

--- a/services/tests/test_repository_service.py
+++ b/services/tests/test_repository_service.py
@@ -960,6 +960,7 @@ class TestRepositoryServiceTestCase(object):
             _report_json=None,
             repository=possible_parent_commit.repository,
         )
+        commit.branch = "main"
         dbsession.add(possible_parent_commit)
         dbsession.add(commit)
         dbsession.flush()
@@ -993,7 +994,7 @@ class TestRepositoryServiceTestCase(object):
         assert commit.pullid == 1
         assert commit.totals is None
         assert commit.report_json == {}
-        assert commit.branch == f"some-guy/{commit.repository.name}:main"
+        assert commit.branch == "main"
         assert commit.parent_commit_id == possible_parent_commit.commitid
         assert commit.state == "complete"
         assert commit.author is not None


### PR DESCRIPTION
We don't want to update the commit using github's information because that will rename the branch to a different format than what we're aiming for in tokenless