### PR TITLE
denoise an obnoxious log

### DIFF
--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import itertools
 import logging
 import random
 import typing
@@ -172,8 +173,7 @@ def process_raw_upload(
         log.info(
             "Example path fixes for this raw upload",
             extra={
-                "fixes": actual_path_fixes.items(),
-                "toc": path_fixer.toc,
+                "fixes": list(itertools.islice(actual_path_fixes.items(), 10)),
                 "disable_default_pathfixes": path_fixer.should_disable_default_pathfixes,
             },
         )


### PR DESCRIPTION
instead of logging the full set of path fixes, log the "first" 10, and skip logging a full table of contents ("toc")

the `fixes` and `toc` keys in this log can potentially have an item for every file in the repository. GCP collapses big logs into a smaller row that you can click to expand, but apparently a log can be so big that it will actually be split across several rows, and in at least one case the log was so big that it took up screenful after screenful and made investigating the issue i was working on much harder

