### PR TITLE
delete outdated/noisy log

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -279,10 +279,6 @@ class ReportService(BaseReportService):
                 #   yet into the new models therefore it needs backfilling
                 self.save_full_report(commit, actual_report)
         elif current_report_row.details is None:
-            log.warning(
-                "Commit unexpectedly had CommitReport but no details",
-                extra=dict(commit=commit.commitid, repoid=commit.repoid),
-            )
             report_details = ReportDetails(
                 report_id=current_report_row.id_,
                 _files_array=[],


### PR DESCRIPTION
i think the new report endpoint that the CLI's `create-report` command hits will create a `CommitReport` without creating a `ReportDetails` ([link](https://github.com/codecov/codecov-api/blob/f1a4eee037253eb39da3291b6a2ccca7702ff518/upload/views/reports.py#L40)) so this log is not actually unexpected and fires way too much