### PR TITLE
fix: rewrite reports in readable format

### DIFF
--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -506,7 +506,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 commit.repository, upload, is_error_case=True
             )
             self._rewrite_raw_report_readable(
-                processing_result={"raw_report": raw_report, "upload_object": upload},
+                processing_result={"raw_report": raw_report, "upload_obj": upload},
                 report_service=report_service,
                 commit=commit,
             )


### PR DESCRIPTION
ticket: https://github.com/codecov/engineering-team/issues/1112

Apparently it was a simple naming issue in that we were passing `upload_object` but expecting `upload_obj`.
There are Sentry issues indicating `'NoneType' object has no attribute 'storage_path'`
