### PR TITLE
1459 ba pr message tweak

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/ae6e12f3cf43188a6d6fa0156ccb78252d3405a8.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/4b51e8af9a42660c7c2f84831534349016ef5113.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz#egg=test-results-parser
 boto3>=1.34

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/f6c2c3852530192ab0c6b9fd0c0a800c2cbdb16f.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/325b496b5dd51a9c6c1b8e6153b47a6650597598.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz#egg=test-results-parser
 boto3>=1.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -368,7 +368,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/f6c2c3852530192ab0c6b9fd0c0a800c2cbdb16f.tar.gz
+shared @ https://github.com/codecov/shared/archive/325b496b5dd51a9c6c1b8e6153b47a6650597598.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -368,7 +368,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/ae6e12f3cf43188a6d6fa0156ccb78252d3405a8.tar.gz
+shared @ https://github.com/codecov/shared/archive/4b51e8af9a42660c7c2f84831534349016ef5113.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/bundle_analysis.py
+++ b/services/bundle_analysis.py
@@ -33,6 +33,7 @@ from services.repository import (
 )
 from services.storage import get_storage_client
 from services.urls import get_bundle_analysis_pull_url
+from services.yaml import read_yaml_field
 
 log = logging.getLogger(__name__)
 
@@ -364,36 +365,41 @@ class Notifier:
             return False
 
         pullid = pull.database_pull.pullid
-        message = self._build_message(pull)
+        bundle_comparison = ComparisonLoader(pull).get_comparison()
+        skip_comment_without_size_changes = bundle_comparison.total_size_delta == 0 and read_yaml_field(self.current_yaml, ("comment", "require_bundle_changes"), False)
 
-        try:
-            comment_id = pull.database_pull.bundle_analysis_commentid
-            if comment_id:
-                await self.repository_service.edit_comment(pullid, comment_id, message)
-            else:
-                res = await self.repository_service.post_comment(pullid, message)
-                pull.database_pull.bundle_analysis_commentid = res["id"]
+        if skip_comment_without_size_changes:
+            # Return true as success
             return True
-        except TorngitClientError:
-            log.error(
-                "Error creating/updapting PR comment",
-                extra=dict(
-                    commitid=self.commit.commitid,
-                    report_key=self.commit_report.external_id,
-                    pullid=pullid,
-                ),
-            )
-            return False
+        else:
+            message = self._build_message(pull=pull, comparison=bundle_comparison)
+            try:
+                comment_id = pull.database_pull.bundle_analysis_commentid
+                if comment_id:
+                    await self.repository_service.edit_comment(pullid, comment_id, message)
+                else:
+                    res = await self.repository_service.post_comment(pullid, message)
+                    pull.database_pull.bundle_analysis_commentid = res["id"]
+                return True
+            except TorngitClientError:
+                log.error(
+                    "Error creating/updapting PR comment",
+                    extra=dict(
+                        commitid=self.commit.commitid,
+                        report_key=self.commit_report.external_id,
+                        pullid=pullid,
+                    ),
+                )
+                return False
 
-    def _build_message(self, pull: EnrichedPull) -> str:
-        comparison = ComparisonLoader(pull).get_comparison()
+    def _build_message(self, pull: EnrichedPull, comparison: BundleAnalysisComparison) -> str:
         bundle_changes = comparison.bundle_changes()
 
-        bundle_rows, total_size_delta = self._create_bundle_rows(
+        bundle_rows = self._create_bundle_rows(
             bundle_changes=bundle_changes, comparison=comparison
         )
         return self._write_lines(
-            bundle_rows=bundle_rows, total_size_delta=total_size_delta, pull=pull
+            bundle_rows=bundle_rows, total_size_delta=comparison.total_size_delta, pull=pull
         )
 
     def _create_bundle_rows(
@@ -402,13 +408,9 @@ class Notifier:
         comparison: BundleAnalysisComparison,
     ) -> Tuple[List[BundleRows], int]:
         bundle_rows = []
-        total_size_delta = 0
 
         # Calculate bundle change data in one loop since bundle_changes is a generator
         for bundle_change in bundle_changes:
-            # TODO: make this a ComparisonReport property
-            total_size_delta += bundle_change.size_delta
-
             # Define row table data
             bundle_name = bundle_change.bundle_name
             if bundle_change.change_type == BundleChange.ChangeType.REMOVED:
@@ -432,7 +434,7 @@ class Notifier:
                 )
             )
 
