### PR TITLE
chore(ci): bump gha workflows to 1.2.20

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -14,14 +14,14 @@ jobs:
       - name: Cleanup
         run: |
           gh extension install actions/gh-actions-cache
-          
+
           REPO=${{ github.repository }}
           BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
           echo "Fetching list of cache key"
           cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH -L 100 | cut -f 1 )
 
-          ## Setting this to not fail the workflow while deleting cache keys. 
+          ## Setting this to not fail the workflow while deleting cache keys.
           set +e
           echo "Deleting caches..."
           for cacheKey in $cacheKeysForPR

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ concurrency:
 jobs:
   lint:
     name: Run Lint
-    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.20
 
   build:
     name: Build Worker
-    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.20
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
@@ -33,13 +33,13 @@ jobs:
   codecovstartup:
     name: Codecov Startup
     needs: build
-    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.20
     secrets: inherit
 
   test:
     name: Test
     needs: [build]
-    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.20
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
@@ -47,7 +47,7 @@ jobs:
   build-self-hosted:
     name: Build Self Hosted Worker
     needs: [build, test]
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.20
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
@@ -56,7 +56,7 @@ jobs:
     name: Push Staging Image
     needs: [build, test]
     if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/staging') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.20
     secrets: inherit
     with:
       environment: staging
@@ -66,7 +66,7 @@ jobs:
     name: Push Production Image
     needs: [build, test]
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.20
     secrets: inherit
     with:
       environment: production
@@ -77,7 +77,7 @@ jobs:
     needs: [build-self-hosted, test]
     secrets: inherit
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/prod') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.20
     with:
       push_rolling: true
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}

--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -11,4 +11,4 @@ on:
 jobs:
   patch-typing-check:
     name: Run Patch Type Check
-    uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.18
+    uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.20

--- a/.github/workflows/self-hosted-release-pr.yml
+++ b/.github/workflows/self-hosted-release-pr.yml
@@ -10,5 +10,5 @@ on:
 jobs:
   create-release-pr:
     name: Create PR for Release ${{ github.event.inputs.versionName }}
-    uses: codecov/gha-workflows/.github/workflows/create-release-pr.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/create-release-pr.yml@v1.2.20
     secrets: inherit

--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -14,7 +14,7 @@ jobs:
   create-release:
     name: Tag Release ${{ github.head_ref }} and Push Docker image to Docker Hub
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/create-release.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/create-release.yml@v1.2.20
     with:
       tag_to_prepend: self-hosted-
     secrets: inherit
@@ -22,7 +22,7 @@ jobs:
   push-image:
     needs: [create-release]
     if: ${{ github.event.pull_request.merged == true && startsWith(github.head_ref, 'release/') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.19
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.20
     secrets: inherit
     with:
       push_release: true


### PR DESCRIPTION
<!-- Describe your PR here. -->

Bumps the GHA Action workflows to 1.2.20

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.