### PR TITLE
fix: cleanup bundle report in finally

### DIFF
--- a/tasks/bundle_analysis_processor.py
+++ b/tasks/bundle_analysis_processor.py
@@ -132,9 +132,6 @@ class BundleAnalysisProcessorTask(
                 self.retry(max_retries=5, countdown=20)
             result.update_upload()
 
-            if result.bundle_report:
-                result.bundle_report.cleanup()
-
             processing_results.append(result.as_dict())
         except (CeleryError, SoftTimeLimitExceeded, SQLAlchemyError):
             raise
@@ -153,6 +150,9 @@ class BundleAnalysisProcessorTask(
             upload.state_id = UploadState.ERROR.db_id
             upload.state = "error"
             raise
+        finally:
+            if result.bundle_report:
+                result.bundle_report.cleanup()
 
         log.info(
             "Finished bundle analysis processor",


### PR DESCRIPTION
Trying this because I suspect we might be leaving a dangling connection to the SQLite db in this part of the code if for some reason we don't reach the call to bundle_report.cleanup, so I'm moving it to a finally so that code will always execute even if there's an error somewhere before it.

Fixes: https://github.com/codecov/internal-issues/issues/439