### PR TITLE
fix: bring back Owner.integration_id check

### DIFF
--- a/services/bots/github_apps.py
+++ b/services/bots/github_apps.py
@@ -225,4 +225,14 @@ def get_github_app_info_for_owner(
         raise NoConfiguredAppsAvailable(
             apps_count=apps_matching_criteria_count, all_rate_limited=True
         )
+    # DEPRECATED FLOW - begin
+    if owner.integration_id and (
+        (repository and repository.using_integration) or (repository is None)
+    ):
+        log.info(
+            "Selected deprecated owner.integration_id to communicate with github",
+            extra=extra_info_to_log,
+        )
+        return [GithubInstallationInfo(installation_id=owner.integration_id)]
+    # DEPRECATED FLOW - end
     return []

--- a/services/bots/tests/test_bots.py
+++ b/services/bots/tests/test_bots.py
@@ -13,7 +13,6 @@ from database.models.core import (
     GithubAppInstallation,
 )
 from database.tests.factories.core import OwnerFactory, RepositoryFactory
-from helpers.exceptions import OwnerWithoutValidBotError, RepositoryWithoutValidBotError
 from services.bots import get_adapter_auth_information
 from services.bots.types import AdapterAuthInformation
 
@@ -160,16 +159,23 @@ class TestGettingAdapterAuthInformation(object):
             "services.bots.github_apps.get_github_integration_token",
             side_effect=get_github_integration_token_side_effect,
         )
-        def test_select_owner_deprecated_using_integration_raises(self, dbsession):
+        def test_select_owner_deprecated_using_integration(self, dbsession):
             owner = self._generate_test_owner(
                 dbsession, with_bot=False, integration_id=1500
             )
             owner.oauth_token = None
             # Owner has no GithubApp, no token, and no bot configured
-            # The integration_id is no longer verified
-            # So we fail with exception
-            with pytest.raises(OwnerWithoutValidBotError):
-                get_adapter_auth_information(owner)
+            # The integration_id is selected
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1500_None",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(installation_id=1500),
+                fallback_installations=[],
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(owner) == expected
 
         @patch(
             "services.bots.github_apps.get_github_integration_token",
@@ -451,8 +457,16 @@ class TestGettingAdapterAuthInformation(object):
             # The repo has not a bot configured
             # The integration_id is no longer verified
             # So we fail with exception
-            with pytest.raises(RepositoryWithoutValidBotError):
-                get_adapter_auth_information(repo.owner, repo)
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1500_None",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(installation_id=1500),
+                fallback_installations=[],
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(repo.owner, repo) == expected
 
         @patch(
             "services.bots.github_apps.get_github_integration_token",


### PR DESCRIPTION
it aims to revert the important bits on https://github.com/codecov/worker/pull/445/commits/f58a5a07f14749e947ef02d66338f19c4043da28

That commit was released and we saw an immediate increase in errors of `RepoWithoutValidBot`.
We suspect that it was not correct to remove the deprecated path just yet.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.