### PR TITLE
chore: re-work public tokens (part I)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/5da20847d9c751f6bee5b69298690bcac114f108.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/bf76a731ff866c6c6e843e7a17c0f6bd16015f94.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz#egg=test-results-parser
 boto3>=1.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -368,7 +368,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/5da20847d9c751f6bee5b69298690bcac114f108.tar.gz
+shared @ https://github.com/codecov/shared/archive/bf76a731ff866c6c6e843e7a17c0f6bd16015f94.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/bots/helpers.py
+++ b/services/bots/helpers.py
@@ -22,7 +22,7 @@ def get_dedicated_app_token_from_config(
             service,
             app_id=app_id,
             installation_id=installation_id,
-            pem_path=f"yaml+file://{service}.dedicated_apps.{token_type.value}",
+            pem_path=f"yaml+file://{service}.dedicated_apps.{token_type.value}.pem",
         )
         return Token(key=actual_token, username=f"{token_type.value}_dedicated_app")
     return None

--- a/services/bots/helpers.py
+++ b/services/bots/helpers.py
@@ -1,0 +1,32 @@
+from shared.config import get_config
+from shared.torngit.base import TokenType
+from shared.typings.oauth_token_types import Token
+
+from services.github import get_github_integration_token
+
+
+def get_dedicated_app_token_from_config(
+    service: str, token_type: TokenType
+) -> Token | None:
+    # GitHub can have 'dedicated_apps', and those are preferred
+    dedicated_app = get_config(service, "dedicated_apps", token_type.value, default={})
+    app_id = dedicated_app.get("id")
+    installation_id = dedicated_app.get("installation_id")
+    pem_exists = "pem" in dedicated_app
+    if app_id and installation_id and pem_exists:
+        actual_token = get_github_integration_token(
+            service,
+            app_id=app_id,
+            installation_id=installation_id,
+            pem_path=f"yaml+file://{service}.dedicated_apps.{token_type.value}",
+        )
+        return Token(key=actual_token, username=f"{token_type.value}_dedicated_app")
+
+
+def get_token_type_from_config(service: str, token_type: TokenType) -> Token | None:
+    if service in ["github", "github_enterprise"]:
+        dedicated_app_config = get_dedicated_app_token_from_config(service, token_type)
+        if dedicated_app_config:
+            return dedicated_app_config
+
+    return get_config(service, "bots", token_type.value)

--- a/services/bots/public_bots.py
+++ b/services/bots/public_bots.py
@@ -62,7 +62,7 @@ def get_token_type_mapping(
 
     mapping = {
         TokenType.admin: admin_bot_token,
-        # [GitHub] Only legacy PATs can post statuses and comment to all public repos, so there can't be a dedicated_app for this
+        # [GitHub] Only legacy Personal Access Tokens (PAT) can post statuses and comment to all public repos, so there can't be a dedicated_app for this
         TokenType.comment: get_config(repo.service, "bots", "comment"),
         TokenType.status: admin_bot_token or get_config(repo.service, "bots", "status"),
     }

--- a/services/bots/tests/test_bots.py
+++ b/services/bots/tests/test_bots.py
@@ -418,6 +418,8 @@ class TestGettingAdapterAuthInformation(object):
                     TokenType.admin: repo_bot_token,
                     TokenType.status: repo_bot_token,
                     TokenType.tokenless: repo_bot_token,
+                    TokenType.pull: repo_bot_token,
+                    TokenType.commit: repo_bot_token,
                 },
             )
             assert get_adapter_auth_information(repo.owner, repo) == expected
@@ -615,6 +617,8 @@ class TestGettingAdapterAuthInformation(object):
                 TokenType.admin: None,
                 TokenType.status: Token(key="status_bot_token"),
                 TokenType.tokenless: Token(key="tokenless_bot_token"),
+                TokenType.pull: None,
+                TokenType.commit: None,
             },
         )
         assert get_adapter_auth_information(repo.owner, repo) == expected

--- a/services/bots/tests/test_helpers.py
+++ b/services/bots/tests/test_helpers.py
@@ -63,7 +63,7 @@ def test_get_dedicated_app_token_from_config(
         "github",
         app_id=dedicated_app_details["id"],
         installation_id=dedicated_app_details["installation_id"],
-        pem_path=f"yaml+file://github.dedicated_apps.{token_type.value}",
+        pem_path=f"yaml+file://github.dedicated_apps.{token_type.value}.pem",
     )
 
 

