### PR TITLE
feat: create django version of the repository and bots services

### DIFF
--- a/helpers/token_refresh_django.py
+++ b/helpers/token_refresh_django.py
@@ -1,0 +1,42 @@
+import logging
+from typing import Callable, Dict
+
+from asgiref.sync import sync_to_async
+from shared.django_apps.codecov_auth.models import Owner
+from shared.encryption.token import encode_token
+
+from services.encryption import encryptor
+
+log = logging.getLogger(__name__)
+
+
+def get_token_refresh_callback(owner: Owner) -> Callable[[Dict], None]:
+    """
+    Produces a callback function that will encode and update the oauth token of a user.
+    This callback is passed to the TorngitAdapter for the service.
+    """
+    # Some tokens don't have to be refreshed (GH integration, default bots)
+    # They don't belong to any owners.
+    if owner is None:
+        return None
+
+    service = owner.service
+    if service == "bitbucket" or service == "bitbucket_server":
+        return None
+
+    async def callback(new_token: Dict) -> None:
+        log.info(
+            "Saving new token after refresh",
+            extra=dict(owner=owner.username, ownerid=owner.ownerid),
+        )
+        string_to_save = encode_token(new_token)
+        oauth_token = encryptor.encode(string_to_save).decode()
+
+        @sync_to_async
+        def save_to_owner():
+            owner.oauth_token = oauth_token
+            owner.save()
+
+        await save_to_owner()
+
+    return callback

--- a/services/bots_django/__init__.py
+++ b/services/bots_django/__init__.py
@@ -1,0 +1,66 @@
+import logging
+from typing import List, Optional
+
+from shared.django_apps.codecov_auth.models import (
+    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+    Owner,
+    Service,
+)
+from shared.django_apps.core.models import Repository
+from shared.typings.torngit import GithubInstallationInfo
+
+from services.bots_django.github_apps import get_github_app_info_for_owner
+from services.bots_django.owner_bots import get_owner_appropriate_bot_token
+from services.bots_django.public_bots import get_token_type_mapping
+from services.bots_django.repo_bots import get_repo_appropriate_bot_token
+from services.bots_django.types import (
+    AdapterAuthInformation,
+)
+
+log = logging.getLogger(__name__)
+
+
+def get_adapter_auth_information(
+    owner: Owner,
+    repository: Optional[Repository] = None,
+    *,
+    ignore_installations: bool = False,
+    installation_name_to_use: str = GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+) -> AdapterAuthInformation:
+    """Gets all the auth information needed to send requests to the provider"""
+    installation_info: GithubInstallationInfo | None = None
+    token_type_mapping = None
+    fallback_installations: List[GithubInstallationInfo] | None = None
+    if (
+        Service(owner.service) in [Service.GITHUB, Service.GITHUB_ENTERPRISE]
+        # in sync_teams and sync_repos we might prefer to use the owner's OAuthToken instead of installation
+        and not ignore_installations
+    ):
+        installations_available_info = get_github_app_info_for_owner(
+            owner,
+            repository=repository,
+            installation_name=installation_name_to_use,
+        )
+        if installations_available_info != []:
+            installation_info, *fallback_installations = installations_available_info
+
+    if repository:
+        token, token_owner = get_repo_appropriate_bot_token(
+            repository, installation_info
+        )
+        if installation_info is None:
+            # the admin_bot_token should be associated with an Owner so we know that it was
+            # actually configured for this Repository.
+            # The exception would be GH installation tokens, but in that case we don't use token_type_mapping
+            token_type_mapping = get_token_type_mapping(
+                repository, admin_bot_token=(token if token_owner else None)
+            )
+    else:
+        token, token_owner = get_owner_appropriate_bot_token(owner, installation_info)
+    return AdapterAuthInformation(
+        token=token,
+        token_owner=token_owner,
+        selected_installation_info=installation_info,
+        fallback_installations=fallback_installations,
+        token_type_mapping=token_type_mapping,
+    )

