### PR TITLE
1164 adjust archive get fn error call

### DIFF
--- a/database/tests/unit/test_model_utils.py
+++ b/database/tests/unit/test_model_utils.py
@@ -99,6 +99,42 @@ class TestArchiveField(object):
         mock_read_file.assert_called_with("gcs_path")
         mock_archive_service.assert_called_with(repository=commit.repository)
 
+    def test_archive_getter_file_not_in_storage(self, db, mocker):
+        mocker.patch(
+            "database.utils.ArchiveField.read_timeout",
+            new_callable=PropertyMock,
+            return_value=5.1,
+        )
+        mock_read_file = mocker.MagicMock(side_effect=FileNotInStorageError())
+        mock_archive_service = mocker.patch("database.utils.ArchiveService")
+        mock_archive_service.return_value.read_file = mock_read_file
+        commit = CommitFactory()
+        test_class = self.ClassWithArchiveField(commit, None, "gcs_path")
+
+        assert test_class._archive_field == None
+        assert test_class._archive_field_storage_path == "gcs_path"
+        assert test_class.archive_field == None
+        mock_read_file.assert_called_with("gcs_path")
+        mock_archive_service.assert_called_with(repository=commit.repository)
+
+    def test_archive_getter_file_not_in_storage(self, db, mocker):
+        mocker.patch(
+            "database.utils.ArchiveField.read_timeout",
+            new_callable=PropertyMock,
+            return_value=0.1,
+        )
+        mock_read_file = mocker.MagicMock(side_effect=FileNotInStorageError())
+        mock_archive_service = mocker.patch("database.utils.ArchiveService")
+        mock_archive_service.return_value.read_file = mock_read_file
+        commit = CommitFactory()
+        test_class = self.ClassWithArchiveField(commit, None, "gcs_path")
+
+        assert test_class._archive_field == None
+        assert test_class._archive_field_storage_path == "gcs_path"
+        assert test_class.archive_field == None
+        mock_read_file.assert_called_with("gcs_path")
+        mock_archive_service.assert_called_with(repository=commit.repository)
+
     def test_archive_setter_db_field(self, db, mocker):
         commit = CommitFactory()
         test_class = self.ClassWithArchiveField(commit, "db_value", "gcs_path", False)

--- a/database/tests/unit/test_model_utils.py
+++ b/database/tests/unit/test_model_utils.py
@@ -99,42 +99,6 @@ class TestArchiveField(object):
         mock_read_file.assert_called_with("gcs_path")
         mock_archive_service.assert_called_with(repository=commit.repository)
 
-    def test_archive_getter_file_not_in_storage(self, db, mocker):
-        mocker.patch(
-            "database.utils.ArchiveField.read_timeout",
-            new_callable=PropertyMock,
-            return_value=5.1,
-        )
-        mock_read_file = mocker.MagicMock(side_effect=FileNotInStorageError())
-        mock_archive_service = mocker.patch("database.utils.ArchiveService")
-        mock_archive_service.return_value.read_file = mock_read_file
-        commit = CommitFactory()
-        test_class = self.ClassWithArchiveField(commit, None, "gcs_path")
-
-        assert test_class._archive_field == None
-        assert test_class._archive_field_storage_path == "gcs_path"
-        assert test_class.archive_field == None
-        mock_read_file.assert_called_with("gcs_path")
-        mock_archive_service.assert_called_with(repository=commit.repository)
-
-    def test_archive_getter_file_not_in_storage(self, db, mocker):
-        mocker.patch(
-            "database.utils.ArchiveField.read_timeout",
-            new_callable=PropertyMock,
-            return_value=0.1,
-        )
-        mock_read_file = mocker.MagicMock(side_effect=FileNotInStorageError())
-        mock_archive_service = mocker.patch("database.utils.ArchiveService")
-        mock_archive_service.return_value.read_file = mock_read_file
-        commit = CommitFactory()
-        test_class = self.ClassWithArchiveField(commit, None, "gcs_path")
-
-        assert test_class._archive_field == None
-        assert test_class._archive_field_storage_path == "gcs_path"
-        assert test_class.archive_field == None
-        mock_read_file.assert_called_with("gcs_path")
-        mock_archive_service.assert_called_with(repository=commit.repository)
-
     def test_archive_setter_db_field(self, db, mocker):
         commit = CommitFactory()
         test_class = self.ClassWithArchiveField(commit, "db_value", "gcs_path", False)

--- a/database/utils.py
+++ b/database/utils.py
@@ -116,29 +116,27 @@ class ArchiveField:
                         )
                     return result
                 except FileNotInStorageError:
-                    if not time.time() < start_time + self.read_timeout:
-                        log.error(
-                            "Archive enabled field not in storage",
-                            extra=dict(
-                                storage_path=archive_field,
-                                object_id=obj.id,
-                                commit=obj.get_commitid(),
-                            ),
-                        )
-                    else:
-                        log.warning(
-                            "Archive enabled not found, retrying soon",
-                            extra=dict(
-                                storage_path=archive_field,
-                                object_id=obj.id,
-                                commit=obj.get_commitid(),
-                            ),
-                        )
-                        error = True
-                        # sleep a little but so we're not hammering the archive service
-                        # in a tight loop
-                        time.sleep(self.read_timeout / 10)
+                    log.warning(
+                        "Archive enabled not found, retrying soon",
+                        extra=dict(
+                            storage_path=archive_field,
+                            object_id=obj.id,
+                            commit=obj.get_commitid(),
+                        ),
+                    )
+                    error = True
+                    # sleep a little but so we're not hammering the archive service
+                    # in a tight loop
+                    time.sleep(self.read_timeout / 10)
 
+            log.error(
+                "Archive enabled field not in storage",
+                extra=dict(
+                    storage_path=archive_field,
+                    object_id=obj.id,
+                    commit=obj.get_commitid(),
+                ),
+            )
         else:
             log.debug(
                 "Both db_field and archive_field are None",


### PR DESCRIPTION
We're seeing timeseries errors pop in sentry that look like this: https://codecov.sentry.io/issues/4354360482/?project=5215654&project=4506250072489984&project=4505534345838592&project=4506739665207296&project=4505562661847040&project=4505562669645824&project=4505562667089920&project=4505743290269696&project=4503926675144704&project=1260170&project=4504171287871488&project=4505225779675136&project=4506634728833024&project=4506317072891904&project=4505131799150592&project=4165036&project=5514400&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D+save_commit_measurements&referrer=issue-stream&statsPeriod=30d&stream_index=1&utc=true. I looked up in our logs that this error is shortly followed by "Archive enabled field found in storage after delay"., so we're erroring and quickly recovering from it, yet spamming our sentry logs with this. More details and specifics here https://github.com/codecov/engineering-team/issues/1164

This PR is to only log an error after the retry timeout is over, and still warn when we retry.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.