--- a/services/bots/tests/test_helpers.py
+++ b/services/bots/tests/test_helpers.py
@@ -1,0 +1,116 @@
+from unittest.mock import patch
+
+from shared.torngit.base import TokenType
+from shared.typings.oauth_token_types import Token
+
+from services.bots.helpers import (
+    get_dedicated_app_token_from_config,
+    get_token_type_from_config,
+)
+
+
+@patch("services.bots.helpers.get_github_integration_token")
+def test_get_dedicated_app_token_from_config(
+    mock_get_integration_token, mock_configuration
+):
+    mock_configuration.set_params(
+        {
+            "github": {
+                "dedicated_apps": {
+                    "read": {"id": 1234, "installation_id": 1000, "pem": "some_path"},
+                    "commit": {
+                        "id": 2345,
+                        "installation_id": 1000,
+                        "pem": "another_path",
+                    },
+                    "tokenless": {"id": 1111},  # not configured (missing pem)
+                },
+            }
+        }
+    )
+    mock_get_integration_token.return_value = "installation_access_token"
+    # TokenType.read has a dedicated app
+    assert get_dedicated_app_token_from_config("github", TokenType.read) == Token(
+        key="installation_access_token", username="read_dedicated_app"
+    )
+    mock_get_integration_token.assert_called_with(
+        "github",
+        app_id=1234,
+        installation_id=1000,
+        pem_path="yaml+file://github.dedicated_apps.read",
+    )
+    # TokenType.commit has a different dedicated app
+    assert get_dedicated_app_token_from_config("github", TokenType.commit) == Token(
+        key="installation_access_token", username="commit_dedicated_app"
+    )
+    mock_get_integration_token.assert_called_with(
+        "github",
+        app_id=2345,
+        installation_id=1000,
+        pem_path="yaml+file://github.dedicated_apps.commit",
+    )
+    # TokenType.pull has no dedicated app
+    assert get_dedicated_app_token_from_config("github", TokenType.pull) is None
+    assert mock_get_integration_token.call_count == 2  # no new calls
+    # TokenType.tokenless is not properly configured
+    assert get_dedicated_app_token_from_config("github", TokenType.tokenless) is None
+    assert mock_get_integration_token.call_count == 2  # no new calls
+
+
+@patch("services.bots.helpers.get_github_integration_token")
+def test_get_token_type_from_config(mock_get_integration_token, mock_configuration):
+    mock_configuration.set_params(
+        {
+            "github": {
+                "bots": {
+                    "tokenless": {"key": "bot_token", "username": "tokenless_bot"},
+                    "read": {"key": "bot_token", "username": "read_bot"},
+                },
+                "dedicated_apps": {
+                    "read": {"id": 1234, "installation_id": 1000, "pem": "some_path"},
+                    "commit": {
+                        "id": 2345,
+                        "installation_id": 1000,
+                        "pem": "another_path",
+                    },
+                    "tokenless": {"id": 1111},  # not configured (missing pem)
+                },
+            }
+        }
+    )
+    mock_get_integration_token.return_value = "installation_access_token"
+    # TokenType.read has a dedicated app AND bot.
+    # Dedicated app is preferred.
+    assert get_token_type_from_config("github", TokenType.read) == Token(
+        key="installation_access_token", username="read_dedicated_app"
+    )
+    # TokenType.pull has no dedicated app AND no bot
+    assert get_token_type_from_config("github", TokenType.pull) is None
+    # TokenType.tokenless is not properly configured BUT has dedicated bot
+    assert get_token_type_from_config("github", TokenType.tokenless) == Token(
+        key="bot_token", username="tokenless_bot"
+    )
+
+
+@patch("services.bots.helpers.get_github_integration_token")
+def test_get_token_type_from_config_not_github_skip_dedicated_apps(
+    mock_get_integration_token, mock_configuration
+):
+    mock_configuration.set_params(
+        {
+            "gitlab": {
+                "bots": {
+                    "read": {"key": "bot_token", "username": "read_bot"},
+                },
+            },
+            "github": {
+                "dedicated_apps": {
+                    "read": {"id": 1234, "pem": "some_path"},
+                },
+            },
+        }
+    )
+    assert get_token_type_from_config("gitlab", TokenType.read) == Token(
+        key="bot_token", username="read_bot"
+    )
+    mock_get_integration_token.assert_not_called()

--- a/services/bots/tests/test_helpers.py
+++ b/services/bots/tests/test_helpers.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import pytest
 from shared.torngit.base import TokenType
 from shared.typings.oauth_token_types import Token
 
@@ -9,107 +10,111 @@ from services.bots.helpers import (
 )
 
 