--- a/services/bots_django/github_apps.py
+++ b/services/bots_django/github_apps.py
@@ -1,0 +1,247 @@
+import logging
+import random
+from datetime import datetime, timezone
+from typing import Dict, List, Optional
+
+from shared.django_apps.codecov_auth.models import (
+    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+    GithubAppInstallation,
+    Owner,
+    Service,
+)
+from shared.django_apps.core.models import Repository
+from shared.github import is_installation_rate_limited
+from shared.typings.oauth_token_types import Token
+from shared.typings.torngit import GithubInstallationInfo
+
+from helpers.exceptions import (
+    NoConfiguredAppsAvailable,
+)
+from services.bots_django.types import TokenWithOwner
+from services.github import get_github_integration_token
+from services.redis import get_redis_connection
+
+log = logging.getLogger(__name__)
+
+
+MAX_GITHUB_APP_SELECTION_WEIGHT = 1200
+
+
+def _get_installation_weight(installation: GithubAppInstallation) -> int:
+    """The weight for a given app installation.
+    Establishes an exponential ramp-up period for installations after being updated.
+    """
+    age = datetime.now(timezone.utc) - installation.created_at
+    if age.days >= 10:
+        return MAX_GITHUB_APP_SELECTION_WEIGHT
+    seconds_in_hour = 3600
+    age_hours = (age.seconds // seconds_in_hour) + age.days * 24
+    # Prevent clock differences from making the weight negative
+    return max(1, age_hours + 2**age.days)
+
+
+def _can_use_this_app(
+    app: GithubAppInstallation, installation_name: str, repository: Optional[Repository]
+) -> bool:
+    return (
+        app.name == installation_name
+        # We ignore apps that are not configured because those can't be used
+        and app.is_configured()
+        # If repository is provided, the installation needs to cover it
+        and ((not repository) or app.is_repo_covered_by_integration(repository))
+    )
+
+
+def _get_apps_from_weighted_selection(
+    owner: Owner, installation_name: str, repository: Optional[Repository]
+) -> List[GithubAppInstallation]:
+    """This function returns an ordered list of GithubAppInstallations that can be used to communicate with GitHub
+    in behalf of the owner. The list is ordered in such a way that the 1st element is the app to be used in Torngit,
+    and the subsequent apps are selected as fallbacks.
+
+    IF the repository is provided, the selected apps also cover the repo.
+    IF installation_name is not the default one, than the default codecov installation
+      is also selected as a possible fallback app.
+
+    Apps are selected randomly but assigned weights based on how recently they were created.
+    This means that older apps are selected more frequently as the main app than newer ones.
+    (up to 10 days, when the probability of being chosen is the same)
+    The random selection is done so we can distribute request load more evenly among apps.
+    """
+    # Map GithubAppInstallation.id --> GithubAppInstallation
+    log.info(
+        f"hello {owner.github_app_installations}",
+    )
+    log.info(f"hi {owner.github_app_installations.all()}")
+    for obj in owner.github_app_installations.all():
+        log.info("hi")
+        log.info(f"world {obj}")
+
+    ghapp_installations_filter: Dict[int, GithubAppInstallation] = {
+        obj.id: obj
+        for obj in filter(
+            lambda obj: _can_use_this_app(obj, installation_name, repository),
+            owner.github_app_installations.all() or [],
+        )
+    }
+    # We assign weights to the apps based on how long ago they were created.
+    # The idea is that there's a greater chance that a change misconfigured the app,
+    # So apps recently created are selected less frequently than older apps
+    keys = list(ghapp_installations_filter.keys())
+    weights = [
+        min(
+            MAX_GITHUB_APP_SELECTION_WEIGHT,
+            _get_installation_weight(ghapp_installations_filter[key]),
+        )
+        for key in keys
+    ]
+    # We pick apps one by one until all apps have been selected
+    # Obviously apps with a higher weight have a higher change of being selected as the main app (1st selection)
+    # But it's important that others are also selected so we can use them as fallbacks
+    apps_to_consider = []
+    apps_to_select = len(keys)
+    selections = 0
+    while selections < apps_to_select:
+        selected_app_id = random.choices(keys, weights, k=1)[0]
+        apps_to_consider.append(ghapp_installations_filter[selected_app_id])
+        # random.choices chooses with replacement
+        # which we are trying to avoid here. So we remove the key selected and its weight from the population.
+        key_idx = keys.index(selected_app_id)
+        keys.pop(key_idx)
+        weights.pop(key_idx)
+        selections += 1
+    if installation_name != GITHUB_APP_INSTALLATION_DEFAULT_NAME:
+        # Add the default app as the last fallback if the owner is using a different app for the task
+        default_apps = filter(
+            lambda obj: _can_use_this_app(
+                obj, GITHUB_APP_INSTALLATION_DEFAULT_NAME, repository
+            ),
+            owner.github_app_installations.all(),
+        )
+        if default_apps:
+            apps_to_consider.extend(default_apps)
+    return apps_to_consider
+
+
+def get_github_app_token(
+    service: Service, installation_info: GithubInstallationInfo
+) -> TokenWithOwner:
+    """Get an access_token from GitHub that we can use to authenticate as the installation
+    See https://docs.github.com/en/enterprise-server@3.9/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation#generating-an-installation-access-token
+    """
+    github_token = get_github_integration_token(
+        service.value,
+        installation_info["installation_id"],
+        app_id=installation_info.get("app_id", None),
+        pem_path=installation_info.get("pem_path", None),
+    )
+    installation_token = Token(key=github_token)
+    # The token is not owned by an Owner object, so 2nd arg is None
+    return installation_token, None
+
+
+def get_github_app_info_for_owner(
+    owner: Owner,
+    *,
+    repository: Optional[Repository] = None,
+    installation_name: str = GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+) -> List[GithubInstallationInfo]:
+    """Gets the GitHub app info needed to communicate with GitHub using an app for this owner.
+    If multiple apps are available for this owner a selection is done to have 1 main app, and the others
+    are listed as fallback options.
+
+    ⚠️ The return of this function is NOT enough to actually send requests to GitHub using the app. For that you need to call 'get_github_integration_token'
+    with an installation info, to get a token. This token is used to send requests to GitHub _as the app_
+    (i.e. authenticating as an app installation, see https://docs.github.com/en/enterprise-server@3.9/apps/creating-github-apps/authenticating-with-a-github-app/about-authentication-with-a-github-app#authentication-as-an-app-installation)
+
+    GitHub App information can be:
+        1. A GithubAppInstallation that belongs to the owner
+        2. (deprecated) Owner.integration_id
+
+    Args:
+        owner (Owner): The owner to get GitHub App info for.
+        repository (Repository | None): The repo that we will interact with.
+            Any GitHub App info returned needs to cover this repo
+        installation_name (str): The installation name to search for in the available apps.
+            GitHubAppInstallation.name must be equal to installation_name for it to be returned.
+
+    Returns:
+        (ordered) List[GithubInstallationInfo]: where index 0 is the main app and the others are fallback options
+
+    Raises:
+        NoConfiguredAppsAvailable: Owner has app installations available, but they are all currently rate limited.
+    """
+    extra_info_to_log = dict(
+        ownerid=owner.ownerid,
+        repoid=getattr(repository, "repoid", None),
+    )
+    log.info(
+        "Getting owner's GitHub Apps info",
+        extra=dict(
+            installation_name=installation_name,
+            **extra_info_to_log,
+        ),
+    )
+    owner_service = Service(owner.service)
+    if owner_service not in [Service.GITHUB, Service.GITHUB_ENTERPRISE]:
+        log.info(
+            "Owner's service not GitHub",
+            extra=dict(service=owner_service, **extra_info_to_log),
+        )
+        return []
+
+    # Get the apps available for the owner with the given 'installation_name'
+    # AND that cover 'repository' (if provided)
+    apps_to_consider = _get_apps_from_weighted_selection(
+        owner, installation_name, repository
+    )
+    apps_matching_criteria_count = len(apps_to_consider)
+
+    redis_connection = get_redis_connection()
+    apps_to_consider = list(
+        filter(
+            lambda obj: not is_installation_rate_limited(
+                redis_connection, obj.installation_id, app_id=obj.app_id
+            ),
+            apps_to_consider,
+        )
+    )
+
+    if apps_to_consider:
+        main_name = apps_to_consider[0].name
+        info_to_get_tokens = list(
+            map(
+                lambda obj: GithubInstallationInfo(
+                    installation_id=obj.installation_id,
+                    app_id=obj.app_id,
+                    pem_path=obj.pem_path,
+                ),
+                apps_to_consider,
+            )
+        )
+        log.info(
+            "Selected installation to communicate with github",
+            extra=dict(
+                installation_id=info_to_get_tokens[0]["installation_id"],
+                installation_name=main_name,
+                fallback_installations=[
+                    obj["installation_id"] for obj in info_to_get_tokens
+                ],
+            ),
+        )
+        return info_to_get_tokens
+    elif apps_matching_criteria_count > 0:
+        raise NoConfiguredAppsAvailable(
+            apps_count=apps_matching_criteria_count, all_rate_limited=True
+        )
+    # DEPRECATED FLOW - begin
+    if owner.integration_id and (
+        (repository and repository.using_integration) or (repository is None)
+    ):
+        log.info(
+            "Selected deprecated owner.integration_id to communicate with github",
+            extra=extra_info_to_log,
+        )
+        return [GithubInstallationInfo(installation_id=owner.integration_id)]
+    # DEPRECATED FLOW - end
+    return []

--- a/services/bots_django/owner_bots.py
+++ b/services/bots_django/owner_bots.py
@@ -1,0 +1,37 @@
+import logging
+
+from shared.django_apps.codecov_auth.models import Owner, Service
+from shared.typings.torngit import GithubInstallationInfo
+
+from helpers.exceptions import OwnerWithoutValidBotError
+from services.bots_django.github_apps import get_github_app_token
+from services.bots_django.types import TokenWithOwner
+from services.encryption import encryptor
+
+log = logging.getLogger(__name__)
+
+
+def get_owner_or_appropriate_bot(owner: Owner, repoid: int | None = None) -> Owner:
+    if owner.bot is not None and owner.bot.oauth_token is not None:
+        log.info(
+            "Owner has specific bot",
+            extra=dict(botid=owner.bot.ownerid, ownerid=owner.ownerid, repoid=repoid),
+        )
+        return owner.bot
+    elif owner.oauth_token is not None:
+        log.info(
+            "No bot, using owner", extra=dict(ownerid=owner.ownerid, repoid=repoid)
+        )
+        return owner
+    raise OwnerWithoutValidBotError()
+
+
+def get_owner_appropriate_bot_token(
+    owner, installation_info: GithubInstallationInfo | None = None
+) -> TokenWithOwner:
+    if installation_info:
+        result = get_github_app_token(Service(owner.service), installation_info)
+        return result
+
+    token_owner = get_owner_or_appropriate_bot(owner)
+    return encryptor.decrypt_token(token_owner.oauth_token), token_owner

--- a/services/bots_django/public_bots.py
+++ b/services/bots_django/public_bots.py
@@ -1,0 +1,68 @@
+import logging
+
+from shared.config import get_config
+from shared.django_apps.codecov_auth.models import Service
+from shared.django_apps.core.models import Repository
+from shared.torngit.base import TokenType
+from shared.typings.oauth_token_types import Token
+
+from helpers.exceptions import RepositoryWithoutValidBotError
+from services.bots_django.types import TokenTypeMapping, TokenWithOwner
+
+log = logging.getLogger(__name__)
+
+
+def get_public_bot_token(service: Service, repoid: int) -> TokenWithOwner:
+    """Gets the configured public bot for a service.
+
+    These bots are declared in the install YAML per service.
+    They can only access public repositories (in general)
+    """
+    # Generic bot for this service
+    public_bot_dict = get_config(service.value, "bot")
+    # Function-specific bots for this service
+    # In this case we want the 'tokenless' function
+    tokenless_bot_dict = get_config(
+        service.value, "bots", "tokenless", default=public_bot_dict
+    )
+
+    if tokenless_bot_dict and tokenless_bot_dict.get("key"):
+        log.info(
+            "Using tokenless bot as bot fallback",
+            extra=dict(repoid=repoid, botname=tokenless_bot_dict.get("username")),
+        )
+        # Once again token not owned by an Owner.
+        return tokenless_bot_dict, None
+
+    log.error(
+        "No tokenless bot dict in get_public_bot_token",
+        extra=dict(repoid=repoid),
+    )
+    raise RepositoryWithoutValidBotError()
+
+
+def get_token_type_mapping(
+    repo: Repository, admin_bot_token: Token | None = None
+) -> TokenTypeMapping | None:
+    """Gets the fallback tokens configured via install YAML per function.
+
+    This only affects _public_ repos, as private ones need a token defined.
+    A public repo might have a token defined (the admin_bot), in which case it is used for all functions,
+    except comment.
+    """
+    if repo.private:
+        return None
+
+    if admin_bot_token is None:
+        log.warning(
+            "No admin_bog_token provided, but still continuing operations in case it is not doing an admin call anyway",
+            extra=dict(repoid=repo.repoid),
+        )
+    return {
+        TokenType.read: admin_bot_token or get_config(repo.service, "bots", "read"),
+        TokenType.admin: admin_bot_token,
+        TokenType.comment: get_config(repo.service, "bots", "comment"),
+        TokenType.status: admin_bot_token or get_config(repo.service, "bots", "status"),
+        TokenType.tokenless: admin_bot_token
+        or get_config(repo.service, "bots", "tokenless"),
+    }

--- a/services/bots_django/repo_bots.py
+++ b/services/bots_django/repo_bots.py
@@ -1,0 +1,73 @@
+import logging
+
+from shared.config import get_config
+from shared.django_apps.codecov_auth.models import Owner, Service
+from shared.django_apps.core.models import Repository
+from shared.typings.torngit import GithubInstallationInfo
+
+from helpers.environment import is_enterprise
+from helpers.exceptions import (
+    OwnerWithoutValidBotError,
+    RepositoryWithoutValidBotError,
+)
+from services.bots_django.github_apps import get_github_app_token
+from services.bots_django.owner_bots import get_owner_or_appropriate_bot
+from services.bots_django.public_bots import get_public_bot_token
+from services.bots_django.types import TokenWithOwner
+from services.encryption import encryptor
+
+log = logging.getLogger(__name__)
+
+
+def get_repo_particular_bot_token(repo) -> TokenWithOwner:
+    appropriate_bot = get_repo_appropriate_bot(repo)
+    token_dict = encryptor.decrypt_token(appropriate_bot.oauth_token)
+    token_dict["username"] = appropriate_bot.username
+    return token_dict, appropriate_bot
+
+
+def get_repo_appropriate_bot(repo: Repository) -> Owner:
+    if repo.bot is not None and repo.bot.oauth_token is not None:
+        log.info(
+            "Repo has specific bot",
+            extra=dict(repoid=repo.repoid, botid=repo.bot.ownerid),
+        )
+        return repo.bot
+    try:
+        return get_owner_or_appropriate_bot(repo.author)
+    except OwnerWithoutValidBotError:
+        raise RepositoryWithoutValidBotError()
+
+
+def get_repo_appropriate_bot_token(
+    repo: Repository,
+    installation_info: GithubInstallationInfo | None = None,
+) -> TokenWithOwner:
+    extra_info_to_log = dict(
+        repoid=repo.repoid, is_private=repo.private, service=repo.service
+    )
+    log.info(
+        "Get repo appropriate bot token",
+        extra={"installation_info": installation_info, **extra_info_to_log},
+    )
+
+    service = Service(repo.service)
+
+    if is_enterprise() and get_config(repo.service, "bot"):
+        log.info(
+            "Using enterprise-configured bot for the service", extra=extra_info_to_log
+        )
+        return get_public_bot_token(service, repo.repoid)
+
+    if installation_info:
+        log.info("Using github installation", extra=extra_info_to_log)
+        return get_github_app_token(service, installation_info)
+    try:
+        token_dict, appropriate_bot = get_repo_particular_bot_token(repo)
+        log.info("Using repo particular bot", extra=extra_info_to_log)
+        return token_dict, appropriate_bot
+    except RepositoryWithoutValidBotError as e:
+        if not repo.private:
+            log.info("Using YAML-configured public bot", extra=extra_info_to_log)
+            return get_public_bot_token(service, repo.repoid)
+        raise e

--- a/services/bots_django/tests/test_bots.py
+++ b/services/bots_django/tests/test_bots.py
@@ -1,0 +1,581 @@
+import datetime
+from typing import List, Optional
+from unittest.mock import patch
+
+import pytest
+from shared.django_apps.codecov_auth.models import (
+    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+    GithubAppInstallation,
+)
+from shared.django_apps.core.tests.factories import OwnerFactory, RepositoryFactory
+from shared.torngit.base import TokenType
+from shared.typings.oauth_token_types import Token
+from shared.typings.torngit import GithubInstallationInfo
+from shared.utils.test_utils import mock_config_helper
+
+from services.bots_django import get_adapter_auth_information
+from services.bots_django.types import AdapterAuthInformation
+
+
+def get_github_integration_token_side_effect(
+    service: str,
+    installation_id: int = None,
+    app_id: Optional[str] = None,
+    pem_path: Optional[str] = None,
+):
+    return f"installation_token_{installation_id}_{app_id}"
+
+
+@pytest.mark.django_db
+class TestGettingAdapterAuthInformation(object):
+    class TestGitHubOwnerNoRepoInfo(object):
+        def _generate_test_owner(
+            self,
+            *,
+            with_bot: bool,
+            integration_id: int | None = None,
+            ghapp_installations: List[GithubAppInstallation] = None,
+        ):
+            if ghapp_installations is None:
+                ghapp_installations = []
+            owner = OwnerFactory(
+                service="github",
+                bot=None,
+                unencrypted_oauth_token="owner_token: :refresh_token",
+                integration_id=integration_id,
+            )
+            if with_bot:
+                owner.bot = OwnerFactory(
+                    service="github",
+                    unencrypted_oauth_token="bot_token: :bot_refresh_token",
+                )
+            owner.save()
+
+            if ghapp_installations:
+                for app in ghapp_installations:
+                    app.owner = owner
+                    app.save()
+
+            assert bool(owner.bot) == with_bot
+            assert list(owner.github_app_installations.all()) == ghapp_installations
+
+            return owner
+
+        def test_select_owner_info(self, transactional_db):
+            owner = self._generate_test_owner(with_bot=False)
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="owner_token", refresh_token="refresh_token", secret=None
+                ),
+                token_owner=owner,
+                selected_installation_info=None,
+                fallback_installations=None,
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(owner) == expected
+
+        def test_select_owner_bot_info(self, transactional_db):
+            owner = self._generate_test_owner(with_bot=True)
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="bot_token", refresh_token="bot_refresh_token", secret=None
+                ),
+                token_owner=owner.bot,
+                selected_installation_info=None,
+                fallback_installations=None,
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(owner) == expected
+
+        @patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            side_effect=get_github_integration_token_side_effect,
+        )
+        def test_select_owner_single_installation(self, transactional_db):
+            installations = [
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1200,
+                    name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+                    app_id=200,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                )
+            ]
+            owner = self._generate_test_owner(
+                with_bot=False, ghapp_installations=installations
+            )
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1200_200",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(
+                    installation_id=1200, app_id=200, pem_path="pem_path"
+                ),
+                fallback_installations=[],
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(owner) == expected
+
+        @patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            side_effect=get_github_integration_token_side_effect,
+        )
+        def test_select_owner_single_installation_ignoring_installations(
+            self, transactional_db
+        ):
+            installations = [
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1200,
+                    name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+                    app_id=200,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                )
+            ]
+            owner = self._generate_test_owner(
+                with_bot=False, ghapp_installations=installations
+            )
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="owner_token", refresh_token="refresh_token", secret=None
+                ),
+                token_owner=owner,
+                selected_installation_info=None,
+                fallback_installations=None,
+                token_type_mapping=None,
+            )
+            assert (
+                get_adapter_auth_information(owner, ignore_installations=True)
+                == expected
+            )
+
+        @patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            side_effect=get_github_integration_token_side_effect,
+        )
+        def test_select_owner_deprecated_using_integration(self, transactional_db):
+            owner = self._generate_test_owner(with_bot=False, integration_id=1500)
+            owner.oauth_token = None
+            # Owner has no GithubApp, no token, and no bot configured
+            # The integration_id is selected
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1500_None",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(installation_id=1500),
+                fallback_installations=[],
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(owner) == expected
+
+        @patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            side_effect=get_github_integration_token_side_effect,
+        )
+        def test_select_owner_multiple_installations_default_name(
+            self, transactional_db
+        ):
+            installations = [
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1200,
+                    name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+                    app_id=200,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                ),
+                # This should be ignored in the selection because of the name
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1300,
+                    name="my_dedicated_app",
+                    app_id=300,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                ),
+            ]
+            owner = self._generate_test_owner(
+                with_bot=False, ghapp_installations=installations
+            )
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1200_200",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(
+                    installation_id=1200, app_id=200, pem_path="pem_path"
+                ),
+                fallback_installations=[],
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(owner) == expected
+
+        @patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            side_effect=get_github_integration_token_side_effect,
+        )
+        def test_select_owner_multiple_installations_custom_name(
+            self, transactional_db
+        ):
+            installations = [
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1200,
+                    name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+                    app_id=200,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                ),
+                # This should be selected first
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1300,
+                    name="my_dedicated_app",
+                    app_id=300,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                ),
+            ]
+            owner = self._generate_test_owner(
+                with_bot=False, ghapp_installations=installations
+            )
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1300_300",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(
+                    installation_id=1300, app_id=300, pem_path="pem_path"
+                ),
+                fallback_installations=[
+                    GithubInstallationInfo(
+                        installation_id=1200, app_id=200, pem_path="pem_path"
+                    )
+                ],
+                token_type_mapping=None,
+            )
+            assert (
+                get_adapter_auth_information(
+                    owner, installation_name_to_use="my_dedicated_app"
+                )
+                == expected
+            )
+
+    class TestGitHubOwnerWithRepoInfo(object):
+        def _generate_test_repo(
+            self,
+            with_bot: bool,
+            with_owner_bot: bool,
+            integration_id: int | None = None,
+            ghapp_installations: List[GithubAppInstallation] = None,
+        ):
+            if ghapp_installations is None:
+                ghapp_installations = []
+            owner = OwnerFactory(
+                service="github",
+                bot=None,
+                unencrypted_oauth_token="owner_token: :refresh_token",
+                integration_id=integration_id,
+            )
+            if with_owner_bot:
+                owner.bot = OwnerFactory(
+                    service="github",
+                    unencrypted_oauth_token="bot_token: :bot_refresh_token",
+                )
+            owner.save()
+
+            if ghapp_installations:
+                for app in ghapp_installations:
+                    app.owner = owner
+                    app.save()
+
+            repo = RepositoryFactory(
+                author=owner, using_integration=(integration_id is not None)
+            )
+            if with_bot:
+                repo.bot = OwnerFactory(
+                    service="github",
+                    unencrypted_oauth_token="repo_bot_token: :repo_bot_refresh_token",
+                )
+
+            repo.save()
+
+            assert bool(owner.bot) == with_owner_bot
+            assert bool(repo.bot) == with_bot
+            assert list(owner.github_app_installations.all()) == ghapp_installations
+
+            return repo
+
+        def test_select_repo_info_fallback_to_owner(self, transactional_db):
+            repo = self._generate_test_repo(with_bot=False, with_owner_bot=False)
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="owner_token",
+                    refresh_token="refresh_token",
+                    secret=None,
+                    username=repo.author.username,
+                ),
+                token_owner=repo.author,
+                selected_installation_info=None,
+                fallback_installations=None,
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(repo.author, repo) == expected
+
+        def test_select_owner_bot_info(self, transactional_db):
+            repo = self._generate_test_repo(with_owner_bot=True, with_bot=False)
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="bot_token",
+                    refresh_token="bot_refresh_token",
+                    secret=None,
+                    username=repo.author.bot.username,
+                ),
+                token_owner=repo.author.bot,
+                selected_installation_info=None,
+                fallback_installations=None,
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(repo.author, repo) == expected
+
+        def test_select_repo_bot_info(self, transactional_db):
+            repo = self._generate_test_repo(with_owner_bot=True, with_bot=True)
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="repo_bot_token",
+                    refresh_token="repo_bot_refresh_token",
+                    secret=None,
+                    username=repo.bot.username,
+                ),
+                token_owner=repo.bot,
+                selected_installation_info=None,
+                fallback_installations=None,
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(repo.author, repo) == expected
+
+        def test_select_repo_bot_info_public_repo(
+            self, transactional_db, mock_configuration
+        ):
+            repo = self._generate_test_repo(with_owner_bot=True, with_bot=True)
+            mock_configuration.set_params(
+                {
+                    "github": {
+                        "bot": {"key": "some_key"},
+                        "bots": {
+                            "read": {"key": "read_bot_key"},
+                            "status": {"key": "status_bot_key"},
+                            "comment": {"key": "commenter_bot_key"},
+                        },
+                    }
+                }
+            )
+            repo.private = False
+
+            repo_bot_token = Token(
+                key="repo_bot_token",
+                refresh_token="repo_bot_refresh_token",
+                secret=None,
+                username=repo.bot.username,
+            )
+            expected = AdapterAuthInformation(
+                token=repo_bot_token,
+                token_owner=repo.bot,
+                selected_installation_info=None,
+                fallback_installations=None,
+                token_type_mapping={
+                    TokenType.comment: Token(key="commenter_bot_key"),
+                    TokenType.read: repo_bot_token,
+                    TokenType.admin: repo_bot_token,
+                    TokenType.status: repo_bot_token,
+                    TokenType.tokenless: repo_bot_token,
+                },
+            )
+            assert get_adapter_auth_information(repo.author, repo) == expected
+
+        @patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            side_effect=get_github_integration_token_side_effect,
+        )
+        def test_select_repo_single_installation(self, transactional_db):
+            installations = [
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1200,
+                    name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+                    app_id=200,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                )
+            ]
+            repo = self._generate_test_repo(
+                with_bot=False,
+                with_owner_bot=False,
+                ghapp_installations=installations,
+            )
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1200_200",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(
+                    installation_id=1200, app_id=200, pem_path="pem_path"
+                ),
+                fallback_installations=[],
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(repo.author, repo) == expected
+
+        @patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            side_effect=get_github_integration_token_side_effect,
+        )
+        def test_select_repo_deprecated_using_integration(self, transactional_db):
+            repo = self._generate_test_repo(
+                with_bot=False, integration_id=1500, with_owner_bot=False
+            )
+            repo.author.oauth_token = None
+            # Repo's owner has no GithubApp, no token, and no bot configured
+            # The repo has not a bot configured
+            # The integration_id is no longer verified
+            # So we fail with exception
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1500_None",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(installation_id=1500),
+                fallback_installations=[],
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(repo.author, repo) == expected
+
+        @patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            side_effect=get_github_integration_token_side_effect,
+        )
+        def test_select_repo_multiple_installations_default_name(
+            self, transactional_db
+        ):
+            installations = [
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1200,
+                    name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+                    app_id=200,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                ),
+                # This should be ignored in the selection because of the name
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1300,
+                    name="my_dedicated_app",
+                    app_id=300,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                ),
+            ]
+            repo = self._generate_test_repo(
+                with_bot=False,
+                with_owner_bot=False,
+                ghapp_installations=installations,
+            )
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1200_200",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(
+                    installation_id=1200, app_id=200, pem_path="pem_path"
+                ),
+                fallback_installations=[],
+                token_type_mapping=None,
+            )
+            assert get_adapter_auth_information(repo.author, repo) == expected
+
+        @patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            side_effect=get_github_integration_token_side_effect,
+        )
+        def test_select_repo_multiple_installations_custom_name(self, transactional_db):
+            installations = [
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1200,
+                    name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+                    app_id=200,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                ),
+                # This should be selected first
+                GithubAppInstallation(
+                    repository_service_ids=None,
+                    installation_id=1300,
+                    name="my_dedicated_app",
+                    app_id=300,
+                    pem_path="pem_path",
+                    created_at=datetime.datetime.now(datetime.UTC),
+                ),
+            ]
+            repo = self._generate_test_repo(
+                with_bot=False,
+                with_owner_bot=False,
+                ghapp_installations=installations,
+            )
+            expected = AdapterAuthInformation(
+                token=Token(
+                    key="installation_token_1300_300",
+                ),
+                token_owner=None,
+                selected_installation_info=GithubInstallationInfo(
+                    installation_id=1300, app_id=300, pem_path="pem_path"
+                ),
+                fallback_installations=[
+                    GithubInstallationInfo(
+                        installation_id=1200, app_id=200, pem_path="pem_path"
+                    )
+                ],
+                token_type_mapping=None,
+            )
+            assert (
+                get_adapter_auth_information(
+                    repo.author, repo, installation_name_to_use="my_dedicated_app"
+                )
+                == expected
+            )
+
+    @pytest.mark.parametrize("service", ["github", "gitlab"])
+    def test_select_repo_public_with_no_token_no_admin_token_configured(
+        self, service, transactional_db, mocker
+    ):
+        repo = RepositoryFactory(author__service=service, private=False)
+        repo.author.oauth_token = None
+        repo.save()
+        mock_config_helper(
+            mocker,
+            configs={
+                f"{service}.bots.tokenless": {"key": "tokenless_bot_token"},
+                f"{service}.bots.comment": {"key": "commenter_bot_token"},
+                f"{service}.bots.read": {"key": "reader_bot_token"},
+                f"{service}.bots.status": {"key": "status_bot_token"},
+            },
+        )
+        expected = AdapterAuthInformation(
+            token=Token(key="tokenless_bot_token"),
+            token_owner=None,
+            selected_installation_info=None,
+            fallback_installations=None,
+            token_type_mapping={
+                TokenType.comment: Token(key="commenter_bot_token"),
+                TokenType.read: Token(key="reader_bot_token"),
+                TokenType.admin: None,
+                TokenType.status: Token(key="status_bot_token"),
+                TokenType.tokenless: Token(key="tokenless_bot_token"),
+            },
+        )
+        assert get_adapter_auth_information(repo.author, repo) == expected

