### PR TITLE
dev: update to latest version of gha-workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,37 +11,35 @@ on:
   merge_group:
 
 permissions:
-  contents: 'read'
-  id-token: 'write'
+  contents: "read"
+  id-token: "write"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-
 jobs:
   lint:
     name: Run Lint
-    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.12
+    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.19
 
   build:
     name: Build Worker
-    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.12
+    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.19
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
 
-
   codecovstartup:
     name: Codecov Startup
     needs: build
-    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.12
+    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.19
     secrets: inherit
 
   test:
     name: Test
     needs: [build]
-    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.15
+    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.19
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
@@ -49,7 +47,7 @@ jobs:
   build-self-hosted:
     name: Build Self Hosted Worker
     needs: [build, test]
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.12
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.19
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
@@ -58,7 +56,7 @@ jobs:
     name: Push Staging Image
     needs: [build, test]
     if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/staging') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.17
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.19
     secrets: inherit
     with:
       environment: staging
@@ -66,9 +64,9 @@ jobs:
 
   production:
     name: Push Production Image
-    needs: [ build, test ]
+    needs: [build, test]
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.17
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.19
     secrets: inherit
     with:
       environment: production
@@ -76,10 +74,10 @@ jobs:
 
   self-hosted:
     name: Push Self Hosted Image
-    needs: [ build-self-hosted, test ]
+    needs: [build-self-hosted, test]
     secrets: inherit
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.12
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.19
     with:
       push_rolling: true
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
@@ -122,5 +120,3 @@ jobs:
   #     - name: Run mutations
   #       run: |
   #         make test_env.run_mutation
-
-

--- a/.github/workflows/self-hosted-release-pr.yml
+++ b/.github/workflows/self-hosted-release-pr.yml
@@ -4,11 +4,11 @@ on:
   workflow_dispatch:
     inputs:
       versionName:
-        description: 'Name of version  (ie 23.9.5)'
+        description: "Name of version  (ie 23.9.5)"
         required: true
 
 jobs:
   create-release-pr:
     name: Create PR for Release ${{ github.event.inputs.versionName }}
-    uses: codecov/gha-workflows/.github/workflows/create-release-pr.yml@v1.2.12
+    uses: codecov/gha-workflows/.github/workflows/create-release-pr.yml@v1.2.19
     secrets: inherit

--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -7,14 +7,14 @@ on:
     types: [closed]
 
 permissions:
-  contents: 'read'
-  id-token: 'write'
+  contents: "read"
+  id-token: "write"
 
 jobs:
   create-release:
     name: Tag Release ${{ github.head_ref }} and Push Docker image to Docker Hub
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/create-release.yml@v1.2.12
+    uses: codecov/gha-workflows/.github/workflows/create-release.yml@v1.2.19
     with:
       tag_to_prepend: self-hosted-
     secrets: inherit
@@ -22,7 +22,7 @@ jobs:
   push-image:
     needs: [create-release]
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.12
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.19
     secrets: inherit
     with:
       push_release: true


### PR DESCRIPTION
Similar to https://github.com/codecov/codecov-api/pull/556, from https://github.com/codecov/gha-workflows/pull/23, updating deprecated GHAs


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.