+@pytest.fixture
+def mock_configuration(mock_configuration):
+    custom_params = {
+        "gitlab": {
+            "bots": {
+                "read": {"key": "bot_token", "username": "read_bot"},
+            },
+        },
+        "github": {
+            "bots": {
+                "tokenless": {"key": "bot_token", "username": "tokenless_bot"},
+                "read": {"key": "bot_token", "username": "read_bot"},
+            },
+            "dedicated_apps": {
+                "read": {"id": 1234, "installation_id": 1000, "pem": "some_path"},
+                "commit": {
+                    "id": 2345,
+                    "installation_id": 1000,
+                    "pem": "another_path",
+                },
+                "tokenless": {"id": 1111},  # not configured (missing pem)
+            },
+        },
+    }
+    mock_configuration.set_params(custom_params)
+    return custom_params
+
+
+@pytest.mark.parametrize(
+    "token_type",
+    [
+        # Has a dedicated app that is configured
+        pytest.param(TokenType.read, id="TokenType.read-app_configured"),
+        # Has a _different_ dedicated app that is configured
+        pytest.param(TokenType.commit, id="TokenType.commit-app_configured"),
+    ],
+)
 @patch("services.bots.helpers.get_github_integration_token")
 def test_get_dedicated_app_token_from_config(
-    mock_get_integration_token, mock_configuration
+    mock_get_integration_token, token_type, mock_configuration
 ):
-    mock_configuration.set_params(
-        {
-            "github": {
-                "dedicated_apps": {
-                    "read": {"id": 1234, "installation_id": 1000, "pem": "some_path"},
-                    "commit": {
-                        "id": 2345,
-                        "installation_id": 1000,
-                        "pem": "another_path",
-                    },
-                    "tokenless": {"id": 1111},  # not configured (missing pem)
-                },
-            }
-        }
-    )
     mock_get_integration_token.return_value = "installation_access_token"
-    # TokenType.read has a dedicated app
-    assert get_dedicated_app_token_from_config("github", TokenType.read) == Token(
-        key="installation_access_token", username="read_dedicated_app"
+    dedicated_app_details = mock_configuration["github"]["dedicated_apps"][
+        token_type.value
+    ]
+
+    assert get_dedicated_app_token_from_config("github", token_type) == Token(
+        key="installation_access_token", username=f"{token_type.value}_dedicated_app"
     )
     mock_get_integration_token.assert_called_with(
         "github",
-        app_id=1234,
-        installation_id=1000,
-        pem_path="yaml+file://github.dedicated_apps.read",
+        app_id=dedicated_app_details["id"],
+        installation_id=dedicated_app_details["installation_id"],
+        pem_path=f"yaml+file://github.dedicated_apps.{token_type.value}",
     )
-    # TokenType.commit has a different dedicated app
-    assert get_dedicated_app_token_from_config("github", TokenType.commit) == Token(
-        key="installation_access_token", username="commit_dedicated_app"
-    )
-    mock_get_integration_token.assert_called_with(
-        "github",
-        app_id=2345,
-        installation_id=1000,
-        pem_path="yaml+file://github.dedicated_apps.commit",
-    )
-    # TokenType.pull has no dedicated app
-    assert get_dedicated_app_token_from_config("github", TokenType.pull) is None
-    assert mock_get_integration_token.call_count == 2  # no new calls
-    # TokenType.tokenless is not properly configured
-    assert get_dedicated_app_token_from_config("github", TokenType.tokenless) is None
-    assert mock_get_integration_token.call_count == 2  # no new calls
 
 
+@pytest.mark.parametrize(
+    "token_type",
+    [
+        # No configuration present
+        pytest.param(TokenType.pull, id="TokenType.pull-app_NOT_configured"),
+        # Some configuration exist, but it's not properly configured, so we can't use
+        pytest.param(
+            TokenType.tokenless,
+            id="TokenType.tokenless-app_NOT_properly_configured",
+        ),
+    ],
+)
 @patch("services.bots.helpers.get_github_integration_token")
-def test_get_token_type_from_config(mock_get_integration_token, mock_configuration):
-    mock_configuration.set_params(
-        {
-            "github": {
-                "bots": {
-                    "tokenless": {"key": "bot_token", "username": "tokenless_bot"},
-                    "read": {"key": "bot_token", "username": "read_bot"},
-                },
-                "dedicated_apps": {
-                    "read": {"id": 1234, "installation_id": 1000, "pem": "some_path"},
-                    "commit": {
-                        "id": 2345,
-                        "installation_id": 1000,
-                        "pem": "another_path",
-                    },
-                    "tokenless": {"id": 1111},  # not configured (missing pem)
-                },
-            }
-        }
-    )
+def test_get_dedicated_app_token_from_config_not_configured(
+    mock_get_integration_token, token_type, mock_configuration
+):
+    assert get_dedicated_app_token_from_config("github", token_type) is None
+    mock_get_integration_token.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "token_type, expected",
+    [
+        pytest.param(
+            TokenType.read,
+            Token(key="installation_access_token", username="read_dedicated_app"),
+            id="dedicated_app_AND_bot_configured",
+        ),
+        pytest.param(TokenType.pull, None, id="no_dedicated_app_no_bot"),
+        pytest.param(
+            TokenType.tokenless,
+            Token(key="bot_token", username="tokenless_bot"),
+            id="no_dedicated_app_yes_bot",
+        ),
+    ],
+)
+@patch("services.bots.helpers.get_github_integration_token")
+def test_get_token_type_from_config(
+    mock_get_integration_token, token_type, expected, mock_configuration
+):
     mock_get_integration_token.return_value = "installation_access_token"