--- a/services/bots_django/types.py
+++ b/services/bots_django/types.py
@@ -1,0 +1,34 @@
+from typing import Dict, List, Optional, Tuple, TypedDict
+
+from shared.django_apps.codecov_auth.models import Owner
+from shared.torngit.base import TokenType
+from shared.typings.oauth_token_types import Token
+from shared.typings.torngit import GithubInstallationInfo
+
+# A Token and its Owner
+# If a Token doesn't belong to Owner (i.e. it's a GitHubAppInstallation Token), second value is None
+type TokenWithOwner = Tuple[Token, Optional[Owner]]
+
+type TokenTypeMapping = Dict[TokenType, Token]
+
+
+class AdapterAuthInformation(TypedDict):
+    """This class is just a type annotation for the return value of services.bots.get_adapter_auth_information
+    It is a container with all the information we need to authenticate a given repo/owner with the git provider.
+    Specific fields have comments to document them further
+    """
+
+    # This is the Authentication used with the git provider
+    token: Token
+    # token_owner is used to decide on token_refresh functions
+    token_owner: Owner | None
+    # GitHub app info - exclusive for GitHub (duh)
+    # Preferred method of authentication (if available)
+    # selected_installation_info is the installation being used to communicate with github. We save this info in the TorngitAdapter.
+    #   If this installation becomes rate-limited the TorngitAdapter uses the info to mark it so (so we don't select it for a while)
+    # fallback_installations are used if multi-apps are available and the selected one becomes rate-limited
+    selected_installation_info: GithubInstallationInfo | None
+    fallback_installations: List[GithubInstallationInfo] | None
+    # TokenTypeMapping
+    # exclusive for public repos not using an installation. Fallback tokens per action
+    token_type_mapping: TokenTypeMapping | None