-        return (bundle_rows, total_size_delta)
+        return bundle_rows
 
     def _write_lines(
         self, bundle_rows: List[BundleRows], total_size_delta: int, pull: EnrichedPull

--- a/services/tests/test_bundle_analysis.py
+++ b/services/tests/test_bundle_analysis.py
@@ -297,6 +297,85 @@ Bundle size has no change :white_check_mark:"""
 
 
 @pytest.mark.asyncio
+async def test_bundle_analysis_no_notification_size_unchanged(
+    dbsession, mocker, mock_storage, mock_repo_provider
+):
+    base_commit = CommitFactory()
+    dbsession.add(base_commit)
+    base_commit_report = CommitReport(
+        commit=base_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(base_commit_report)
+
+    head_commit = CommitFactory(repository=base_commit.repository)
+    dbsession.add(head_commit)
+    head_commit_report = CommitReport(
+        commit=head_commit, report_type=ReportType.BUNDLE_ANALYSIS.value
+    )
+    dbsession.add(head_commit_report)
+
+    pull = PullFactory(
+        repository=base_commit.repository,
+        head=head_commit.commitid,
+        base=base_commit.commitid,
+        compared_to=base_commit.commitid,
+    )
+    dbsession.add(pull)
+    dbsession.commit()
+
+    notifier = Notifier(
+        head_commit, UserYaml.from_dict({"comment": {"require_bundle_changes": True}})
+    )
+
+    repo_key = ArchiveService.get_archive_hash(base_commit.repository)
+    mock_storage.write_file(
+        get_bucket_name(),
+        f"v1/repos/{repo_key}/{base_commit_report.external_id}/bundle_report.sqlite",
+        "test-content",
+    )
+    mock_storage.write_file(
+        get_bucket_name(),
+        f"v1/repos/{repo_key}/{head_commit_report.external_id}/bundle_report.sqlite",
+        "test-content",
+    )
+
+    mocker.patch(
+        "services.bundle_analysis.get_appropriate_storage_service",
+        return_value=mock_storage,
+    )
+    mocker.patch("shared.bundle_analysis.report.BundleAnalysisReport._setup")
+    mocker.patch(
+        "services.bundle_analysis.get_repo_provider_service",
+        return_value=mock_repo_provider,
+    )
+
+    bundle_changes = mocker.patch(
+        "shared.bundle_analysis.comparison.BundleAnalysisComparison.bundle_changes"
+    )
+    bundle_changes.return_value = [
+        BundleChange("test-bundle", BundleChange.ChangeType.CHANGED, size_delta=0),
+    ]
+
+    bundle_report = mocker.patch(
+        "shared.bundle_analysis.report.BundleAnalysisReport.bundle_report"
+    )
+    bundle_report.return_value = MockBundleReport()
+
+    fetch_pr = mocker.patch(
+        "services.bundle_analysis.fetch_and_update_pull_request_information_from_commit"
+    )
+    fetch_pr.return_value = EnrichedPull(
+        database_pull=pull,
+        provider_pull={},
+    )
+
+    success = await notifier.notify()
+    assert success == True
+    mock_repo_provider.post_comment.assert_not_called()
+    mock_repo_provider.edit_comment.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_bundle_analysis_notify_missing_commit_report(
     dbsession, mocker, mock_storage, mock_repo_provider
 ):

--- a/tasks/bundle_analysis_notify.py
+++ b/tasks/bundle_analysis_notify.py
@@ -99,8 +99,6 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
             # every processor errored, nothing to notify on
             notify = False
 
-        should_notify = self._should_notify()
-
         success = None
         if notify:
             installation_name_to_use = get_installation_name_for_owner_for_task(

--- a/tasks/bundle_analysis_notify.py
+++ b/tasks/bundle_analysis_notify.py
@@ -99,6 +99,8 @@ class BundleAnalysisNotifyTask(BaseCodecovTask, name=bundle_analysis_notify_task
             # every processor errored, nothing to notify on
             notify = False
 
+        should_notify = self._should_notify()
+
         success = None
         if notify:
             installation_name_to_use = get_installation_name_for_owner_for_task(


### PR DESCRIPTION
We're adjusting the BA PR comment to accommodate customers that don’t want a PR message when there are no changes, posting here for visibility. To summarize:
- We’re adding require_bundle_changes, a setting you can add to your codecov yaml
- If there are no changes
  - If require_bundle_changes = false we show “Bundle size has no change” - we default to this
  - If require_bundle_changes = true, we don’t show the comment at all
- When there are changes, we always display them, regardless of this setting ^

Moved around some logic to make it work but generally this is it

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.