-    # TokenType.read has a dedicated app AND bot.
-    # Dedicated app is preferred.
-    assert get_token_type_from_config("github", TokenType.read) == Token(
-        key="installation_access_token", username="read_dedicated_app"
-    )
-    # TokenType.pull has no dedicated app AND no bot
-    assert get_token_type_from_config("github", TokenType.pull) is None
-    # TokenType.tokenless is not properly configured BUT has dedicated bot
-    assert get_token_type_from_config("github", TokenType.tokenless) == Token(
-        key="bot_token", username="tokenless_bot"
-    )
+    assert get_token_type_from_config("github", token_type) == expected
 
 
 @patch("services.bots.helpers.get_github_integration_token")
 def test_get_token_type_from_config_not_github_skip_dedicated_apps(
     mock_get_integration_token, mock_configuration
 ):
-    mock_configuration.set_params(
-        {
-            "gitlab": {
-                "bots": {
-                    "read": {"key": "bot_token", "username": "read_bot"},
-                },
-            },
-            "github": {
-                "dedicated_apps": {
-                    "read": {"id": 1234, "pem": "some_path"},
-                },
-            },
-        }
-    )
     assert get_token_type_from_config("gitlab", TokenType.read) == Token(
         key="bot_token", username="read_bot"
     )

--- a/services/tests/test_bots.py
+++ b/services/tests/test_bots.py
@@ -539,6 +539,8 @@ class TestBotsService(BaseTestCase):
             TokenType.comment: None,
             TokenType.status: None,
             TokenType.tokenless: None,
+            TokenType.pull: None,
+            TokenType.commit: None,
         }
         assert expected_result == get_token_type_mapping(repo)
 
@@ -570,6 +572,8 @@ class TestBotsService(BaseTestCase):
             TokenType.read: None,
             TokenType.comment: None,
             TokenType.status: None,
+            TokenType.pull: None,
+            TokenType.commit: None,
             TokenType.tokenless: {"key": "sometokenlesskey"},
         }
         assert expected_result == get_token_type_mapping(repo)
@@ -586,6 +590,7 @@ class TestBotsService(BaseTestCase):
                         "status": {"key": "status", "username": "status"},
                         "comment": {"key": "nada"},
                         "tokenless": {"key": "tokenlessKey"},
+                        "pull": {"key": "pullbot"},
                     },
                 }
             }
@@ -608,6 +613,8 @@ class TestBotsService(BaseTestCase):
             TokenType.status: {"key": "status", "username": "status"},
             TokenType.comment: {"key": "nada"},
             TokenType.tokenless: {"key": "tokenlessKey"},
+            TokenType.pull: {"key": "pullbot"},
+            TokenType.commit: None,
         }
         assert expected_result == get_token_type_mapping(repo)
 
@@ -652,6 +659,8 @@ class TestBotsService(BaseTestCase):
             TokenType.comment: {"key": "bibu", "username": "cket"},
             TokenType.status: None,
             TokenType.tokenless: {"key": "tokenlessKey", "username": "aa"},
+            TokenType.pull: None,
+            TokenType.commit: None,
         }
         assert expected_result == get_token_type_mapping(repo)
 
@@ -704,4 +713,6 @@ class TestBotsService(BaseTestCase):
             TokenType.comment: None,
             TokenType.status: None,
             TokenType.tokenless: None,
+            TokenType.pull: None,
+            TokenType.commit: None,
         }


### PR DESCRIPTION
ticket: https://l.codecov.dev/QLcMzU

1st part of the move to having more dedicated-tokens for certain functionality in the app.
It also now allows dedicated-tokens to come from apps (for GitHub)

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.