--- a/services/repository_django.py
+++ b/services/repository_django.py
@@ -1,0 +1,270 @@
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping, Tuple
+
+import shared.torngit as torngit
+from asgiref.sync import sync_to_async
+from django.db.models import Q
+from shared.config import get_config, get_verify_ssl
+from shared.django_apps.codecov_auth.models import (
+    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+    Owner,
+)
+from shared.django_apps.core.models import Commit, Pull, Repository
+from shared.torngit.exceptions import (
+    TorngitClientError,
+    TorngitError,
+    TorngitObjectNotFoundError,
+)
+from shared.typings.torngit import (
+    OwnerInfo,
+    RepoInfo,
+    TorngitInstanceData,
+)
+
+from helpers.token_refresh_django import get_token_refresh_callback
+from services.bots_django import get_adapter_auth_information
+from services.yaml import read_yaml_field
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class EnrichedPull(object):
+    database_pull: Pull
+    provider_pull: Mapping[str, Any] | None
+
+
+def _is_repo_using_integration(repo: Repository) -> bool:
+    owner = repo.author
+    default_ghapp_installation = list(
+        filter(
+            lambda obj: obj.name == GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+            owner.github_app_installations.all() or [],
+        )
+    )
+    if default_ghapp_installation:
+        ghapp_installation = owner.github_app_installations.all()[0]
+        return ghapp_installation.is_repo_covered_by_integration(repo)
+    return repo.using_integration
+
+
+@sync_to_async
+def get_repo_provider_service(
+    repository: Repository,
+    installation_name_to_use: str | None = GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+) -> torngit.base.TorngitBaseAdapter:
+    _timeouts = [
+        get_config("setup", "http", "timeouts", "connect", default=30),
+        get_config("setup", "http", "timeouts", "receive", default=60),
+    ]
+
+    service = repository.author.service
+    adapter_auth_info = get_adapter_auth_information(
+        repository.author,
+        repository=repository,
+        installation_name_to_use=installation_name_to_use,
+    )
+    data = TorngitInstanceData(
+        repo=RepoInfo(
+            name=repository.name,
+            using_integration=_is_repo_using_integration(repository),
+            service_id=repository.service_id,
+            repoid=repository.repoid,
+        ),
+        owner=OwnerInfo(
+            service_id=repository.author.service_id,
+            ownerid=repository.author_id,
+            username=repository.author.username,
+        ),
+        installation=adapter_auth_info["selected_installation_info"],
+        fallback_installations=adapter_auth_info["fallback_installations"],
+    )
+
+    adapter_params = dict(
+        token=adapter_auth_info["token"],
+        token_type_mapping=adapter_auth_info["token_type_mapping"],
+        verify_ssl=get_verify_ssl(service),
+        timeouts=_timeouts,
+        oauth_consumer_token=dict(
+            key=get_config(service, "client_id"),
+            secret=get_config(service, "client_secret"),
+        ),
+        on_token_refresh=get_token_refresh_callback(adapter_auth_info["token_owner"]),
+        **data,
+    )
+    return _get_repo_provider_service_instance(repository.service, **adapter_params)
+
+
+def _get_repo_provider_service_instance(service_name, **adapter_params):
+    return torngit.get(service_name, **adapter_params)
+
+
+@sync_to_async
+def get_head_commit(pull: Pull):
+    return Commit.objects.filter(
+        repository_id=pull.repository_id, commitid=pull.head
+    ).first()
+
+
+async def fetch_and_update_pull_request_information_from_commit(
+    repository_service, commit, current_yaml
+) -> EnrichedPull | None:
+    pullid = commit.pullid
+    if not commit.pullid:
+        try:
+            pullid = await repository_service.find_pull_request(
+                commit=commit.commitid, branch=commit.branch
+            )
+            print(pullid)
+        except TorngitClientError:
+            log.warning(
+                "Unable to fetch what pull request the commit belongs to",
+                exc_info=True,
+                extra=dict(repoid=commit.repository_id, commit=commit.commitid),
+            )
+    if not pullid:
+        return None
+    enriched_pull = await fetch_and_update_pull_request_information(
+        repository_service, commit.repository_id, pullid, current_yaml
+    )
+    pull = enriched_pull.database_pull
+    if pull is not None:
+        head = await get_head_commit(pull)
+        if head is None or head.timestamp <= commit.timestamp:
+            pull.head = commit.commitid
+    return enriched_pull
+
+
+@sync_to_async
+def get_pull_from_db(pullid, repoid):
+    return Pull.objects.filter(pullid=pullid, repository_id=repoid).first()
+
+
+@sync_to_async
+def update_or_create_pull(pullid, repoid, pull_information):
+    pull, _ = Pull.objects.update_or_create(
+        pullid=pullid,
+        repository_id=repoid,
+        defaults={
+            "issueid": int(pull_information["id"]),
+            "state": pull_information["state"],
+            "title": pull_information["title"],
+        },
+    )
+    return pull
+
+
+@sync_to_async
+def get_val_of_new_base_query(new_base_query):
+    return new_base_query.first()
+
+
+@sync_to_async
+def get_base_commit(pull_base_sha, repoid):
+    return Commit.objects.filter(commitid=pull_base_sha, repository_id=repoid).first()
+
+
+@sync_to_async
+def save_pull(pull):
+    pull.save()
+
+
+@sync_to_async
+def pull_author(pull):
+    return pull.author
+
+
+async def fetch_and_update_pull_request_information(
+    repository_service, repoid, pullid, current_yaml
+) -> EnrichedPull:
+    try:
+        pull_information = await repository_service.get_pull_request(pullid=pullid)
+    except TorngitClientError:
+        log.warning(
+            "Unable to find pull request information on provider to update it due to client error",
+            extra=dict(repoid=repoid, pullid=pullid),
+        )
+
+        pull = await get_pull_from_db(pullid, repoid)
+        return EnrichedPull(database_pull=pull, provider_pull=None)
+    except TorngitError:
+        log.warning(
+            "Unable to find pull request information on provider to update it due to unknown provider error",
+            extra=dict(repoid=repoid, pullid=pullid),
+        )
+        pull = await get_pull_from_db(pullid, repoid)
+        return EnrichedPull(database_pull=pull, provider_pull=None)
+
+    pull = await update_or_create_pull(pullid, repoid, pull_information)
+
+    base_commit_sha, compared_to = await _pick_best_base_comparedto_pair(
+        repository_service, pull, current_yaml, pull_information
+    )
+    pull.base = base_commit_sha
+    pull.compared_to = compared_to
+
+    if pull is not None:
+        pr_author = await get_or_create_author(
+            repository_service.service,
+            pull_information["author"]["id"],
+            pull_information["author"]["username"],
+        )
+        if pr_author:
+            pull.author = pr_author
+
+    await save_pull(pull)
+
+    return EnrichedPull(database_pull=pull, provider_pull=pull_information)
+
+
+async def _pick_best_base_comparedto_pair(
+    repository_service, pull, current_yaml, pull_information
+) -> Tuple[str, str | None]:
+    repoid = pull.repository_id
+    candidates_to_base = (
+        [pull.user_provided_base_sha, pull_information["base"]["commitid"]]
+        if pull is not None and pull.user_provided_base_sha is not None
+        else [pull_information["base"]["commitid"]]
+    )
+    for pull_base_sha in candidates_to_base:
+        base_commit = await get_base_commit(pull_base_sha, repoid)
+        if base_commit:
+            return (pull_base_sha, pull_base_sha)
+        try:
+            commit_dict = await repository_service.get_commit(pull_base_sha)
+            new_base_query = Commit.objects.filter(
+                Q(pullid__isnull=True) | Q(merged=True),
+                Q(timestamp__lt=commit_dict["timestamp"]),
+                repository_id=repoid,
+                branch=pull_information["base"]["branch"],
+            )
+
+            if read_yaml_field(current_yaml, ("codecov", "require_ci_to_pass"), True):
+                new_base_query = new_base_query.filter(ci_passed=True)
+            new_base_query = new_base_query.order_by("-timestamp")
+            new_base = await get_val_of_new_base_query(new_base_query)
+            if new_base:
+                return (pull_base_sha, new_base.commitid)
+        except TorngitObjectNotFoundError:
+            log.warning(
+                "Cannot find (in the provider) commit that is supposed to be the PR base",
+                extra=dict(repoid=repoid, supposed_base=pull_base_sha),
+            )
+    return (candidates_to_base[0], None)
+
+
+@sync_to_async
+def get_or_create_author(service, service_id, username, email=None, name=None) -> Owner:
+    author, _ = Owner.objects.get_or_create(
+        service=service,
+        service_id=str(service_id),
+        defaults={
+            "username": username,
+            "name": name,
+            "email": email,
+            "createstamp": datetime.now(),
+        },
+    )
+    return author

