### PR TITLE
feat: Add functions to get/set apps to commits

### DIFF
--- a/services/github.py
+++ b/services/github.py
@@ -1,11 +1,14 @@
 import logging
 from typing import Optional
 
+from redis import RedisError
 from shared.github import InvalidInstallationError
 from shared.github import get_github_integration_token as _get_github_integration_token
 
+from database.models.core import Commit
 from helpers.cache import cache
 from helpers.exceptions import RepositoryWithoutValidBotError
+from services.redis import get_redis_connection
 
 log = logging.getLogger(__name__)
 
@@ -24,3 +27,35 @@ def get_github_integration_token(
     except InvalidInstallationError:
         log.warning("Failed to get installation token")
         raise RepositoryWithoutValidBotError()
+
+
+COMMIT_GHAPP_KEY_NAME = lambda commit_id: f"app_to_use_for_commit_{commit_id}"
+
+
+def set_github_app_for_commit(
+    installation_id: str | int | None, commit: Commit
+) -> bool:
+    if installation_id is None:
+        return False
+    redis = get_redis_connection()
+    try:
+        redis.set(
+            COMMIT_GHAPP_KEY_NAME(commit.id), str(installation_id), ex=(60 * 60 * 2)
+        )  # 2h
+        return True
+    except RedisError:
+        log.exception(
+            "Failed to set app for commit", extra=dict(commit=commit.commitid)
+        )
+        return False
+
+
+def get_github_app_for_commit(commit: Commit) -> str | None:
+    redis = get_redis_connection()
+    try:
+        return redis.get(COMMIT_GHAPP_KEY_NAME(commit.id))
+    except RedisError:
+        log.exception(
+            "Failed to get app for commit", extra=dict(commit=commit.commitid)
+        )
+        return None

--- a/services/tests/test_github.py
+++ b/services/tests/test_github.py
@@ -1,0 +1,71 @@
+from unittest.mock import MagicMock
+
+import pytest
+from redis import RedisError
+
+from database.models.core import GithubAppInstallation, Owner
+from database.tests.factories.core import CommitFactory
+from services.github import get_github_app_for_commit, set_github_app_for_commit
+
+
+class TestGetSetGithubAppsToCommits(object):
+    def _get_commit(self, dbsession):
+        commit = CommitFactory(repository__owner__service="github")
+        dbsession.add(commit)
+        dbsession.flush()
+        return commit
+
+    def _get_app(self, owner: Owner, dbsession):
+        app = GithubAppInstallation(
+            owner=owner, installation_id=1250, app_id=250, pem_path="some_path"
+        )
+        dbsession.add(app)
+        dbsession.flush()
+        return app
+
+    @pytest.fixture
+    def mock_redis(self, mocker):
+        fake_redis = MagicMock(name="fake_redis")
+        mock_conn = mocker.patch("services.github.get_redis_connection")
+        mock_conn.return_value = fake_redis
+        return fake_redis
+
+    def test_set_app_for_commit_no_app(self, mock_redis, dbsession):
+        commit = self._get_commit(dbsession)
+        assert set_github_app_for_commit(None, commit) == False
+        mock_redis.set.assert_not_called()
+
+    def test_set_app_for_commit_redis_success(self, mock_redis, dbsession):
+        commit = self._get_commit(dbsession)
+        app = self._get_app(commit.repository.owner, dbsession)
+        assert set_github_app_for_commit(app.id, commit) == True
+        mock_redis.set.assert_called_with(
+            f"app_to_use_for_commit_{commit.id}", str(app.id), ex=(60 * 60 * 2)
+        )
+
+    def test_set_app_for_commit_redis_error(self, mock_redis, dbsession):
+        commit = self._get_commit(dbsession)
+        mock_redis.set.side_effect = RedisError
+        assert set_github_app_for_commit("1000", commit) == False
+        mock_redis.set.assert_called_with(
+            f"app_to_use_for_commit_{commit.id}", "1000", ex=(60 * 60 * 2)
+        )
+
+    def test_get_app_for_commit(self, mock_redis):
+        redis_keys = {
+            "app_to_use_for_commit_12": "1200",
+            "app_to_use_for_commit_10": "1000",
+        }
+        fake_commit_12 = MagicMock(name="fake_commit", **{"id": 12})
+        fake_commit_10 = MagicMock(name="fake_commit", **{"id": 10})
+        fake_commit_50 = MagicMock(name="fake_commit", **{"id": 50})
+        mock_redis.get.side_effect = lambda key: redis_keys.get(key)
+        assert get_github_app_for_commit(fake_commit_12) == "1200"
+        assert get_github_app_for_commit(fake_commit_10) == "1000"
+        assert get_github_app_for_commit(fake_commit_50) == None
+
+    def test_get_app_for_commit_error(self, mock_redis):
+        mock_redis.get.side_effect = RedisError
+        fake_commit_12 = MagicMock(name="fake_commit", **{"id": 12})
+        assert get_github_app_for_commit(fake_commit_12) == None
+        mock_redis.get.assert_called_with("app_to_use_for_commit_12")


### PR DESCRIPTION
Adds `set_github_app_for_commit` and `get_github_app_for_commit` functions. These let us set and later get a GithubAppInstallation.id that's related to a Commit.id

ticket: https://github.com/codecov/engineering-team/issues/1737

👀 This commit is part 1/4 of a bigger change that is actually done, but I decided to break it up into multiple PRs so it's easier to review. See how it plays with the rest here: https://github.com/codecov/worker/compare/main...gio/pin-commit-to-ghapp

(I'll try to leave the original branch up to date best as I can)