### PR TITLE
sync_repos: allow private repo permissions to be set on error

### DIFF
--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -13,7 +13,7 @@ from shared.celery_config import (
 from shared.config import get_config
 from shared.metrics import metrics
 from shared.torngit.base import TorngitBaseAdapter
-from shared.torngit.exceptions import TorngitClientError
+from shared.torngit.exceptions import TorngitClientError, TorngitServerFailureError
 from sqlalchemy import and_
 from sqlalchemy.orm.session import Session
 
@@ -424,29 +424,26 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
             async for page in git.list_repos_generator():
                 process_repos(page)
 
-        except SoftTimeLimitExceeded:
+        except (
+            SoftTimeLimitExceeded,
+            TorngitClientError,
+            TorngitServerFailureError,
+        ) as e:
             old_permissions = owner.permission or []
-            log.warning(
-                "System timed out while listing repos",
+            if isinstance(e, SoftTimeLimitExceeded):
+                error_string = "System timed out while listing repos"
+            else:
+                error_string = "Torngit failure while listing repos"
+
+            log.error(
+                f"{error_string}. Permissions list may be incomplete",
+                exc_info=True,
                 extra=dict(
                     ownerid=owner.ownerid,
-                    old_permissions=old_permissions[:100],
                     number_old_permissions=len(old_permissions),
+                    number_new_permissions=len(set(private_project_ids)),
                 ),
             )
-            raise
-        except TorngitClientError as e:
-            old_permissions = owner.permission or []
-            log.warning(
-                "Unable to verify user permissions on Github. Dropping all permissions",
-                extra=dict(
-                    ownerid=owner.ownerid,
-                    old_permissions=old_permissions[:100],
-                    number_old_permissions=len(old_permissions),
-                ),
-            )
-            owner.permission = []
-            return
 
         log.info(
             "Updating permissions",


### PR DESCRIPTION
https://github.com/codecov/engineering-team/issues/1757

in most tasks, all db writes occur in a transaction and if an uncaught error occurs we roll the transaction back. for sync_repos, if a user syncs 999/1000 repos and then encounters an error, we actually don't want to roll everything back.

[`sync_repos` already commits after each repo insert](https://github.com/codecov/worker/blob/1beef847cdd951cd084adf4632893c39f4c442e9/tasks/sync_repos.py#L436) so the repo data won't be thrown away. however, what we _don't_ do is update the list of private repos that the syncing user can see. so if they sync 999 new private repos and then get a 502, the 999 repos will be in our database but we won't let the user view any of them. this PR changes that

the old behavior, when catching a worker task timeout or `TorngitClientError`, would clear the private repo permission list entirely to avoid the possibility of leaving the user with permission they shouldn't have. that was stricter than necessary though; the `private_project_ids` list may be incomplete if an error occurs before we've processed every repo but the things it _does_ have are definitely visible to the user. so it's fine to set `owner.permission = private_project_ids`.

the old behavior did not catch `TorngitServerFailureError` and if such an error occurred (as it would if github returns a 504) no changes would be made to the private repo permission list. no new repos will be added, and if access to a private repo was supposed to have been revoked, the user will still be able to see it in codecov.

the new behavior handles timeouts, `TorngitClientError`s, and `TorngitServerFailureError`s the same way: log the error, mention that the private repo permission list may be incomplete, and then set `owner.permission` and complete the task normally. the way this appears to the user:
- a new or existing user who sees a worker task timeout or `TorngitClientError` (e.g. rate limit, token flukes) will no longer have the list of private repos they can see totally wiped. the list may be incomplete, but it will no longer be empty
- a new user who sees a `TorngitServerFailureError` (e.g. github 504) will not be left with an empty list of private repos. they will be able to see any repos that successfully synced
- an existing user who sees a `TorngitServerFailureError` (e.g. github 504) will have their permission list updated to a new, possibly incomplete list. some repos may be added, some repos may "disappear". repos that should not be in the list will no longer be in the list