### PR TITLE
fix mypy config for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
-- repo: local
-  hooks:
-  - id: lint
-    name: lint
-    description: "Lint and sort"
-    entry: make lint
-    pass_filenames: false
-    require_serial: true
-    language: system
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: 'v1.10.0'
-  hooks:
-  - id: mypy
-    verbose: true
-    entry: bash -c 'mypy "$@" || true' --
+  - repo: local
+    hooks:
+      - id: lint
+        name: lint
+        description: "Lint and sort"
+        entry: make lint
+        pass_filenames: false
+        require_serial: true
+        language: system
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v1.10.0"
+    hooks:
+      - id: mypy
+        verbose: true
+        entry: bash -c 'mypy "$@" --explicit-package-bases || true' --

--- a/services/bots/types.py
+++ b/services/bots/types.py
@@ -8,9 +8,9 @@ from database.models.core import Owner
 
 # A Token and its Owner
 # If a Token doesn't belong to Owner (i.e. it's a GitHubAppInstallation Token), second value is None
-type TokenWithOwner = Tuple[Token, Optional[Owner]]
+TokenWithOwner = Tuple[Token, Optional[Owner]]
 
-type TokenTypeMapping = Dict[TokenType, Token]
+TokenTypeMapping = Dict[TokenType, Token]
 
 
 class AdapterAuthInformation(TypedDict):


### PR DESCRIPTION
Fixes the mypy config in the pre-commit hook so it actually runs.
Apparently it doesn't like the "type" keyworkd, so removing that

ps.: fixing in CI depends on https://github.com/codecov/gha-workflows/pull/26
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.