### PR TITLE
Increase the number of decimal places for the AbstractLevelTotals

### DIFF
--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -190,7 +190,7 @@ class ReportDetails(CodecovBaseModel, MixinBaseClass):
 
 class AbstractTotals(MixinBaseClass):
     branches = Column(types.Integer)
-    coverage = Column(types.Numeric(precision=7, scale=2))
+    coverage = Column(types.Numeric(precision=8, scale=5))
     hits = Column(types.Integer)
     lines = Column(types.Integer)
     methods = Column(types.Integer)

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/f6c2c3852530192ab0c6b9fd0c0a800c2cbdb16f.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/ae6e12f3cf43188a6d6fa0156ccb78252d3405a8.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz#egg=test-results-parser
 boto3>=1.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -368,7 +368,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/f6c2c3852530192ab0c6b9fd0c0a800c2cbdb16f.tar.gz
+shared @ https://github.com/codecov/shared/archive/ae6e12f3cf43188a6d6fa0156ccb78252d3405a8.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
After the migration to increase the number of decimal places for these tables, we should be able to use them to 5 decimal places. We just need to also update the models used in worker for consistency.

Migration happens in `shared`: https://github.com/codecov/shared/pull/224

ref: https://github.com/codecov/engineering-team/issues/1614

Diff for the `shared` update: https://github.com/codecov/shared/compare/codecov:f6c2c3852530192ab0c6b9fd0c0a800c2cbdb16f%5E%5E%5E%5E%5E...codecov:ae6e12f3cf43188a6d6fa0156ccb78252d3405a8

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.