### PR TITLE
dev: Upgrade stripe to latest

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -37,7 +37,7 @@ sentry-sdk>=1.40.0
 SQLAlchemy-Utils
 SQLAlchemy
 statsd
-stripe
+stripe>=9.6.0
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 urllib3>=1.26.18
 vcrpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -400,7 +400,7 @@ statsd==3.3.0
     # via
     #   -r requirements.in
     #   shared
-stripe==8.9.0
+stripe==9.6.0
     # via -r requirements.in
 test-results-parser @ https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz
     # via -r requirements.in

--- a/services/stripe.py
+++ b/services/stripe.py
@@ -2,7 +2,7 @@ import stripe
 from shared.config import get_config
 
 stripe.api_key = get_config("services", "stripe", "api_key")
-stripe.api_version = "2023-10-16"
+stripe.api_version = "2024-04-10"
 
 client = stripe.http_client.RequestsClient()
 stripe.default_http_client = client


### PR DESCRIPTION
Upgrades stripe to latest API version

Related Ticket: https://github.com/codecov/engineering-team/issues/1754

Main changes found here: https://github.com/codecov/codecov-api/pull/569

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.