### PR TITLE
refactor: Comment conditions

### DIFF
--- a/services/notification/notifiers/base.py
+++ b/services/notification/notifiers/base.py
@@ -12,11 +12,24 @@ log = logging.getLogger(__name__)
 
 @dataclass
 class NotificationResult(object):
-    notification_attempted: bool
-    notification_successful: bool
-    explanation: str
-    data_sent: Mapping[str, Any]
+    notification_attempted: bool = False
+    notification_successful: bool = False
+    explanation: str = None
+    data_sent: Mapping[str, Any] = None
     data_received: Mapping[str, Any] = None
+
+    def merge(self, other: "NotificationResult") -> "NotificationResult":
+        ans = NotificationResult()
+        ans.notification_attempted = bool(
+            self.notification_attempted or other.notification_attempted
+        )
+        ans.notification_successful = bool(
+            self.notification_successful or other.notification_successful
+        )
+        ans.explanation = self.explanation or other.explanation
+        ans.data_sent = self.data_sent or other.data_sent
+        ans.data_received = self.data_received or other.data_received
+        return ans
 
 
 class AbstractBaseNotifier(object):

--- a/services/notification/notifiers/comment/__init__.py
+++ b/services/notification/notifiers/comment/__init__.py
@@ -11,11 +11,21 @@ from shared.torngit.exceptions import (
 from database.enums import Notification
 from helpers.metrics import metrics
 from services.billing import BillingPlan
+from services.comparison import ComparisonProxy
 from services.comparison.types import Comparison
 from services.license import requires_license
 from services.notification.notifiers.base import (
     AbstractBaseNotifier,
     NotificationResult,
+)
+from services.notification.notifiers.comment.conditions import (
+    ComparisonHasPull,
+    HasEnoughBuilds,
+    HasEnoughRequiredChanges,
+    NotifyCondition,
+    PullHeadMatchesComparisonHead,
+    PullRequestInProvider,
+    PullRequestOpen,
 )
 from services.notification.notifiers.mixins.message import MessageMixin
 from services.repository import get_repo_provider_service
@@ -25,6 +35,15 @@ log = logging.getLogger(__name__)
 
 
 class CommentNotifier(MessageMixin, AbstractBaseNotifier):
+    notify_conditions: List[NotifyCondition] = [
+        ComparisonHasPull,
+        PullRequestInProvider,
+        PullRequestOpen,
+        PullHeadMatchesComparisonHead,
+        HasEnoughBuilds,
+        HasEnoughRequiredChanges,
+    ]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._repository_service = None
@@ -69,88 +88,31 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
             return True
         return False
 
-    async def notify(self, comparison: Comparison, **extra_data) -> NotificationResult:
-        if comparison.pull is None:
-            return NotificationResult(
-                notification_attempted=False,
-                notification_successful=None,
-                explanation="no_pull_request",
-                data_sent=None,
-                data_received=None,
-            )
-        if (
-            comparison.enriched_pull is None
-            or comparison.enriched_pull.provider_pull is None
-        ):
-            return NotificationResult(
-                notification_attempted=False,
-                notification_successful=None,
-                explanation="pull_request_not_in_provider",
-                data_sent=None,
-                data_received=None,
-            )
-        if comparison.pull.state != "open":
-            return NotificationResult(
-                notification_attempted=False,
-                notification_successful=None,
-                explanation="pull_request_closed",
-                data_sent=None,
-                data_received=None,
-            )
-        if comparison.pull.head != comparison.head.commit.commitid:
-            return NotificationResult(
-                notification_attempted=False,
-                notification_successful=None,
-                explanation="pull_head_does_not_match",
-                data_sent=None,
-                data_received=None,
-            )
-        if self.notifier_yaml_settings.get("after_n_builds") is not None:
-            n_builds_present = len(comparison.head.report.sessions)
-            if n_builds_present < self.notifier_yaml_settings.get("after_n_builds"):
-                return NotificationResult(
+    async def notify(
+        self, comparison: ComparisonProxy, **extra_data
+    ) -> NotificationResult:
+        for condition in self.notify_conditions:
+            if (
+                condition.is_async_condition
+                and not (
+                    await condition.check_condition(
+                        notifier=self, comparison=comparison
+                    )
+                )
+            ) or (not condition.check_condition(notifier=self, comparison=comparison)):
+                side_effect_result = (
+                    condition.on_failure_side_effect(self, comparison)
+                    if condition.is_async_condition is False
+                    else (await condition.on_failure_side_effect(self, comparison))
+                )
+                default_result = NotificationResult(
                     notification_attempted=False,
-                    notification_successful=None,
-                    explanation="not_enough_builds",
+                    explanation=condition.failure_explanation,
                     data_sent=None,
                     data_received=None,
                 )
+                return default_result.merge(side_effect_result)
         pull = comparison.pull
-        if self.notifier_yaml_settings.get("require_changes"):
-            if not (await self.has_enough_changes(comparison)):
-                data_received = None
-                if pull.commentid is not None:
-                    log.info(
-                        "Deleting comment because there are not enough changes according to YAML",
-                        extra=dict(
-                            repoid=pull.repoid,
-                            pullid=pull.pullid,
-                            commentid=pull.commentid,
-                        ),
-                    )
-                    try:
-                        await self.repository_service.delete_comment(
-                            pull.pullid, pull.commentid
-                        )
-                        data_received = {"deleted_comment": True}
-                    except TorngitClientError:
-                        log.warning(
-                            "Comment could not be deleted due to client permissions",
-                            exc_info=True,
-                            extra=dict(
-                                repoid=pull.repoid,
-                                pullid=pull.pullid,
-                                commentid=pull.commentid,
-                            ),
-                        )
-                        data_received = {"deleted_comment": False}
-                return NotificationResult(
-                    notification_attempted=False,
-                    notification_successful=None,
-                    explanation="changes_required",
-                    data_sent=None,
-                    data_received=data_received,
-                )
         try:
             with metrics.timer(
                 "worker.services.notifications.notifiers.comment.build_message"
@@ -167,7 +129,6 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
             )
             return NotificationResult(
                 notification_attempted=False,
-                notification_successful=None,
                 explanation="unable_build_message",
                 data_sent=None,
                 data_received=None,

--- a/services/notification/notifiers/comment/conditions.py
+++ b/services/notification/notifiers/comment/conditions.py
@@ -1,0 +1,141 @@
+import logging
+from abc import ABC, abstractmethod
+
+from shared.torngit.exceptions import (
+    TorngitClientError,
+)
+
+from services.comparison import ComparisonProxy
+from services.notification.notifiers.base import (
+    AbstractBaseNotifier,
+    NotificationResult,
+)
+
+log = logging.getLogger(__name__)
+
+
+class NotifyCondition(ABC):
+    is_async_condition: bool = False
+    failure_explanation: str
+
+    @abstractmethod
+    def check_condition(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> bool:
+        pass
+
+    def on_failure_side_effect(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> NotificationResult:
+        return NotificationResult()
+
+
+class AsyncNotifyCondition(NotifyCondition):
+    is_async_condition: bool = True
+
+    @abstractmethod
+    async def check_condition(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> bool:
+        pass
+
+    async def on_failure_side_effect(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> NotificationResult:
+        pass
+
+
+class ComparisonHasPull(NotifyCondition):
+    failure_explanation = "no_pull_request"
+
+    def check_condition(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> bool:
+        return comparison.pull is not None
+
+
+class PullRequestInProvider(NotifyCondition):
+    failure_explanation = "pull_request_not_in_provider"
+
+    def check_condition(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> bool:
+        return (
+            comparison.enriched_pull is not None
+            and comparison.enriched_pull.provider_pull is not None
+        )
+
+
+class PullRequestOpen(NotifyCondition):
+    failure_explanation = "pull_request_closed"
+
+    def check_condition(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> bool:
+        return comparison.pull.state == "open"
+
+
+class PullHeadMatchesComparisonHead(NotifyCondition):
+    failure_explanation = "pull_head_does_not_match"
+
+    def check_condition(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> bool:
+        return comparison.pull.head == comparison.head.commit.commitid
+
+
+class HasEnoughBuilds(NotifyCondition):
+    failure_explanation = "not_enough_builds"
+
+    def check_condition(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> bool:
+        expected_builds = notifier.notifier_yaml_settings.get("after_n_builds", 0)
+        present_builds = len(comparison.head.report.sessions)
+        return present_builds >= expected_builds
+
+
+class HasEnoughRequiredChanges(AsyncNotifyCondition):
+    failure_explanation = "changes_required"
+
+    async def check_condition(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> bool:
+        requires_changes = notifier.notifier_yaml_settings.get("require_changes", False)
+        return (requires_changes == False) or await notifier.has_enough_changes(
+            comparison
+        )
+
+    async def on_failure_side_effect(
+        notifier: AbstractBaseNotifier, comparison: ComparisonProxy
+    ) -> NotificationResult:
+        pull = comparison.pull
+        data_received = None
+        if pull.commentid is not None:
+            # Just porting logic as-is, but not sure if it's the best
+            # TODO: codecov/engineering-team#1761
+            log.info(
+                "Deleting comment because there are not enough changes according to YAML",
+                extra=dict(
+                    repoid=pull.repoid,
+                    pullid=pull.pullid,
+                    commentid=pull.commentid,
+                ),
+            )
+            try:
+                await notifier.repository_service.delete_comment(
+                    pull.pullid, pull.commentid
+                )
+                data_received = {"deleted_comment": True}
+            except TorngitClientError:
+                log.warning(
+                    "Comment could not be deleted due to client permissions",
+                    exc_info=True,
+                    extra=dict(
+                        repoid=pull.repoid,
+                        pullid=pull.pullid,
+                        commentid=pull.commentid,
+                    ),
+                )
+                data_received = {"deleted_comment": False}
+        return NotificationResult(data_received=data_received)

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -2416,7 +2416,7 @@ class TestCommentNotifier(object):
             "response", "message"
         )
         result = await notifier.send_actual_notification(data)
-        assert not result.notification_attempted
+        assert result.notification_attempted is False
         assert result.notification_successful is None
         assert result.explanation == "comment_deleted"
         assert result.data_sent == data
@@ -2642,7 +2642,7 @@ class TestCommentNotifier(object):
         )
         result = await notifier.notify(sample_comparison_without_pull)
         assert not result.notification_attempted
-        assert result.notification_successful is None
+        assert result.notification_successful == False
         assert result.explanation == "no_pull_request"
         assert result.data_sent is None
         assert result.data_received is None
@@ -2663,7 +2663,7 @@ class TestCommentNotifier(object):
         )
         result = await notifier.notify(sample_comparison)
         assert not result.notification_attempted
-        assert result.notification_successful is None
+        assert result.notification_successful is False
         assert result.explanation == "pull_head_does_not_match"
         assert result.data_sent is None
         assert result.data_received is None
@@ -2684,7 +2684,7 @@ class TestCommentNotifier(object):
         )
         result = await notifier.notify(sample_comparison_database_pull_without_provider)
         assert not result.notification_attempted
-        assert result.notification_successful is None
+        assert result.notification_successful is False
         assert result.explanation == "pull_request_not_in_provider"
         assert result.data_sent is None
         assert result.data_received is None
@@ -2821,7 +2821,7 @@ class TestCommentNotifier(object):
         dbsession.refresh(sample_comparison.pull)
         result = await notifier.notify(sample_comparison)
         assert not result.notification_attempted
-        assert result.notification_successful is None
+        assert result.notification_successful is False
         assert result.explanation == "pull_request_closed"
         assert result.data_sent is None
         assert result.data_received is None
@@ -2847,7 +2847,7 @@ class TestCommentNotifier(object):
         )
         result = await notifier.notify(sample_comparison)
         assert not result.notification_attempted
-        assert result.notification_successful is None
+        assert result.notification_successful is False
         assert result.explanation == "unable_build_message"
         assert result.data_sent is None
         assert result.data_received is None
@@ -2867,7 +2867,7 @@ class TestCommentNotifier(object):
         )
         result = await notifier.notify(sample_comparison)
         assert not result.notification_attempted
-        assert result.notification_successful is None
+        assert result.notification_successful is False
         assert result.explanation == "not_enough_builds"
         assert result.data_sent is None
         assert result.data_received is None
@@ -3133,7 +3133,7 @@ class TestCommentNotifier(object):
         )
         res = await notifier.notify(sample_comparison_no_change)
         assert res.notification_attempted is False
-        assert res.notification_successful is None
+        assert res.notification_successful is False
         assert res.explanation == "changes_required"
         assert res.data_sent is None
         assert res.data_received is None
@@ -3195,7 +3195,7 @@ class TestCommentNotifier(object):
         )
         res = await notifier.notify(sample_comparison_no_change)
         assert res.notification_attempted is False
-        assert res.notification_successful is None
+        assert res.notification_successful is False
         assert res.explanation == "changes_required"
         assert res.data_sent is None
         assert res.data_received == {"deleted_comment": True}
@@ -3260,7 +3260,7 @@ class TestCommentNotifier(object):
         )
         res = await notifier.notify(sample_comparison_no_change)
         assert res.notification_attempted is False
-        assert res.notification_successful is None
+        assert res.notification_successful is False
         assert res.explanation == "changes_required"
         assert res.data_sent is None
         assert res.data_received == {"deleted_comment": False}

--- a/services/notification/tests/unit/test_notification_result.py
+++ b/services/notification/tests/unit/test_notification_result.py
@@ -1,0 +1,35 @@
+from services.notification.notifiers.base import NotificationResult
+
+
+def test_notification_result_or_operation():
+    result_default = NotificationResult()
+    result_explanation = NotificationResult(explanation="some_explanation")
+    result_not_attempted = NotificationResult(
+        notification_attempted=False,
+        notification_successful=False,
+        explanation="dont_want",
+    )
+    result_attempted = NotificationResult(
+        notification_attempted=True,
+        notification_successful=True,
+        explanation=None,
+    )
+    result_some_data = NotificationResult(
+        data_sent={"comment": "hi"}, data_received={"response": "hi"}
+    )
+    assert result_default.merge(result_explanation) == result_explanation
+    assert result_default.merge(result_not_attempted) == result_not_attempted
+    assert result_attempted.merge(result_some_data) == NotificationResult(
+        notification_attempted=True,
+        notification_successful=True,
+        explanation=None,
+        data_sent={"comment": "hi"},
+        data_received={"response": "hi"},
+    )
+    assert result_not_attempted.merge(result_some_data) == NotificationResult(
+        notification_attempted=False,
+        notification_successful=False,
+        explanation="dont_want",
+        data_sent={"comment": "hi"},
+        data_received={"response": "hi"},
+    )


### PR DESCRIPTION
These are proposed changes to move much of the verifying logic of "can we send this comment?"
to a dedicated `NotificationCondition` class.

This is inspired by the authentication classes of rest framework (like we use in api), but
more explicit. My hope is that we can expand this for other notifiers as well, and hopefully
reuse some of the notify conditions accross notifiers.

But I'd like to test the waters (== team's appetite for these changes) before commiting
a bunch more time in refactoring more code.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.