### PR TITLE
attempt to fix cff duplicates

### DIFF
--- a/services/delete/delete.py
+++ b/services/delete/delete.py
@@ -1,0 +1,42 @@
+import logging
+from itertools import islice
+from typing import List
+
+import sentry_sdk
+
+from database.engine import Session
+from database.models import (
+    Commit,
+    Upload,
+    UploadError,
+    UploadLevelTotals,
+    uploadflagmembership,
+)
+
+log = logging.getLogger(__name__)
+
+
+@sentry_sdk.trace
+def delete_upload_by_ids(db_session: Session, upload_ids: List[int], commit: Commit):
+    db_session.query(UploadError).filter(UploadError.upload_id.in_(upload_ids)).delete(
+        synchronize_session=False
+    )
+    db_session.query(UploadLevelTotals).filter(
+        UploadLevelTotals.upload_id.in_(upload_ids)
+    ).delete(synchronize_session=False)
+    db_session.query(uploadflagmembership).filter(
+        uploadflagmembership.c.upload_id.in_(upload_ids)
+    ).delete(synchronize_session=False)
+    db_session.query(Upload).filter(Upload.id_.in_(upload_ids)).delete(
+        synchronize_session=False
+    )
+    db_session.commit()
+    log.info(
+        "Deleted uploads",
+        extra=dict(
+            commit=commit.commitid,
+            repo=commit.repoid,
+            number_uploads=len(upload_ids),
+            upload_ids=islice(upload_ids, 20),
+        ),
+    )


### PR DESCRIPTION
Change isn't too bad, length is mostly from tests, but it's important to understand the problem. More described here as well: https://github.com/codecov/internal-issues/issues/478. These are the changes in summary but the proper explanation is below:
- Added _possibly_delete_existing_cffs and _determine_cffs_and_depths_in_db fns. These find if there are suitable carryforwards sessions that should be deleted
- Exposed the parent_depth in `session_extras` for uploads
- Added a script to delete uploads + associated DB records
- Added a couple of tests for the above ^

---

We've been seeing some very inconsistent and strange behaviour where customers using carryforward flags (cffs) see a disproportionate growth of cffs over time. It doesn't happen every commit, nor there is a specific pattern to it, but it is confirmed. A little on carryforward uploads.

What are cffs? It's a feature we offer where customers can persist upload coverage across commits without having to explicitly upload on every commit - customers specify this in their codecov yaml. Behind the scenes, we look for a commit's **parent commit** and "copy paste" the relevant upload information into the current commit. 

The problem we're seeing is certain commits carry forward uploads from **two different parent commits**; this should never happen. (you'll see me here say upload and session interchangeably). How does this happen? See this example:

### Example 
Imagine you have a chain of commits, A -> B -> C, where C is the current commit, B is C's parent, and A is B's parent/C's grand-parent. In normal circumstances, if a customer has cffs on for say "unit" flag and they don't provide an upload with the "unit" flag in B and C, B would carry forward the upload from A, and C would carry forward the upload from B. 

While we have a `parent_commit` field for the `Commit` model, we have a [dedicated function](https://github.com/codecov/worker/blob/08d078553953aa8bb5f39b925692110a36885d7d/services/report/__init__.py#L648-L649) to know which parent a commit should carry forward to. This function will find the closest suitable parent commit (normally it's immediate parent) and carryforward reports from it. This function is needed because sometimes a commit's direct parent might not have a valid report or one at all, the commit might be in an error state, there might not be a direct parent at all, etc. I won't go too much in detail in the different states but you can read the function if you're curious, but I want to focus on the scenario where a parent_commit is processing, which is when it is in "pending" state. A parent commit that is processing isn't a suitable candidate to carryforward a report from, because for all we know it doesn't have a valid report or it can error or other causes, so we advance to its parent and use that as a candidate. In the example above, C would look at B, which is processing, so C would carryforward from A.  

This is so far expected and normal. The funky part occurs if you upload two or more times for commit C, one upload when B is processing, and one after B is successfully completed. In the the eyes of C, it would carryforward from A the first time and from B the second time, and if you consider A to have "N" uploads to carryforward and B to have "M" uploads to carry forward, then C would end up with "M + N" carryforward uploads - this is wrong, and C should only have "N" uploads. To take the example even further, if D eventually happens after C, and it carries the uploads from C, it would end up with "M + N" uploads, hence you see this "duplicate" effect every now and then.  -- end of example

Now, if you're thinking, why doesn't this happen all the time as many people upload more than once per commit, you're thinking in the right vein. That's because, for this weird bug to happen, you need to upload multiple times `very fast`, and those uploads need to be `very big`. A commit doesn't stay processing for very long, so the window two different uploads to occur when a commit is processing and when it's not is slim. It is not impossible, but it's very unlikely. On top of that, two different uploads won't run this logic because it needs to go through [this](https://github.com/codecov/worker/blob/08d078553953aa8bb5f39b925692110a36885d7d/services/report/__init__.py#L293-L294) first, which is true when there isn't a report object and false after that is populated (so technically, 2 different uploads should never get here cause the second run will evaluate false and keep going). And thirdly, upload tasks have a lock for a task + repo + commit combo, so two uploads for the same commit couldn't be racing for the same function.

So, how does this actually happen? It's because there are **two** tasks that could run into this functionality: the `upload` and `preprocessing` tasks. These two can theoretically call the logic that chooses the commit's parent for cffs, one that chooses A as the "parent" and the other one that chooses "B" as the parent. 

So if we piece everything together: if you run the preprocess + upload tasks `in quick succession` for a commit with `a lot` of uploads, there is a chance that they choose `different parents`. 

So what am I doing? (finally), I'm writing some logic at "upload insertion time" to determine if there are already cffs from an older parent, and delete those if they exist. In the example above parting from C, I would be deleting the cffs from A when I see cffs coming from B.

Hopefully you enjoyed the read! 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.