--- a/services/tests/test_repository_django.py
+++ b/services/tests/test_repository_django.py
@@ -1,0 +1,1162 @@
+import inspect
+from datetime import UTC, datetime
+
+import mock
+import pytest
+from asgiref.sync import async_to_sync
+from freezegun import freeze_time
+from shared.django_apps.codecov_auth.models import (
+    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+    GithubAppInstallation,
+    Owner,
+)
+from shared.django_apps.core.tests.factories import (
+    CommitFactory,
+    OwnerFactory,
+    PullFactory,
+    RepositoryFactory,
+)
+from shared.encryption.oauth import get_encryptor_from_configuration
+from shared.torngit.base import TorngitBaseAdapter
+from shared.torngit.exceptions import (
+    TorngitClientError,
+    TorngitObjectNotFoundError,
+    TorngitServerUnreachableError,
+)
+
+from services.repository_django import (
+    _is_repo_using_integration,
+    _pick_best_base_comparedto_pair,
+    fetch_and_update_pull_request_information,
+    fetch_and_update_pull_request_information_from_commit,
+    get_or_create_author,
+    get_repo_provider_service,
+)
+
+
+@pytest.mark.parametrize("using_integration", [True, False])
+def test__is_repo_using_integration_deprecated_flow(
+    using_integration, transactional_db
+):
+    repo = RepositoryFactory.create(using_integration=using_integration)
+    assert _is_repo_using_integration(repo) == using_integration
+
+
+def test__is_repo_using_integration_ghapp_covers_all_repos(transactional_db):
+    owner = OwnerFactory.create(service="github")
+    repo = RepositoryFactory.create(author=owner)
+    other_repo_same_owner = RepositoryFactory.create(author=owner)
+    repo_different_owner = RepositoryFactory.create()
+    assert repo.author != repo_different_owner.author
+    ghapp_installation = GithubAppInstallation(
+        name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+        owner=owner,
+        repository_service_ids=None,
+        installation_id=12345,
+    )
+    ghapp_installation.save()
+
+    assert _is_repo_using_integration(repo) == True
+    assert _is_repo_using_integration(other_repo_same_owner) == True
+    assert _is_repo_using_integration(repo_different_owner) == False
+
+
+def test__is_repo_using_integration_ghapp_covers_some_repos(transactional_db):
+    owner = OwnerFactory.create(service="github")
+    repo = RepositoryFactory.create(author=owner)
+    other_repo_same_owner = RepositoryFactory.create(author=owner)
+    repo_different_owner = RepositoryFactory.create()
+    assert repo.author != repo_different_owner.author
+    ghapp_installation = GithubAppInstallation(
+        name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+        owner=owner,
+        repository_service_ids=[repo.service_id],
+        installation_id=12345,
+    )
+    ghapp_installation.save()
+    assert _is_repo_using_integration(repo) == True
+    assert _is_repo_using_integration(other_repo_same_owner) == False
+    assert _is_repo_using_integration(repo_different_owner) == False
+
+
+class TestRepositoryServiceTestCase(object):
+    def test_get_repo_provider_service_github(self, transactional_db):
+        repo = RepositoryFactory.create(
+            author__unencrypted_oauth_token="testyftq3ovzkb3zmt823u3t04lkrt9w",
+            author__service="github",
+            name="example-python",
+        )
+        repo.save()
+        res = async_to_sync(get_repo_provider_service)(repo)
+        expected_data = {
+            "owner": {
+                "ownerid": repo.author.ownerid,
+                "service_id": repo.author.service_id,
+                "username": repo.author.username,
+            },
+            "repo": {
+                "name": "example-python",
+                "using_integration": False,
+                "service_id": repo.service_id,
+                "repoid": repo.repoid,
+            },
+            "installation": None,
+            "fallback_installations": None,
+        }
+        assert res.data == expected_data
+        assert repo.author.service == "github"
+        assert res._on_token_refresh is not None
+        assert inspect.isawaitable(res._on_token_refresh(None))
+        assert res.token == {
+            "username": repo.author.username,
+            "key": "testyftq3ovzkb3zmt823u3t04lkrt9w",
+            "secret": None,
+        }
+
+    def test_get_repo_provider_service_github_with_installations(
+        self, transactional_db, mocker
+    ):
+        mocker.patch(
+            "services.bots_django.github_apps.get_github_integration_token",
+            return_value="installation_token",
+        )
+        mocker.patch(
+            "shared.django_apps.codecov_auth.models.get_config", return_value=200
+        )
+        repo = RepositoryFactory.create(
+            author__service="github",
+            name="example-python",
+            using_integration=False,
+        )
+        installation_0 = GithubAppInstallation(
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+            installation_id=1200,
+            app_id=200,
+            repository_service_ids=None,
+            owner=repo.author,
+        )
+        installation_1 = GithubAppInstallation(
+            name="my_app",
+            installation_id=1300,
+            app_id=300,
+            pem_path="path",
+            repository_service_ids=None,
+            owner=repo.author,
+        )
+        installation_0.save()
+        installation_1.save()
+
+        repo.author.github_app_installations.set([installation_0, installation_1])
+        repo.save()
+
+        res = async_to_sync(get_repo_provider_service)(
+            repo, installation_name_to_use="my_app"
+        )
+        expected_data = {
+            "owner": {
+                "ownerid": repo.author.ownerid,
+                "service_id": repo.author.service_id,
+                "username": repo.author.username,
+            },
+            "repo": {
+                "name": "example-python",
+                "using_integration": True,
+                "service_id": repo.service_id,
+                "repoid": repo.repoid,
+            },
+            "installation": {
+                "installation_id": 1300,
+                "app_id": 300,
+                "pem_path": "path",
+            },
+            "fallback_installations": [
+                {"app_id": 200, "installation_id": 1200, "pem_path": None}
+            ],
+        }
+        assert res.data == expected_data
+        assert repo.author.service == "github"
+        assert res._on_token_refresh is None
+        assert res.token == {
+            "key": "installation_token",
+        }
+
+    def test_get_repo_provider_service_bitbucket(self, transactional_db):
+        repo = RepositoryFactory.create(
+            author__unencrypted_oauth_token="testyftq3ovzkb3zmt823u3t04lkrt9w",
+            author__service="bitbucket",
+            name="example-python",
+        )
+        repo.save()
+        res = async_to_sync(get_repo_provider_service)(repo)
+        expected_data = {
+            "owner": {
+                "ownerid": repo.author.ownerid,
+                "service_id": repo.author.service_id,
+                "username": repo.author.username,
+            },
+            "repo": {
+                "name": "example-python",
+                "using_integration": False,
+                "service_id": repo.service_id,
+                "repoid": repo.repoid,
+            },
+            "installation": None,
+            "fallback_installations": None,
+        }
+        assert res.data == expected_data
+        assert repo.author.service == "bitbucket"
+        assert res._on_token_refresh is None
+        assert res.token == {
+            "username": repo.author.username,
+            "key": "testyftq3ovzkb3zmt823u3t04lkrt9w",
+            "secret": None,
+        }
+
+    def test_get_repo_provider_service_with_token_refresh_callback(
+        self, transactional_db
+    ):
+        repo = RepositoryFactory.create(
+            author__unencrypted_oauth_token="testyftq3ovzkb3zmt823u3t04lkrt9w",
+            author__service="gitlab",
+            name="example-python",
+        )
+        repo.save()
+        res = async_to_sync(get_repo_provider_service)(repo)
+        expected_data = {
+            "owner": {
+                "ownerid": repo.author.ownerid,
+                "service_id": repo.author.service_id,
+                "username": repo.author.username,
+            },
+            "repo": {
+                "name": "example-python",
+                "using_integration": False,
+                "service_id": repo.service_id,
+                "repoid": repo.repoid,
+            },
+            "installation": None,
+            "fallback_installations": None,
+        }
+        assert res.data == expected_data
+        assert res._on_token_refresh is not None
+        assert inspect.isawaitable(res._on_token_refresh(None))
+        assert res.token == {
+            "username": repo.author.username,
+            "key": "testyftq3ovzkb3zmt823u3t04lkrt9w",
+            "secret": None,
+        }
+
+    def test_get_repo_provider_service_repo_bot(
+        self, transactional_db, mock_configuration
+    ):
+        repo = RepositoryFactory.create(
+            author__unencrypted_oauth_token="testyftq3ovzkb3zmt823u3t04lkrt9w",
+            author__service="gitlab",
+            name="example-python",
+            private=False,
+        )
+
+        res = async_to_sync(get_repo_provider_service)(repo)
+        expected_data = {
+            "owner": {
+                "ownerid": repo.author.ownerid,
+                "service_id": repo.author.service_id,
+                "username": repo.author.username,
+            },
+            "repo": {
+                "name": "example-python",
+                "using_integration": False,
+                "service_id": repo.service_id,
+                "repoid": repo.repoid,
+            },
+            "installation": None,
+            "fallback_installations": None,
+        }
+        assert res.data == expected_data
+        assert res.token == {
+            "username": repo.author.username,
+            "key": "testyftq3ovzkb3zmt823u3t04lkrt9w",
+            "secret": None,
+        }
+        assert res._on_token_refresh is not None
+
+    def test_token_refresh_callback(self, transactional_db):
+        repo = RepositoryFactory.create(
+            author__unencrypted_oauth_token="testyftq3ovzkb3zmt823u3t04lkrt9w",
+            author__service="gitlab",
+            name="example-python",
+        )
+        repo.save()
+
+        res = async_to_sync(get_repo_provider_service)(repo)
+        new_token = dict(key="new_access_token", refresh_token="new_refresh_token")
+        async_to_sync(res._on_token_refresh)(new_token)
+        owner = Owner.objects.filter(ownerid=repo.author.ownerid).first()
+        encryptor = get_encryptor_from_configuration()
+        saved_token = encryptor.decrypt_token(owner.oauth_token)
+        assert saved_token["key"] == "new_access_token"
+        assert saved_token["refresh_token"] == "new_refresh_token"
+
+    def test_get_repo_provider_service_different_bot(self, transactional_db):
+        bot_token = "bcaa0dc0c66b4a8c8c65ac919a1a91aa"
+        bot = OwnerFactory.create(unencrypted_oauth_token=bot_token)
+        repo = RepositoryFactory.create(
+            author__unencrypted_oauth_token="testyftq3ovzkb3zmt823u3t04lkrt9w",
+            bot=bot,
+            name="example-python",
+        )
+        repo.save()
+        bot.save()
+
+        res = async_to_sync(get_repo_provider_service)(repo)
+        expected_data = {
+            "owner": {
+                "ownerid": repo.author.ownerid,
+                "service_id": repo.author.service_id,
+                "username": repo.author.username,
+            },
+            "repo": {
+                "name": "example-python",
+                "using_integration": False,
+                "service_id": repo.service_id,
+                "repoid": repo.repoid,
+            },
+            "installation": None,
+            "fallback_installations": None,
+        }
+        assert res.data["repo"] == expected_data["repo"]
+        assert res.data == expected_data
+        assert res.token == {
+            "username": repo.bot.username,
+            "key": bot_token,
+            "secret": None,
+        }
+
+    def test_get_repo_provider_service_no_bot(self, transactional_db):
+        bot_token = "bcaa0dc0c66b4a8c8c65ac919a1a91aa"
+        owner_bot = OwnerFactory.create(unencrypted_oauth_token=bot_token)
+        repo = RepositoryFactory.create(
+            author__unencrypted_oauth_token="testyftq3ovzkb3zmt823u3t04lkrt9w",
+            author__bot=owner_bot,
+            bot=None,
+            name="example-python",
+        )
+        repo.save()
+        owner_bot.save()
+
+        res = async_to_sync(get_repo_provider_service)(repo)
+        expected_data = {
+            "owner": {
+                "ownerid": repo.author.ownerid,
+                "service_id": repo.author.service_id,
+                "username": repo.author.username,
+            },
+            "repo": {
+                "name": "example-python",
+                "using_integration": False,
+                "service_id": repo.service_id,
+                "repoid": repo.repoid,
+            },
+            "installation": None,
+            "fallback_installations": None,
+        }
+        assert res.data == expected_data
+        assert res.token == {
+            "username": repo.author.bot.username,
+            "key": bot_token,
+            "secret": None,
+        }
+
+    @freeze_time("2024-03-28T00:00:00")
+    def test_get_or_create_author_doesnt_exist(self, transactional_db):
+        service = "github"
+        author_id = "123"
+        username = "username"
+        email = "email"
+        name = "name"
+        author = async_to_sync(get_or_create_author)(
+            service, author_id, username, email, name
+        )
+
+        assert author.free == 0
+        assert author is not None
+        assert author.service == "github"
+        assert author.service_id == "123"
+        assert author.name == "name"
+        assert author.email == "email"
+        assert author.username == "username"
+        assert author.plan_activated_users is None
+        assert author.admins is None
+        assert author.permission is None
+        assert author.integration_id is None
+        assert author.yaml is None
+        assert author.oauth_token is None
+        assert author.bot_id is None
+        assert author.createstamp.isoformat() == "2024-03-28T00:00:00"
+
+    def test_get_or_create_author_already_exists(self, transactional_db):
+        owner = OwnerFactory.create(
+            service="bitbucket",
+            service_id="975",
+            email="different_email@email.com",
+            username="whoknew",
+            yaml=dict(a=["12", "3"]),
+        )
+
+        owner.save()
+
+        service = "bitbucket"
+        author_id = "975"
+        username = "username"
+        email = "email"
+        name = "name"
+        author = async_to_sync(get_or_create_author)(
+            service, author_id, username, email, name
+        )
+
+        assert author.ownerid == owner.ownerid
+        assert author.free == 0
+        assert author is not None
+        assert author.service == "bitbucket"
+        assert author.service_id == "975"
+        assert author.name == owner.name
+        assert author.email == "different_email@email.com"
+        assert author.username == "whoknew"
+        assert author.plan_activated_users == []
+        assert author.admins == []
+        assert author.permission == []
+        assert author.integration_id is None
+        assert author.yaml == {"a": ["12", "3"]}
+        assert author.oauth_token == owner.oauth_token
+        assert author.bot_id == owner.bot_id
+        assert owner.createstamp is None
+
+
+class TestPullRequestFetcher(object):
+    def test_fetch_and_update_pull_request_information_from_commit_new_pull_commits_in_place(
+        self, transactional_db, mocker
+    ):
+        now = datetime.now(UTC)
+        commit = CommitFactory.create(
+            message="",
+            pullid=None,
+            totals=None,
+        )
+        commit.timestamp = datetime.now()
+        commit.pullid = 1
+        base_commit = CommitFactory.create(repository=commit.repository, pullid=None)
+        commit.save()
+
+        base_commit.save()
+
+        current_yaml = {}
+        get_pull_request_result = {
+            "base": {"branch": "master", "commitid": base_commit.commitid},
+            "head": {"branch": "reason/some-testing", "commitid": commit.commitid},
+            "number": "1",
+            "id": "1",
+            "state": "open",
+            "title": "Creating new code for reasons no one knows",
+            "author": {"id": "123", "username": "pr_author_username"},
+        }
+        repository_service = mocker.MagicMock(
+            service="github",
+            get_pull_request=mock.AsyncMock(return_value=get_pull_request_result),
+        )
+
+        enriched_pull = async_to_sync(
+            fetch_and_update_pull_request_information_from_commit
+        )(repository_service, commit, current_yaml)
+        res = enriched_pull.database_pull
+
+        assert res is not None
+        assert res.repository_id == commit.repository_id
+        assert res.pullid == 1
+        assert res.issueid == 1
+        assert res.updatestamp > now
+        assert res.state == "open"
+        assert res.title == "Creating new code for reasons no one knows"
+        assert res.base == base_commit.commitid
+        assert res.compared_to == base_commit.commitid
+        assert res.head == commit.commitid
+        assert res.commentid is None
+        assert res.diff is None
+        assert res._flare is None
+        assert res._flare_storage_path is None
+        assert (
+            res.author
+            == Owner.objects.filter(
+                service="github",
+                service_id=get_pull_request_result["author"]["id"],
+                username=get_pull_request_result["author"]["username"],
+            ).first()
+        )
+
+    def test_fetch_and_update_pull_request_information_from_commit_existing_pull_commits_in_place(
+        self, transactional_db, mocker
+    ):
+        now = datetime.now(UTC)
+        repository = RepositoryFactory.create()
+        repository.save()
+
+        pull = PullFactory.create(
+            repository=repository, author=None, commentid=None, diff=None, pullid=1
+        )
+        commit = CommitFactory.create(
+            message="",
+            pullid=pull.pullid,
+            totals=None,
+            repository=repository,
+        )
+        base_commit = CommitFactory.create(repository=repository, branch="master")
+        pull.save()
+        commit.save()
+        base_commit.save()
+
+        current_yaml = {}
+        f = {
+            "author": {
+                "id": "author_id",
+                "username": "author_username",
+                "email": "email@email.com",
+                "name": "Mario",
+            },
+            "message": "Merged in aaaa/coverage.py (pull request #99) Fix #123: crash",
+            "timestamp": datetime(2019, 10, 10),
+            "parents": [],
+        }
+        get_pull_request_result = {
+            "base": {"branch": "master", "commitid": base_commit.commitid},
+            "head": {"branch": "reason/some-testing", "commitid": commit.commitid},
+            "number": str(pull.pullid),
+            "id": str(pull.pullid),
+            "state": "open",
+            "title": "Creating new code for reasons no one knows",
+            "author": {"id": "123", "username": "pr_author_username"},
+        }
+        print("pullid", pull.pullid)
+        repository_service = mocker.MagicMock(
+            service="github",
+            get_commit=mock.AsyncMock(return_value=f),
+            get_pull_request=mock.AsyncMock(return_value=get_pull_request_result),
+            find_pull_request=mock.AsyncMock(return_value=pull.pullid),
+        )
+        enriched_pull = async_to_sync(
+            fetch_and_update_pull_request_information_from_commit
+        )(repository_service, commit, current_yaml)
+        res = enriched_pull.database_pull
+
+        assert res is not None
+        assert res == pull
+        assert res.repository_id == commit.repository_id
+        assert res.pullid == pull.pullid
+        assert res.issueid == pull.pullid
+        assert res.updatestamp > now
+        assert res.state == "open"
+        assert res.title == "Creating new code for reasons no one knows"
+        assert res.base == base_commit.commitid
+        assert res.compared_to == base_commit.commitid
+        assert res.head == commit.commitid
+        assert res.commentid is None
+        assert res.diff is None
+        assert res._flare is None
+        assert res._flare_storage_path is None
+        assert (
+            res.author
+            == Owner.objects.filter(
+                service="github",
+                service_id=get_pull_request_result["author"]["id"],
+                username=get_pull_request_result["author"]["username"],
+            ).first()
+        )
+
+    def test_fetch_and_update_pull_request_multiple_pulls_same_repo(
+        self, transactional_db, mocker
+    ):
+        now = datetime.now(UTC)
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(
+            repository=repository,
+            title="purposelly bad title",
+            author=None,
+            commentid=None,
+            diff=None,
+        )
+        second_pull = PullFactory.create(repository=repository)
+        commit = CommitFactory.create(
+            message="",
+            pullid=pull.pullid,
+            totals=None,
+            repository=repository,
+        )
+        base_commit = CommitFactory.create(repository=repository, branch="master")
+        pull.save()
+        second_pull.save()
+        commit.save()
+        base_commit.save()
+
+        current_yaml = {}
+        f = {
+            "author": {
+                "id": "author_id",
+                "username": "author_username",
+                "email": "email@email.com",
+                "name": "Mario",
+            },
+            "message": "Merged in aaaa/coverage.py (pull request #99) Fix #123: crash",
+            "timestamp": datetime(2019, 10, 10),
+            "parents": [],
+        }
+        get_pull_request_result = {
+            "base": {"branch": "master", "commitid": base_commit.commitid},
+            "head": {"branch": "reason/some-testing", "commitid": commit.commitid},
+            "number": str(pull.pullid),
+            "id": str(pull.pullid),
+            "state": "open",
+            "title": "Creating new code for reasons no one knows",
+            "author": {"id": "123", "username": "pr_author_username"},
+        }
+
+        repository_service = mocker.MagicMock(
+            service="github",
+            get_commit=mock.AsyncMock(return_value=f),
+            get_pull_request=mock.AsyncMock(return_value=get_pull_request_result),
+        )
+        enriched_pull = async_to_sync(
+            fetch_and_update_pull_request_information_from_commit
+        )(repository_service, commit, current_yaml)
+        res = enriched_pull.database_pull
+
+        assert res is not None
+        assert res == pull
+        assert res != second_pull
+        assert res.repository_id == commit.repository_id
+        assert res.pullid == pull.pullid
+        assert res.issueid == pull.pullid
+        assert res.updatestamp > now
+        assert res.state == "open"
+        assert res.title == "Creating new code for reasons no one knows"
+        assert res.base == base_commit.commitid
+        assert res.compared_to == base_commit.commitid
+        assert res.head == commit.commitid
+        assert res.commentid is None
+        assert res.diff is None
+        assert res._flare is None
+        assert res._flare_storage_path is None
+        assert (
+            res.author
+            == Owner.objects.filter(
+                service="github",
+                service_id=get_pull_request_result["author"]["id"],
+                username=get_pull_request_result["author"]["username"],
+            ).first()
+        )
+
+    def test_fetch_and_update_pull_request_information_from_commit_different_compared_to(
+        self, transactional_db, mocker
+    ):
+        now = datetime.now(UTC)
+        repository = RepositoryFactory.create()
+        repository.save()
+
+        pull = PullFactory.create(
+            repository=repository, author=None, commentid=None, diff=None
+        )
+
+        commit = CommitFactory.create(
+            message="",
+            pullid=pull.pullid,
+            totals=None,
+            repository=repository,
+        )
+        second_comparedto_commit = CommitFactory.create(
+            repository=repository,
+            branch="master",
+            merged=True,
+            timestamp=datetime(2019, 5, 6),
+        )
+        compared_to_commit = CommitFactory.create(
+            repository=repository,
+            branch="master",
+            merged=True,
+            timestamp=datetime(2019, 7, 15),
+        )
+        pull.save()
+        commit.save()
+        second_comparedto_commit.save()
+        compared_to_commit.save()
+        current_yaml = {}
+        f = {
+            "author": {
+                "id": "author_id",
+                "username": "author_username",
+                "email": "email@email.com",
+                "name": "Mario",
+            },
+            "message": "Merged in aaaa/coverage.py (pull request #99) Fix #123: crash",
+            "parents": [],
+            "timestamp": datetime(2019, 10, 10),
+        }
+        get_pull_request_result = {
+            "base": {"branch": "master", "commitid": "somecommitid"},
+            "head": {"branch": "reason/some-testing", "commitid": commit.commitid},
+            "number": str(pull.pullid),
+            "id": str(pull.pullid),
+            "state": "open",
+            "title": "Creating new code for reasons no one knows",
+            "author": {"id": "123", "username": "pr_author_username"},
+        }
+        repository_service = mocker.MagicMock(
+            service="github",
+            get_commit=mock.AsyncMock(return_value=f),
+            get_pull_request=mock.AsyncMock(return_value=get_pull_request_result),
+        )
+        enriched_pull = async_to_sync(
+            fetch_and_update_pull_request_information_from_commit
+        )(repository_service, commit, current_yaml)
+        res = enriched_pull.database_pull
+
+        assert res is not None
+        assert res == pull
+        assert res.repository_id == commit.repository_id
+        assert res.pullid == pull.pullid
+        assert res.issueid == pull.pullid
+        assert res.updatestamp > now
+        assert res.state == "open"
+        assert res.title == "Creating new code for reasons no one knows"
+        assert res.base == "somecommitid"
+        assert res.compared_to == compared_to_commit.commitid
+        assert res.head == commit.commitid
+        assert res.commentid is None
+        assert res.diff is None
+        assert res._flare is None
+        assert res._flare_storage_path is None
+        assert (
+            res.author
+            == Owner.objects.filter(
+                service="github",
+                service_id=get_pull_request_result["author"]["id"],
+                username=get_pull_request_result["author"]["username"],
+            ).first()
+        )
+
+    def test_fetch_and_update_pull_request_information_no_compared_to(
+        self, transactional_db, mocker
+    ):
+        now = datetime.now()
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(
+            repository=repository,
+            author=None,
+            commentid=None,
+            diff=None,
+            head=None,
+            base=None,
+        )
+        compared_to_commit = CommitFactory.create(
+            repository=repository, branch="master", merged=True, pullid=None
+        )
+        commit = CommitFactory.create(
+            message="", totals=None, repository=repository, pullid=None
+        )
+        pull.save()
+        commit.pullid = pull.pullid
+        commit.save()
+        compared_to_commit.save()
+
+        current_yaml = {}
+        get_pull_request_result = {
+            "base": {"branch": "master", "commitid": "somecommitid"},
+            "head": {"branch": "reason/some-testing", "commitid": commit.commitid},
+            "number": str(pull.pullid),
+            "id": str(pull.pullid),
+            "state": "open",
+            "title": "Creating new code for reasons no one knows",
+            "author": {"id": "123", "username": "pr_author_username"},
+        }
+        repository_service = mocker.MagicMock(
+            service="github",
+            get_commit=mock.AsyncMock(
+                side_effect=TorngitObjectNotFoundError("response", "message")
+            ),
+            get_pull_request=mock.AsyncMock(return_value=get_pull_request_result),
+        )
+
+        enriched_pull = async_to_sync(fetch_and_update_pull_request_information)(
+            repository_service, pull.repository_id, pull.pullid, current_yaml
+        )
+
+        res = enriched_pull.database_pull
+
+        res.refresh_from_db()
+
+        assert res is not None
+        assert res == pull
+        assert res.repository_id == commit.repository_id
+        assert res.pullid == pull.pullid
+        assert res.issueid == pull.pullid
+        assert res.updatestamp > now
+        assert res.state == "open"
+        assert res.title == "Creating new code for reasons no one knows"
+        assert res.base == "somecommitid"
+        assert res.compared_to is None
+        assert res.head == commit.commitid
+        assert res.commentid is None
+        assert res.diff is None
+        assert res._flare is None
+        assert res._flare_storage_path is None
+        assert (
+            res.author
+            == Owner.objects.filter(
+                service="github",
+                service_id=get_pull_request_result["author"]["id"],
+                username=get_pull_request_result["author"]["username"],
+            ).first()
+        )
+
+    def test_fetch_and_update_pull_request_information_torngitexception(
+        self, transactional_db, mocker
+    ):
+        repository = RepositoryFactory.create()
+        repository.save()
+        commit = CommitFactory.create(
+            message="",
+            pullid=None,
+            totals=None,
+            repository=repository,
+        )
+        compared_to_commit = CommitFactory.create(
+            repository=repository, branch="master", merged=True
+        )
+        commit.save()
+        compared_to_commit.save()
+        current_yaml = {}
+        repository_service = mocker.MagicMock(
+            find_pull_request=mock.AsyncMock(
+                side_effect=TorngitClientError(422, "response", "message")
+            )
+        )
+        res = async_to_sync(fetch_and_update_pull_request_information_from_commit)(
+            repository_service, commit, current_yaml
+        )
+        assert res is None
+
+    def test_fetch_and_update_pull_request_information_torngitexception_getting_pull(
+        self, transactional_db, mocker
+    ):
+        repository = RepositoryFactory.create()
+        repository.save()
+        commit = CommitFactory.create(
+            message="",
+            pullid=None,
+            totals=None,
+            repository=repository,
+        )
+        commit.timestamp = datetime.now()
+        commit.pullid = "123"
+        compared_to_commit = CommitFactory.create(
+            repository=repository, branch="master", merged=True
+        )
+        commit.save()
+        compared_to_commit.save()
+        current_yaml = {}
+        repository_service = mocker.MagicMock(
+            get_pull_request=mock.AsyncMock(
+                side_effect=TorngitObjectNotFoundError("response", "message")
+            )
+        )
+        res = async_to_sync(fetch_and_update_pull_request_information_from_commit)(
+            repository_service, commit, current_yaml
+        )
+        assert res.database_pull is None
+        assert res.provider_pull is None
+
+    def test_fetch_and_update_pull_request_information_torngitserverexception_getting_pull(
+        self, transactional_db, mocker
+    ):
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(repository=repository)
+        pull.save()
+        current_yaml = {}
+        repository_service = mocker.MagicMock(
+            get_pull_request=mock.AsyncMock(side_effect=TorngitServerUnreachableError())
+        )
+        res = async_to_sync(fetch_and_update_pull_request_information)(
+            repository_service, pull.repository_id, pull.pullid, current_yaml
+        )
+        assert res.database_pull == pull
+        assert res.provider_pull is None
+
+    def test_fetch_and_update_pull_request_information_notfound_pull_already_exists(
+        self, transactional_db, mocker
+    ):
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(repository=repository)
+        pull.save()
+        commit = CommitFactory.create(
+            message="",
+            pullid=pull.pullid,
+            totals=None,
+            repository=repository,
+        )
+        compared_to_commit = CommitFactory.create(
+            repository=repository, branch="master", merged=True
+        )
+        commit.save()
+        compared_to_commit.save()
+        current_yaml = {}
+        repository_service = mocker.MagicMock(
+            get_pull_request=mock.AsyncMock(
+                side_effect=TorngitObjectNotFoundError("response", "message")
+            )
+        )
+        res = async_to_sync(fetch_and_update_pull_request_information_from_commit)(
+            repository_service, commit, current_yaml
+        )
+        assert res.database_pull == pull
+
+    def test_pick_best_base_comparedto_pair_no_user_provided_base_no_candidate(
+        self, mocker, transactional_db
+    ):
+        async def get_commit_mocked(commit_sha):
+            return {"timestamp": datetime(2021, 3, 10).isoformat()}
+
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(repository=repository)
+        pull.save()
+        repository_service = mocker.Mock(
+            TorngitBaseAdapter, get_commit=get_commit_mocked
+        )
+        current_yaml = mocker.MagicMock()
+        pull_information = {
+            "base": {"commitid": "abcqwert" * 5, "branch": "basebranch"}
+        }
+        res = async_to_sync(_pick_best_base_comparedto_pair)(
+            repository_service, pull, current_yaml, pull_information
+        )
+        assert res == ("abcqwertabcqwertabcqwertabcqwertabcqwert", None)
+
+    def test_pick_best_base_comparedto_pair_yes_user_provided_base_no_candidate(
+        self, mocker, transactional_db
+    ):
+        async def get_commit_mocked(commit_sha):
+            return {"timestamp": datetime(2021, 3, 10).isoformat()}
+
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(
+            repository=repository,
+            user_provided_base_sha="lkjhgfdslkjhgfdslkjhgfdslkjhgfdslkjhgfds",
+        )
+        pull.save()
+        repository_service = mocker.Mock(
+            TorngitBaseAdapter, get_commit=get_commit_mocked
+        )
+        current_yaml = mocker.MagicMock()
+        pull_information = {
+            "base": {"commitid": "abcqwert" * 5, "branch": "basebranch"}
+        }
+        res = async_to_sync(_pick_best_base_comparedto_pair)(
+            repository_service, pull, current_yaml, pull_information
+        )
+        assert res == ("lkjhgfdslkjhgfdslkjhgfdslkjhgfdslkjhgfds", None)
+
+    def test_pick_best_base_comparedto_pair_yes_user_provided_base_exact_match(
+        self, mocker, transactional_db
+    ):
+        async def get_commit_mocked(commit_sha):
+            return {"timestamp": datetime(2021, 3, 10).isoformat()}
+
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(
+            repository=repository,
+            user_provided_base_sha="1007cbfb857592b9e7cbe3ecb25748870e2c07fc",
+        )
+        pull.save()
+        commit = CommitFactory.create(
+            repository=repository, commitid="1007cbfb857592b9e7cbe3ecb25748870e2c07fc"
+        )
+        commit.save()
+        repository_service = mocker.Mock(
+            TorngitBaseAdapter, get_commit=get_commit_mocked
+        )
+        current_yaml = mocker.MagicMock()
+        pull_information = {
+            "base": {"commitid": "abcqwert" * 5, "branch": "basebranch"}
+        }
+        res = async_to_sync(_pick_best_base_comparedto_pair)(
+            repository_service, pull, current_yaml, pull_information
+        )
+        assert res == (
+            "1007cbfb857592b9e7cbe3ecb25748870e2c07fc",
+            "1007cbfb857592b9e7cbe3ecb25748870e2c07fc",
+        )
+
+    def test_pick_best_base_comparedto_pair_yes_user_given_no_base_exact_match(
+        self, mocker, transactional_db
+    ):
+        async def get_commit_mocked(commit_sha):
+            return {"timestamp": datetime(2021, 3, 10).isoformat()}
+
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(
+            repository=repository,
+            user_provided_base_sha="1007cbfb857592b9e7cbe3ecb25748870e2c07fc",
+        )
+        pull.save()
+        commit = CommitFactory.create(
+            repository=repository, commitid="1007cbfb857592b9e7cbe3ecb25748870e2c07fc"
+        )
+        commit.save()
+        repository_service = mocker.Mock(
+            TorngitBaseAdapter, get_commit=get_commit_mocked
+        )
+        current_yaml = mocker.MagicMock()
+        pull_information = {
+            "base": {"commitid": "abcqwert" * 5, "branch": "basebranch"}
+        }
+        res = async_to_sync(_pick_best_base_comparedto_pair)(
+            repository_service, pull, current_yaml, pull_information
+        )
+        assert res == (
+            "1007cbfb857592b9e7cbe3ecb25748870e2c07fc",
+            "1007cbfb857592b9e7cbe3ecb25748870e2c07fc",
+        )
+
+    def test_pick_best_base_comparedto_pair_yes_user_given_no_base_no_match(
+        self, mocker, transactional_db
+    ):
+        async def get_commit_mocked(commit_sha):
+            return {"timestamp": datetime(2021, 3, 10).isoformat()}
+
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(
+            repository=repository,
+            user_provided_base_sha="1007cbfb857592b9e7cbe3ecb25748870e2c07fc",
+        )
+        pull.save()
+        commit = CommitFactory.create(
+            repository=repository,
+            commitid="e9868516aafd365aeab2957d3745353b532d3a37",
+            branch="basebranch",
+            timestamp=datetime(2021, 3, 9),
+            pullid=None,
+        )
+        other_commit = CommitFactory.create(
+            repository=repository,
+            commitid="2c07d7804dd9ff61ca5a1d6ee01de108af8cc7e0",
+            branch="basebranch",
+            timestamp=datetime(2021, 3, 11),
+            pullid=None,
+        )
+        commit.save()
+        other_commit.save()
+        repository_service = mocker.Mock(
+            TorngitBaseAdapter, get_commit=get_commit_mocked
+        )
+        current_yaml = mocker.MagicMock()
+        pull_information = {
+            "base": {"commitid": "abcqwert" * 5, "branch": "basebranch"}
+        }
+        res = async_to_sync(_pick_best_base_comparedto_pair)(
+            repository_service, pull, current_yaml, pull_information
+        )
+        assert res == (
+            "1007cbfb857592b9e7cbe3ecb25748870e2c07fc",
+            "e9868516aafd365aeab2957d3745353b532d3a37",
+        )
+
+    def test_pick_best_base_comparedto_pair_yes_user_given_not_found(
+        self, mocker, transactional_db
+    ):
+        async def get_commit_mocked(commit_sha):
+            if commit_sha == "1007cbfb857592b9e7cbe3ecb25748870e2c07fc":
+                raise TorngitObjectNotFoundError("response", "message")
+            return {"timestamp": datetime(2021, 3, 10).isoformat()}
+
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(
+            repository=repository,
+            user_provided_base_sha="1007cbfb857592b9e7cbe3ecb25748870e2c07fc",
+        )
+        pull.save()
+        commit = CommitFactory.create(
+            repository=repository,
+            commitid="e9868516aafd365aeab2957d3745353b532d3a37",
+            branch="basebranch",
+            timestamp=datetime(2021, 3, 9),
+            pullid=None,
+        )
+        other_commit = CommitFactory.create(
+            repository=repository,
+            commitid="2c07d7804dd9ff61ca5a1d6ee01de108af8cc7e0",
+            branch="basebranch",
+            timestamp=datetime(2021, 3, 11),
+            pullid=None,
+        )
+        commit.save()
+        other_commit.save()
+        repository_service = mocker.Mock(
+            TorngitBaseAdapter, get_commit=get_commit_mocked
+        )
+        current_yaml = mocker.MagicMock()
+        pull_information = {
+            "base": {"commitid": "abcqwert" * 5, "branch": "basebranch"}
+        }
+        res = async_to_sync(_pick_best_base_comparedto_pair)(
+            repository_service, pull, current_yaml, pull_information
+        )
+        assert res == (
+            "abcqwertabcqwertabcqwertabcqwertabcqwert",
+            "e9868516aafd365aeab2957d3745353b532d3a37",
+        )
+
+    def test_pick_best_base_comparedto_pair_no_user_given(
+        self, mocker, transactional_db
+    ):
+        async def get_commit_mocked(commit_sha):
+            return {"timestamp": datetime(2021, 3, 10).isoformat()}
+
+        repository = RepositoryFactory.create()
+        repository.save()
+        pull = PullFactory.create(repository=repository, user_provided_base_sha=None)
+        pull.save()
+        commit = CommitFactory.create(
+            repository=repository,
+            commitid="e9868516aafd365aeab2957d3745353b532d3a37",
+            branch="basebranch",
+            timestamp=datetime(2021, 3, 9),
+            pullid=None,
+        )
+        other_commit = CommitFactory.create(
+            repository=repository,
+            commitid="2c07d7804dd9ff61ca5a1d6ee01de108af8cc7e0",
+            branch="basebranch",
+            timestamp=datetime(2021, 3, 11),
+            pullid=None,
+        )
+        commit.save()
+        other_commit.save()
+        repository_service = mocker.MagicMock(
+            TorngitBaseAdapter, get_commit=get_commit_mocked
+        )
+        current_yaml = mocker.MagicMock()
+        pull_information = {
+            "base": {"commitid": "abcqwert" * 5, "branch": "basebranch"}
+        }
+        res = async_to_sync(_pick_best_base_comparedto_pair)(
+            repository_service, pull, current_yaml, pull_information
+        )
+        assert res == (
+            "abcqwertabcqwertabcqwertabcqwertabcqwert",
+            "e9868516aafd365aeab2957d3745353b532d3a37",
+        )


### PR DESCRIPTION
This PR creates copies of the repository and bots services that use the Django models instead of the SQLAlchemy models. This is so that the test results finisher can use the django models instead of the SQLAlchemy models.

Note: there is a difference in the behaviour we're verifying between the regular repository service tests and the django repository service tests. One example is `test_fetch_and_update_pull_request_information_no_compared_to`