### PR TITLE
Logic to remove checks from team plan customer

### DIFF
--- a/services/notification/__init__.py
+++ b/services/notification/__init__.py
@@ -13,9 +13,10 @@ from typing import Iterator, List
 from celery.exceptions import CeleryError, SoftTimeLimitExceeded
 from shared.config import get_config
 from shared.helpers.yaml import default_if_true
+from shared.plan.constants import TEAM_PLAN_REPRESENTATIONS
 from shared.yaml import UserYaml
 
-from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
+from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME, Owner
 from helpers.metrics import metrics
 from services.comparison import ComparisonProxy
 from services.decoration import Decoration
@@ -60,8 +61,11 @@ class NotificationService(object):
         if checks_yaml_field is False:
             return False
 
-        owner = self.repository.owner
+        owner: Owner = self.repository.owner
         if owner.service not in ["github", "github_enterprise"]:
+            return False
+
+        if owner.plan in TEAM_PLAN_REPRESENTATIONS:
             return False
 
         app_installation_filter = filter(

--- a/services/notification/notifiers/__init__.py
+++ b/services/notification/notifiers/__init__.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Dict, List, Type
 
 from services.notification.notifiers.base import AbstractBaseNotifier
@@ -29,20 +30,26 @@ def get_all_notifier_classes_mapping() -> Dict[str, Type[AbstractBaseNotifier]]:
     }
 
 
+class StatusType(Enum):
+    PATCH = "patch"
+    PROJECT = "project"
+    CHANGES = "changes"
+
+
 def get_status_notifier_class(
     status_type: str, class_type: str = "status"
 ) -> Type[AbstractBaseNotifier]:
-    if status_type == "patch" and class_type == "checks":
+    if status_type == StatusType.PATCH.value and class_type == "checks":
         return PatchChecksNotifier
-    if status_type == "project" and class_type == "checks":
+    if status_type == StatusType.PROJECT.value and class_type == "checks":
         return ProjectChecksNotifier
-    if status_type == "changes" and class_type == "checks":
+    if status_type == StatusType.CHANGES.value and class_type == "checks":
         return ChangesChecksNotifier
-    if status_type == "patch" and class_type == "status":
+    if status_type == StatusType.PATCH.value and class_type == "status":
         return PatchStatusNotifier
-    if status_type == "project" and class_type == "status":
+    if status_type == StatusType.PROJECT.value and class_type == "status":
         return ProjectStatusNotifier
-    if status_type == "changes" and class_type == "status":
+    if status_type == StatusType.CHANGES.value and class_type == "status":
         return ChangesStatusNotifier
 
 


### PR DESCRIPTION
Customers with team plan only get patch status/checks, regardless of their yaml settings. This PR is to add this logic as it was never done when first creating the team plan. Ticket here https://github.com/codecov/engineering-team/issues/1660.

I introduced 2 new variables that indicate whether we need a status and a check. We are reusing `_should_use_checks_notifier` to check for status I just added a small piece to make it work with this logic. We are adding `_should_use_status_notifier` which returns true unless it's a team plan without a `patch` status/check - we've always returned status otherwise. Let me know if there's any confusion with this approach

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.