### PR TITLE
Bundle analysis handle rate limit error

### DIFF
--- a/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -3,6 +3,7 @@ from unittest.mock import ANY
 import pytest
 from redis.exceptions import LockError
 from shared.bundle_analysis.storage import get_bucket_name
+from shared.storage.exceptions import PutRequestRateLimitError
 
 from database.models import CommitReport
 from database.tests.factories import CommitFactory, UploadFactory
@@ -298,3 +299,68 @@ def test_bundle_analysis_processor_task_locked(
 
     assert upload.state == "started"
     retry.assert_called_once_with(countdown=ANY, max_retries=5)
+
+
+def test_bundle_analysis_process_upload_rate_limit_error(
+    mocker,
+    mock_configuration,
+    dbsession,
+    mock_storage,
+    mock_redis,
+    celery_app,
+):
+    storage_path = (
+        f"v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite"
+    )
+    mock_storage.write_file(get_bucket_name(), storage_path, "test-content")
+
+    mocker.patch.object(BundleAnalysisProcessorTask, "app", celery_app)
+
+    commit = CommitFactory.create(state="pending")
+    dbsession.add(commit)
+    dbsession.flush()
+
+    commit_report = CommitReport(commit_id=commit.id_)
+    dbsession.add(commit_report)
+    dbsession.flush()
+
+    upload = UploadFactory.create(storage_path=storage_path, report=commit_report)
+    dbsession.add(upload)
+    dbsession.flush()
+
+    task = BundleAnalysisProcessorTask()
+    retry = mocker.patch.object(task, "retry")
+
+    ingest = mocker.patch("shared.bundle_analysis.BundleAnalysisReport.ingest")
+    ingest.side_effect = PutRequestRateLimitError()
+
+    result = task.run_impl(
+        dbsession,
+        {"results": [{"previous": "result"}]},
+        repoid=commit.repoid,
+        commitid=commit.commitid,
+        commit_yaml={},
+        params={
+            "upload_pk": upload.id_,
+            "commit": commit.commitid,
+        },
+    )
+    assert result == {
+        "results": [
+            {"previous": "result"},
+            {
+                "error": {
+                    "code": "rate_limit_error",
+                    "params": {
+                        "location": "v1/repos/testing/ed1bdd67-8fd2-4cdb-ac9e-39b99e4a3892/bundle_report.sqlite"
+                    },
+                },
+                "session_id": None,
+                "upload_id": upload.id_,
+            },
+        ],
+    }
+
+    assert commit.state == "error"
+    assert upload.state == "error"
+    retry.assert_called_once_with(countdown=20, max_retries=5)


### PR DESCRIPTION
2 of 2 PRs of the fix.

When encountering a rate limit error by GCS when doing save file to the BA bucket, instead of failing the processor step completely, it will now retry.

GCS has a 1 PUT request per second rate limit when updating an existing object in storage, the BA processor may encounter this edge case when multiple BA processing tasks are running in parallel to update multiple bundle stats files. And when this is encountered, we don't update the SQLite file for this stats file therefore causing incorrect data. This fix will retry the task after a short 20s cooldown to once again attempt to upload, at this time most likely the rate limit threshold would be passed. Note that there can still be cases when multiple retried tasks run at the same time again, but the probability of this would be really low considering the existing issue of rate limiting error from GCS is also seen very rarely.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.