### PR TITLE
feat: pin down commits to apps

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -210,6 +210,7 @@ def mock_repo_provider(mocker):
     m = mocker.patch("services.repository._get_repo_provider_service_instance")
     provider_instance = mocker.MagicMock(
         GithubHandler,
+        data={},
         get_commit_diff=mock.AsyncMock(return_value={}),
         get_distance_in_commits=mock.AsyncMock(
             return_value={"behind_by": 0, "behind_by_commit": None}

--- a/services/github.py
+++ b/services/github.py
@@ -69,7 +69,8 @@ def get_github_app_for_commit(commit: Commit) -> str | None:
         return None
     redis = get_redis_connection()
     try:
-        return redis.get(COMMIT_GHAPP_KEY_NAME(commit.id))
+        value = redis.get(COMMIT_GHAPP_KEY_NAME(commit.id))
+        return value if value is None else value.decode()
     except RedisError:
         log.exception(
             "Failed to get app for commit", extra=dict(commit=commit.commitid)

--- a/services/notification/notifiers/base.py
+++ b/services/notification/notifiers/base.py
@@ -17,6 +17,7 @@ class NotificationResult(object):
     explanation: str = None
     data_sent: Mapping[str, Any] = None
     data_received: Mapping[str, Any] = None
+    github_app_used: int | None = None
 
     def merge(self, other: "NotificationResult") -> "NotificationResult":
         ans = NotificationResult()
@@ -60,10 +61,10 @@ class AbstractBaseNotifier(object):
         :param title: The project name for this notification, if applicable. For more info see https://docs.codecov.io/docs/commit-status#splitting-up-projects-example
         :param notifier_yaml_settings: Contains the codecov yaml fields, if any, for this particular notification.
             example: status -> patch -> custom_project_name -> <whatever is here is in notifier_yaml_settings for custom_project_name's status patch notifier>
-        :param notifier_site_settings -> Contains the codecov yaml fields under the "notify" header
-        :param current_yaml -> The complete codecov yaml used for this notification.
-        :param decoration_type -> Indicates whether the user needs to upgrade their account before they can see the notification
-        :param gh_installation_name_to_use -> [GitHub exclusive] propagates choice of the installation_name in case of gh multi apps
+        :param notifier_site_settings: Contains the codecov yaml fields under the "notify" header
+        :param current_yaml: The complete codecov yaml used for this notification.
+        :param decoration_type: Indicates whether the user needs to upgrade their account before they can see the notification
+        :param gh_installation_name_to_use: [GitHub exclusive] propagates choice of the installation_name in case of gh multi apps
         """
         self.repository = repository
         self.title = title
@@ -90,7 +91,7 @@ class AbstractBaseNotifier(object):
 
         Args:
             comparison (Comparison): The comparison with which this notify ran
-            result (NotificationResult): The results of the notificaiton
+            result (NotificationResult): The results of the notification
         """
         raise NotImplementedError()
 

--- a/services/notification/notifiers/checks/base.py
+++ b/services/notification/notifiers/checks/base.py
@@ -4,10 +4,13 @@ from typing import Dict
 
 from shared.torngit.exceptions import TorngitClientError, TorngitError
 
+from database.models.core import Commit
 from helpers.metrics import metrics
 from services.notification.notifiers.base import Comparison, NotificationResult
 from services.notification.notifiers.status.base import StatusNotifier
-from services.repository import get_repo_provider_service
+from services.repository import (
+    get_repo_provider_service_for_specific_commit,
+)
 from services.urls import (
     append_tracking_params_to_urls,
     get_commit_url,
@@ -344,19 +347,17 @@ class ChecksNotifier(StatusNotifier):
             annotations.append(annotation)
         return annotations
 
-    @property
-    def repository_service(self):
+    def repository_service(self, commit: Commit):
         if not self._repository_service:
-            self._repository_service = get_repo_provider_service(
-                self.repository, installation_name_to_use=self.gh_installation_name
+            self._repository_service = get_repo_provider_service_for_specific_commit(
+                commit, fallback_installation_name=self.gh_installation_name
             )
         return self._repository_service
 
     async def send_notification(self, comparison: Comparison, payload):
         title = self.get_status_external_name()
-        repository_service = self.repository_service
         head = comparison.head.commit
-        head_report = comparison.head.report
+        repository_service = self.repository_service(head)
         state = payload["state"]
         state = "success" if self.notifier_yaml_settings.get("informational") else state
 
@@ -438,4 +439,5 @@ class ChecksNotifier(StatusNotifier):
             notification_successful=True,
             explanation=None,
             data_sent=payload,
+            github_app_used=self.get_github_app_used(),
         )

--- a/services/notification/notifiers/checks/base.py
+++ b/services/notification/notifiers/checks/base.py
@@ -4,13 +4,9 @@ from typing import Dict
 
 from shared.torngit.exceptions import TorngitClientError, TorngitError
 
-from database.models.core import Commit
 from helpers.metrics import metrics
 from services.notification.notifiers.base import Comparison, NotificationResult
 from services.notification.notifiers.status.base import StatusNotifier
-from services.repository import (
-    get_repo_provider_service_for_specific_commit,
-)
 from services.urls import (
     append_tracking_params_to_urls,
     get_commit_url,
@@ -346,13 +342,6 @@ class ChecksNotifier(StatusNotifier):
             }
             annotations.append(annotation)
         return annotations
-
-    def repository_service(self, commit: Commit):
-        if not self._repository_service:
-            self._repository_service = get_repo_provider_service_for_specific_commit(
-                commit, fallback_installation_name=self.gh_installation_name
-            )
-        return self._repository_service
 
     async def send_notification(self, comparison: Comparison, payload):
         title = self.get_status_external_name()

--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -3,6 +3,7 @@ from typing import Dict
 
 from shared.config import get_config
 from shared.helpers.cache import NO_VALUE, make_hash_sha256
+from shared.torngit.base import TorngitBaseAdapter
 from shared.torngit.exceptions import TorngitClientError, TorngitError
 
 from database.models.core import Commit
@@ -28,7 +29,7 @@ log = logging.getLogger(__name__)
 class StatusNotifier(AbstractBaseNotifier):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
-        self._repository_service = None
+        self._repository_service: TorngitBaseAdapter = None
 
     def is_enabled(self) -> bool:
         return True
@@ -68,7 +69,7 @@ class StatusNotifier(AbstractBaseNotifier):
 
     def determine_status_check_behavior_to_apply(
         self, comparison, field_name
-    ) -> str or None:
+    ) -> str | None:
         """
         Used for fields that can be set at the global level for all checks in "default_rules", or at the component level for an individual check.
         For more context, see https://docs.codecov.io/docs/commit-status#default_rules
@@ -106,7 +107,7 @@ class StatusNotifier(AbstractBaseNotifier):
             len(report_uploaded_flags.intersection(flags_included_in_status_check)) > 0
         )
 
-    def repository_service(self, commit: Commit):
+    def repository_service(self, commit: Commit) -> TorngitBaseAdapter:
         if not self._repository_service:
             self._repository_service = get_repo_provider_service_for_specific_commit(
                 commit, fallback_installation_name=self.gh_installation_name

--- a/services/notification/tests/unit/test_commit_notifications.py
+++ b/services/notification/tests/unit/test_commit_notifications.py
@@ -1,23 +1,24 @@
-import dataclasses
-
 import pytest
 
 from database.enums import Decoration, Notification, NotificationState
+from database.models.core import GithubAppInstallation
 from database.tests.factories import (
     CommitFactory,
     CommitNotificationFactory,
     PullFactory,
     RepositoryFactory,
 )
+from services.comparison.types import Comparison, FullCommit
 from services.notification.commit_notifications import (
     create_or_update_commit_notification_from_notification_result,
 )
 from services.notification.notifiers.base import NotificationResult
 from services.notification.notifiers.comment import CommentNotifier
+from services.repository import EnrichedPull
 
 
 @pytest.fixture
-def pull(dbsession):
+def comparison(dbsession):
     repository = RepositoryFactory.create(
         owner__username="codecov",
         owner__unencrypted_oauth_token="testtlxuu2kfef3km1fbecdlmnb2nvpikvmoadi3",
@@ -40,11 +41,19 @@ def pull(dbsession):
     dbsession.add(head_commit)
     dbsession.add(pull)
     dbsession.flush()
-    return pull
+    return Comparison(
+        head=FullCommit(commit=head_commit, report=None),
+        project_coverage_base=FullCommit(commit=base_commit, report=None),
+        patch_coverage_base_commitid=base_commit.commitid,
+        enriched_pull=EnrichedPull(database_pull=pull, provider_pull=None),
+    )
 
 
 class TestCommitNotificationsServiceTestCase(object):
-    def test_create_or_update_commit_notification_not_yet_exists(self, dbsession, pull):
+    def test_create_or_update_commit_notification_not_yet_exists(
+        self, dbsession, comparison
+    ):
+        pull = comparison.pull
         commit = pull.get_head_commit()
         notifier = CommentNotifier(
             repository=pull.repository,
@@ -61,9 +70,9 @@ class TestCommitNotificationsServiceTestCase(object):
             data_received=dict(id=123),
             data_sent=dict(a=1, b=2),
         )
-        result_dict = dataclasses.asdict(notify_res)
+
         res = create_or_update_commit_notification_from_notification_result(
-            pull, notifier, result_dict
+            comparison, notifier, notify_res
         )
         dbsession.flush()
         assert res.commit_id == commit.id_
@@ -71,10 +80,47 @@ class TestCommitNotificationsServiceTestCase(object):
         assert res.notification_type == notifier.notification_type
         assert res.state == NotificationState.error
 
-    def test_create_or_update_commit_notification_no_result(self, dbsession, pull):
-        commit = pull.get_head_commit()
+    def test_create_or_update_commit_notification_not_yet_exists_no_pull_but_ghapp_info(
+        self, dbsession, comparison
+    ):
+        comparison.enriched_pull = None
+        commit = comparison.head.commit
+        app = GithubAppInstallation(owner=commit.repository.owner)
+        dbsession.add(app)
+        dbsession.flush()
         notifier = CommentNotifier(
-            repository=pull.repository,
+            repository=commit.repository,
+            title="title",
+            notifier_yaml_settings={"layout": "reach, diff, flags, files, footer"},
+            notifier_site_settings=True,
+            current_yaml={},
+            decoration_type=Decoration.standard,
+        )
+        notify_res = NotificationResult(
+            notification_attempted=True,
+            notification_successful=True,
+            explanation=None,
+            data_received=dict(id=123),
+            data_sent=dict(a=1, b=2),
+            github_app_used=app.id,
+        )
+
+        res = create_or_update_commit_notification_from_notification_result(
+            comparison, notifier, notify_res
+        )
+        dbsession.flush()
+        assert res.commit_id == commit.id_
+        assert res.decoration_type == notifier.decoration_type
+        assert res.notification_type == notifier.notification_type
+        assert res.state == NotificationState.success
+        assert res.gh_app_id == app.id
+
+    def test_create_or_update_commit_notification_no_result(
+        self, dbsession, comparison
+    ):
+        commit = comparison.head.commit
+        notifier = CommentNotifier(
+            repository=commit.repository,
             title="title",
             notifier_yaml_settings={"layout": "reach, diff, flags, files, footer"},
             notifier_site_settings=True,
@@ -83,7 +129,7 @@ class TestCommitNotificationsServiceTestCase(object):
         )
         result_dict = None
         res = create_or_update_commit_notification_from_notification_result(
-            pull, notifier, result_dict
+            comparison, notifier, result_dict
         )
         dbsession.flush()
         assert res.commit_id == commit.id_
@@ -92,9 +138,9 @@ class TestCommitNotificationsServiceTestCase(object):
         assert res.state == NotificationState.error
 
     def test_create_or_update_commit_notification_decoration_change(
-        self, dbsession, pull
+        self, dbsession, comparison
     ):
-        head_commit = pull.get_head_commit()
+        head_commit = comparison.head.commit
 
         cn = CommitNotificationFactory(
             commit=head_commit,
@@ -106,7 +152,7 @@ class TestCommitNotificationsServiceTestCase(object):
         dbsession.flush()
 
         notifier = CommentNotifier(
-            repository=pull.repository,
+            repository=head_commit.repository,
             title="title",
             notifier_yaml_settings={"layout": "reach, diff, flags, files, footer"},
             notifier_site_settings=True,
@@ -120,9 +166,8 @@ class TestCommitNotificationsServiceTestCase(object):
             data_received=dict(id=123),
             data_sent=dict(a=1, b=2),
         )
-        result_dict = dataclasses.asdict(notify_res)
         res = create_or_update_commit_notification_from_notification_result(
-            pull, notifier, result_dict
+            comparison, notifier, notify_res
         )
         dbsession.flush()
         assert cn.commit_id == head_commit.id_
@@ -130,8 +175,10 @@ class TestCommitNotificationsServiceTestCase(object):
         assert cn.notification_type == notifier.notification_type
         assert cn.state == NotificationState.success
 
-    def test_create_or_update_commit_notification_now_successful(self, dbsession, pull):
-        head_commit = pull.get_head_commit()
+    def test_create_or_update_commit_notification_now_successful(
+        self, dbsession, comparison
+    ):
+        head_commit = comparison.head.commit
 
         cn = CommitNotificationFactory(
             commit=head_commit,
@@ -143,7 +190,7 @@ class TestCommitNotificationsServiceTestCase(object):
         dbsession.flush()
 
         notifier = CommentNotifier(
-            repository=pull.repository,
+            repository=head_commit.repository,
             title="title",
             notifier_yaml_settings={"layout": "reach, diff, flags, files, footer"},
             notifier_site_settings=True,
@@ -157,9 +204,8 @@ class TestCommitNotificationsServiceTestCase(object):
             data_received=dict(id=123),
             data_sent=dict(a=1, b=2),
         )
-        result_dict = dataclasses.asdict(notify_res)
         res = create_or_update_commit_notification_from_notification_result(
-            pull, notifier, result_dict
+            comparison, notifier, notify_res
         )
         dbsession.flush()
         assert cn.commit_id == head_commit.id_

--- a/services/tests/test_github.py
+++ b/services/tests/test_github.py
@@ -56,8 +56,8 @@ class TestGetSetGithubAppsToCommits(object):
         repo_ghe = RepositoryFactory(owner__service="github_enterprise")
         repo_gitlab = RepositoryFactory(owner__service="gitlab")
         redis_keys = {
-            "app_to_use_for_commit_12": "1200",
-            "app_to_use_for_commit_10": "1000",
+            "app_to_use_for_commit_12": b"1200",
+            "app_to_use_for_commit_10": b"1000",
         }
         fake_commit_12 = MagicMock(
             name="fake_commit", **{"id": 12, "repository": repo_github}
@@ -87,3 +87,13 @@ class TestGetSetGithubAppsToCommits(object):
         )
         assert get_github_app_for_commit(fake_commit_12) == None
         mock_redis.get.assert_called_with("app_to_use_for_commit_12")
+
+    @pytest.mark.integration
+    def test_get_and_set_app_for_commit(self, dbsession):
+        commit = self._get_commit(dbsession)
+        # String
+        set_github_app_for_commit("12", commit)
+        assert get_github_app_for_commit(commit) == "12"
+        # Int
+        set_github_app_for_commit(24, commit)
+        assert get_github_app_for_commit(commit) == "24"

--- a/services/tests/test_repository_service.py
+++ b/services/tests/test_repository_service.py
@@ -1104,8 +1104,8 @@ class TestGetRepoProviderServiceForSpecificCommit(object):
         commit = CommitFactory(repository__owner__service="github")
         assert commit.id not in [10000, 15000]
         redis_keys = {
-            "app_to_use_for_commit_15000": "1200",
-            "app_to_use_for_commit_10000": "1000",
+            "app_to_use_for_commit_15000": b"1200",
+            "app_to_use_for_commit_10000": b"1000",
         }
         mock_redis.get.side_effect = lambda key: redis_keys.get(key)
 
@@ -1139,7 +1139,7 @@ class TestGetRepoProviderServiceForSpecificCommit(object):
         dbsession.flush()
         assert commit.repository.owner.github_app_installations == [app]
         redis_keys = {
-            f"app_to_use_for_commit_{commit.id}": str(app.id),
+            f"app_to_use_for_commit_{commit.id}": str(app.id).encode(),
         }
         mock_redis.get.side_effect = lambda key: redis_keys.get(key)
         response = get_repo_provider_service_for_specific_commit(commit, "some_name")

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -9,12 +9,13 @@ from shared.celery_config import (
     status_set_error_task_name,
 )
 from shared.reports.readonly import ReadOnlyReport
+from shared.torngit.base import TorngitBaseAdapter
 from shared.torngit.exceptions import TorngitClientError, TorngitServerFailureError
 from shared.yaml import UserYaml
 from sqlalchemy.orm.session import Session
 
 from app import celery_app
-from database.enums import CommitErrorTypes, Decoration, ReportType
+from database.enums import CommitErrorTypes, Decoration, NotificationState, ReportType
 from database.models import Commit, Pull
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
 from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
@@ -28,6 +29,7 @@ from services.commit_status import RepositoryCIFilter
 from services.comparison import ComparisonContext, ComparisonProxy
 from services.comparison.types import Comparison, FullCommit
 from services.decoration import determine_decoration_details
+from services.github import get_github_app_for_commit, set_github_app_for_commit
 from services.lock_manager import LockManager, LockRetry, LockType
 from services.notification import NotificationService
 from services.redis import Redis, get_redis_connection
@@ -193,6 +195,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
             repository_service = get_repo_provider_service(
                 commit.repository, installation_name_to_use=installation_name_to_use
             )
+            self._possibly_pin_commit_to_github_app(commit, repository_service)
         except RepositoryWithoutValidBotError:
             save_commit_error(
                 commit, error_code=CommitErrorTypes.REPO_BOT_INVALID.value
@@ -398,6 +401,55 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 extra=dict(commit=commit.commitid, repoid=commit.repoid),
             )
             return {"notified": False, "notifications": None}
+
+    def _possibly_refresh_previous_selection(self, commit: Commit) -> bool:
+        installation_cached: str = get_github_app_for_commit(commit)
+        app_id_used_in_successful_comment: int = next(
+            (
+                obj.gh_app_id
+                for obj in commit.notifications
+                if obj.gh_app_id is not None and obj.state == NotificationState.success
+            ),
+            None,
+        )
+        if installation_cached or app_id_used_in_successful_comment:
+            id_to_cache = installation_cached or app_id_used_in_successful_comment
+            # Some app is already set for this commit, so we renew the caching of the app.
+            # It's OK if this app is not the same as the one chosen by torngit (argument), because the
+            # different notifiers have their own torngit adapter and will look at the pinned app first.
+            set_github_app_for_commit(id_to_cache, commit)
+            return True
+        return False
+
+    def _possibly_pin_commit_to_github_app(
+        self, commit: Commit, torngit: TorngitBaseAdapter
+    ) -> int | str | None:
+        """Pins down the github app to use when emitting notifications for this commit, as needed.
+
+        For non-GitHub, do nothing.
+        For situations that we don't use a GithubAppInstance to communicate, do nothing.
+
+        If there is already an app cached in redis for this commit, OR a CommitNotification that was
+        successful with an app, renew that app's caching (it might be different from our selection, but that's ok)
+
+        Returns:
+            the cached app's id (int | str | None) - to make it easier to test
+        """
+        is_github = commit.repository.service in ["github", "github_enterprise"]
+        if not is_github:
+            return
+        refreshed_previous_selection = self._possibly_refresh_previous_selection(commit)
+        if refreshed_previous_selection:
+            # If a selection was already made we shouldn't overwrite it
+            return
+        torngit_installation = torngit.data.get("installation")
+        selected_installation_id = (
+            torngit_installation.get("id") if torngit_installation else None
+        )
+        if selected_installation_id is not None:
+            # Here we pin our selection to be the app to use
+            set_github_app_for_commit(selected_installation_id, commit)
+            return selected_installation_id
 
     def has_upcoming_notifies_according_to_redis(
         self, redis_connection: Redis, repoid: int, commitid: str

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -424,7 +424,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
     def _possibly_pin_commit_to_github_app(
         self, commit: Commit, torngit: TorngitBaseAdapter
     ) -> int | str | None:
-        """Pins down the github app to use when emitting notifications for this commit, as needed.
+        """Pin the GitHub app to use when emitting notifications for this commit, as needed.
 
         For non-GitHub, do nothing.
         For situations that we don't use a GithubAppInstance to communicate, do nothing.

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -7,6 +7,7 @@ from mock import PropertyMock
 from database.models import Pull
 from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
 from services.archive import ArchiveService
+from services.notification.notifiers.base import NotificationResult
 from tasks.notify import NotifyTask
 
 sample_token = "ghp_test6ldgmyaglf73gcnbi0kprz7dyjz6nzgn"
@@ -35,7 +36,7 @@ class TestNotifyTask(object):
         mock_redis,
     ):
         mock_requests_post.return_value.status_code = 200
-        mock_redis.get.return_value = False
+        mock_redis.get.return_value = None
         mock_configuration.params["setup"]["codecov_dashboard_url"] = (
             "https://codecov.io"
         )
@@ -88,11 +89,11 @@ class TestNotifyTask(object):
                 {
                     "notifier": "codecov-slack-app",
                     "title": "codecov-slack-app",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": "Successfully notified slack app",
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation="Successfully notified slack app",
+                        data_sent={
                             "repository": "example-python",
                             "owner": "ThiagoCodecov",
                             "comparison": {
@@ -142,8 +143,8 @@ class TestNotifyTask(object):
                                 "head_totals_c": "85.00000",
                             },
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 }
             ],
         }
@@ -215,26 +216,26 @@ class TestNotifyTask(object):
                 {
                     "notifier": "status-project",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": False,
-                        "notification_successful": None,
-                        "explanation": "already_done",
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=False,
+                        notification_successful=None,
+                        explanation="already_done",
+                        data_sent={
                             "title": "codecov/project",
                             "state": "success",
                             "message": "85.00% (+0.00%) compared to 17a71a9",
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 },
                 {
                     "notifier": "codecov-slack-app",
                     "title": "codecov-slack-app",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": "Successfully notified slack app",
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation="Successfully notified slack app",
+                        data_sent={
                             "repository": "example-python",
                             "owner": "ThiagoCodecov",
                             "comparison": {
@@ -321,8 +322,8 @@ class TestNotifyTask(object):
                                 "head_totals_c": "85.00000",
                             },
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 },
             ],
         }
@@ -405,56 +406,56 @@ class TestNotifyTask(object):
                 {
                     "notifier": "status-project",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "title": "codecov/project",
                             "state": "success",
                             "message": "85.00% (+0.00%) compared to 081d919",
                         },
-                        "data_received": {"id": 9333281614},
-                    },
+                        data_received={"id": 9333281614},
+                    ),
                 },
                 {
                     "notifier": "status-patch",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "title": "codecov/patch",
                             "state": "success",
                             "message": "Coverage not affected when comparing 081d919...f089529",
                         },
-                        "data_received": {"id": 9333281697},
-                    },
+                        data_received={"id": 9333281697},
+                    ),
                 },
                 {
                     "notifier": "status-changes",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "title": "codecov/changes",
                             "state": "failure",
                             "message": "1 file has indirect coverage changes not visible in diff",
                         },
-                        "data_received": {"id": 9333281703},
-                    },
+                        data_received={"id": 9333281703},
+                    ),
                 },
                 {
                     "notifier": "codecov-slack-app",
                     "title": "codecov-slack-app",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": "Successfully notified slack app",
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation="Successfully notified slack app",
+                        data_sent={
                             "repository": "example-python",
                             "owner": "ThiagoCodecov",
                             "comparison": {
@@ -541,8 +542,8 @@ class TestNotifyTask(object):
                                 "head_totals_c": "85.00000",
                             },
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 },
             ],
         }
@@ -632,56 +633,56 @@ class TestNotifyTask(object):
                 {
                     "notifier": "status-project",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "title": "codecov/project",
                             "state": "success",
                             "message": "85.00% (+0.00%) compared to f089529",
                         },
-                        "data_received": {"id": 9333363767},
-                    },
+                        data_received={"id": 9333363767},
+                    ),
                 },
                 {
                     "notifier": "status-patch",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "title": "codecov/patch",
                             "state": "success",
                             "message": "Coverage not affected when comparing f089529...11daa27",
                         },
-                        "data_received": {"id": 9333363778},
-                    },
+                        data_received={"id": 9333363778},
+                    ),
                 },
                 {
                     "notifier": "status-changes",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "title": "codecov/changes",
                             "state": "success",
                             "message": "No indirect coverage changes found",
                         },
-                        "data_received": {"id": 9333363801},
-                    },
+                        data_received={"id": 9333363801},
+                    ),
                 },
                 {
                     "notifier": "codecov-slack-app",
                     "title": "codecov-slack-app",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": "Successfully notified slack app",
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation="Successfully notified slack app",
+                        data_sent={
                             "repository": "example-python",
                             "owner": "ThiagoCodecov",
                             "comparison": {
@@ -768,8 +769,8 @@ class TestNotifyTask(object):
                                 "head_totals_c": "85.00000",
                             },
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 },
             ],
         }
@@ -878,11 +879,11 @@ class TestNotifyTask(object):
                 {
                     "notifier": "WebhookNotifier",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "repo": {
                                 "url": "https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo",
                                 "service_id": repository.service_id,
@@ -991,78 +992,78 @@ class TestNotifyTask(object):
                                 "merged": False,
                             },
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 },
                 {
                     "notifier": "SlackNotifier",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "text": f"Coverage for <https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/commit/5601846871b8142ab0df1e0b8774756c658bcc7d|joseph-sentry/codecov-demo> *no change* `<https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/pull/9|0.00%>` on `test` is `85.00000%` via `<https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/commit/5601846871b8142ab0df1e0b8774756c658bcc7d|5601846>`",
                             "author_name": "Codecov",
                             "author_link": "https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/commit/5601846871b8142ab0df1e0b8774756c658bcc7d",
                             "attachments": [],
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 },
                 {
                     "notifier": "status-project",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": False,
-                        "notification_successful": None,
-                        "explanation": "already_done",
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=False,
+                        notification_successful=None,
+                        explanation="already_done",
+                        data_sent={
                             "title": "codecov/project",
                             "state": "success",
                             "message": f"85.00% (+0.00%) compared to {master_sha[:7]}",
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 },
                 {
                     "notifier": "status-patch",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": False,
-                        "notification_successful": None,
-                        "explanation": "already_done",
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=False,
+                        notification_successful=None,
+                        explanation="already_done",
+                        data_sent={
                             "title": "codecov/patch",
                             "state": "success",
                             "message": f"Coverage not affected when comparing {master_sha[:7]}...{head_commitid[:7]}",
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 },
                 {
                     "notifier": "status-changes",
                     "title": "default",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "title": "codecov/changes",
                             "state": "success",
                             "message": "No indirect coverage changes found",
                         },
-                        "data_received": {"id": 24846000025},
-                    },
+                        data_received={"id": 24846000025},
+                    ),
                 },
                 {
                     "notifier": "codecov-slack-app",
                     "title": "codecov-slack-app",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": "Successfully notified slack app",
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation="Successfully notified slack app",
+                        data_sent={
                             "repository": "codecov-demo",
                             "owner": "joseph-sentry",
                             "comparison": {
@@ -1149,17 +1150,17 @@ class TestNotifyTask(object):
                                 "head_totals_c": "85.00000",
                             },
                         },
-                        "data_received": None,
-                    },
+                        data_received=None,
+                    ),
                 },
                 {
                     "notifier": "comment",
                     "title": "comment",
-                    "result": {
-                        "notification_attempted": True,
-                        "notification_successful": True,
-                        "explanation": None,
-                        "data_sent": {
+                    "result": NotificationResult(
+                        notification_attempted=True,
+                        notification_successful=True,
+                        explanation=None,
+                        data_sent={
                             "message": [
                                 "## [Codecov](https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/pull/9?dropdown=coverage&src=pr&el=h1) Report",
                                 "All modified and coverable lines are covered by tests :white_check_mark:",
@@ -1202,8 +1203,8 @@ class TestNotifyTask(object):
                             "commentid": None,
                             "pullid": 9,
                         },
-                        "data_received": {"id": 1699669573},
-                    },
+                        data_received={"id": 1699669573},
+                    ),
                 },
             ],
         }
@@ -1217,21 +1218,19 @@ class TestNotifyTask(object):
             sorted(expected_result["notifications"], key=lambda x: x["notifier"]),
         ):
             assert (
-                expected["result"]["notification_attempted"]
-                == actual["result"]["notification_attempted"]
+                expected["result"].notification_attempted
+                == actual["result"].notification_attempted
             )
             assert (
-                expected["result"]["notification_successful"]
-                == actual["result"]["notification_successful"]
+                expected["result"].notification_successful
+                == actual["result"].notification_successful
             )
-            assert expected["result"]["explanation"] == actual["result"]["explanation"]
-            assert expected["result"]["data_sent"].get("message") == actual["result"][
-                "data_sent"
-            ].get("message")
-            assert expected["result"]["data_sent"] == actual["result"]["data_sent"]
-            assert (
-                expected["result"]["data_received"] == actual["result"]["data_received"]
-            )
+            assert expected["result"].explanation == actual["result"].explanation
+            assert expected["result"].data_sent.get("message") == actual[
+                "result"
+            ].data_sent.get("message")
+            assert expected["result"].data_sent == actual["result"].data_sent
+            assert expected["result"].data_received == actual["result"].data_received
             assert expected["result"] == actual["result"]
             assert expected == actual
         assert sorted(result["notifications"], key=lambda x: x["notifier"]) == sorted(

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import call
+from unittest.mock import MagicMock, call
 
 import pytest
 from celery.exceptions import MaxRetriesExceededError, Retry
@@ -10,9 +10,11 @@ from shared.torngit.exceptions import (
     TorngitClientGeneralError,
     TorngitServer5xxCodeError,
 )
+from shared.typings.torngit import GithubInstallationInfo, TorngitInstanceData
 from shared.yaml import UserYaml
 
-from database.enums import Decoration, Notification
+from database.enums import Decoration, Notification, NotificationState
+from database.models.core import CommitNotification, GithubAppInstallation
 from database.tests.factories import (
     CommitFactory,
     OwnerFactory,
@@ -240,6 +242,95 @@ class TestNotifyTaskHelpers(object):
             ),
         )
 
+    @pytest.mark.parametrize("cached_id, app_to_save", [("24", "24"), (None, 12)])
+    def test__possibly_refresh_previous_selection(
+        self, cached_id, app_to_save, mocker, dbsession
+    ):
+        commit = CommitFactory(repository__owner__service="github")
+        app = GithubAppInstallation(id_=12, owner=commit.repository.owner)
+        other_app = GithubAppInstallation(id_=24, owner=commit.repository.owner)
+        commit_notifications = [
+            CommitNotification(
+                commit=commit,
+                notification_type=Notification.checks_project,
+                state=NotificationState.success,
+            ),
+            CommitNotification(
+                commit=commit,
+                notification_type=Notification.checks_patch,
+                state=NotificationState.error,
+                gh_app_id=other_app.id,
+            ),
+            CommitNotification(
+                commit=commit,
+                notification_type=Notification.checks_changes,
+                state=NotificationState.success,
+                gh_app_id=app.id,
+            ),
+        ]
+        dbsession.add_all([commit, app, other_app] + commit_notifications)
+        dbsession.flush()
+        mock_set_gh_app_for_commit = mocker.patch(
+            "tasks.notify.set_github_app_for_commit"
+        )
+        mocker.patch("tasks.notify.get_github_app_for_commit", return_value=cached_id)
+        task = NotifyTask()
+        assert task._possibly_refresh_previous_selection(commit) == True
+        mock_set_gh_app_for_commit.assert_called_with(app_to_save, commit)
+
+    def test__possibly_refresh_previous_selection(self, mocker, dbsession):
+        commit = CommitFactory(repository__owner__service="github")
+        dbsession.add(commit)
+        dbsession.flush()
+        mocker.patch("tasks.notify.get_github_app_for_commit", return_value=None)
+        mock_set_gh_app_for_commit = mocker.patch(
+            "tasks.notify.set_github_app_for_commit"
+        )
+        task = NotifyTask()
+        assert task._possibly_refresh_previous_selection(commit) == False
+        mock_set_gh_app_for_commit.assert_not_called()
+
+    def test_possibly_pin_commit_to_github_app_not_github_or_no_installation(
+        self, mocker, dbsession
+    ):
+        commit = CommitFactory(repository__owner__service="gitlab")
+        commit_from_gh = CommitFactory(repository__owner__service="github")
+        dbsession.add_all([commit, commit_from_gh])
+        dbsession.flush()
+        mock_refresh_selection = mocker.patch.object(
+            NotifyTask, "_possibly_refresh_previous_selection", return_value=None
+        )
+        torngit = MagicMock(data=TorngitInstanceData())
+        torngit_with_installation = MagicMock(
+            data=TorngitInstanceData(installation=GithubInstallationInfo(id=12))
+        )
+        task = NotifyTask()
+        assert (
+            task._possibly_pin_commit_to_github_app(commit, torngit_with_installation)
+            == None
+        )
+        mock_refresh_selection.assert_not_called()
+        assert task._possibly_pin_commit_to_github_app(commit_from_gh, torngit) == None
+        mock_refresh_selection.assert_called_with(commit_from_gh)
+
+    def test_possibly_pin_commit_to_github_app_new_selection(self, mocker, dbsession):
+        commit = CommitFactory(repository__owner__service="github")
+        dbsession.add(commit)
+        dbsession.flush()
+        mock_refresh_selection = mocker.patch.object(
+            NotifyTask, "_possibly_refresh_previous_selection", return_value=None
+        )
+        mock_set_gh_app_for_commit = mocker.patch(
+            "tasks.notify.set_github_app_for_commit"
+        )
+        torngit = MagicMock(
+            data=TorngitInstanceData(installation=GithubInstallationInfo(id=12))
+        )
+        task = NotifyTask()
+        assert task._possibly_pin_commit_to_github_app(commit, torngit) == 12
+        mock_refresh_selection.assert_called_with(commit)
+        mock_set_gh_app_for_commit.assert_called_with(12, commit)
+
 
 class TestNotifyTask(object):
     def test_simple_call_no_notifications(
@@ -435,13 +526,13 @@ class TestNotifyTask(object):
                 {
                     "notifier": "fake_hahaha",
                     "title": "the_title",
-                    "result": {
-                        "data_sent": {"all": ["The", 1, "data"]},
-                        "notification_successful": True,
-                        "notification_attempted": True,
-                        "data_received": None,
-                        "explanation": "",
-                    },
+                    "result": NotificationResult(
+                        data_sent={"all": ["The", 1, "data"]},
+                        notification_successful=True,
+                        notification_attempted=True,
+                        data_received=None,
+                        explanation="",
+                    ),
                 }
             ],
         }
@@ -803,13 +894,13 @@ class TestNotifyTask(object):
             {
                 "notifier": "good_name",
                 "title": "good_notifier",
-                "result": {
-                    "notification_attempted": True,
-                    "notification_successful": True,
-                    "explanation": "",
-                    "data_sent": {"some": "data"},
-                    "data_received": None,
-                },
+                "result": NotificationResult(
+                    notification_attempted=True,
+                    notification_successful=True,
+                    explanation="",
+                    data_sent={"some": "data"},
+                    data_received=None,
+                ),
             },
         ]
         res = task.submit_third_party_notifications(


### PR DESCRIPTION
extends NotificationResult to record the app that was used. After notifications go through we save them to `CommitNotification`, including the app. This is the "permanent pindown"
Previously this would only happen for pull requests, but not it _also_ saves a `CommitNotification` everytime we have a record of an app_id being used (for a successful notification)

The `Notify` task after selecting an app will possibly pindown the commit to that selected app, or refresh the permanent pindown in Redis (faster to access). Notice then, that if a notifier is to use a specific app this will certainly be in redis. Put there by the `NotifyTask`.

I've found some errors in the redis get/set though (through manual testing). It turns out that the return value is a binary string, not a "regular" string. Hence the changes to the "get" method.

Only notifiers that notify on a specific commit (status and checks) check for a specific app. The comment notifier might use any app. But that's OK because an app _can_ edit the comment of another app.

👀 This is PR 4/4 for pinning commits to apps