### PR TITLE
Remove reference to `ts_telemetry`

### DIFF
--- a/migrate-timeseries.sh
+++ b/migrate-timeseries.sh
@@ -8,4 +8,3 @@ fi
 
 $prefix python manage.py migrate --database timeseries rollouts
 $prefix python manage.py migrate --database timeseries pg_telemetry
-$prefix python manage.py migrate --database timeseries ts_telemetry


### PR DESCRIPTION
The reference to the `ts_telemetry` has been removed in the django apps in #443. We just need to remove referencing it in the migration script. 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.