### PR TITLE
fix: improve adjusted base comparison

### DIFF
--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -221,7 +221,7 @@ class StatusProjectMixin(object):
         quantized_base_adjusted_coverage = base_adjusted_coverage.quantize(
             Decimal("0.00000")
         )
-        if quantized_base_adjusted_coverage <= head_coverage:
+        if abs(quantized_base_adjusted_coverage - head_coverage) < Decimal("0.01"):
             rounded_difference = round_number(
                 self.current_yaml, head_coverage - base_adjusted_coverage
             )


### PR DESCRIPTION
ticket: https://github.com/codecov/internal-issues/issues/204

Let me preface this by saying that the latest comment in the ticket doesn't seem an accurate complain
cause looking in the logs the adjusted base coverage is 91.30752 and the head covereage is 91.24169.

That being said, it's still possible that for a decent sized code base the change is less than what we
display as a "change" (that is, the change is smaller than 0.01), but it's still a change (might be 0.0001)
Realistically no one would care.

So this change protects us by having a little wiggle room. The check would only fail if the difference is
more than 0.01 (so the numbers in the comment would look different).

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.