### PR TITLE
feat: experiment on sync_pulls

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -12,3 +12,5 @@ USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = Feature(
 PARALLEL_UPLOAD_PROCESSING_BY_REPO = Feature("parallel_upload_processing")
 
 CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER = Feature("carryforward_base_search_range")
+
+SYNC_PULL_LOCK_TIMEOUT = Feature("sync_pull_lock_timeout")


### PR DESCRIPTION
This experiment aims at reducing the time we wait for a lock before giving up
in the snyc_pulls task.

For more info please see https://l.codecov.dev/DeIgE5

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.