### PR TITLE
refactor: Break up HeaderSectionWriter

### DIFF
--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -53,9 +53,11 @@ class MessageMixin(object):
 
         links = {
             "pull": get_pull_url(pull),
-            "base": get_commit_url(comparison.project_coverage_base.commit)
-            if comparison.project_coverage_base.commit is not None
-            else None,
+            "base": (
+                get_commit_url(comparison.project_coverage_base.commit)
+                if comparison.project_coverage_base.commit is not None
+                else None
+            ),
             "head": get_commit_url(comparison.head.commit),
         }
 

--- a/services/notification/notifiers/mixins/message/helpers.py
+++ b/services/notification/notifiers/mixins/message/helpers.py
@@ -10,6 +10,12 @@ from services.yaml.reader import get_minimum_precision, round_number
 zero_change_regex = re.compile("0.0+%?")
 
 
+def padded(message: str) -> str:
+    if message != "":
+        return "\n" + message
+    return message
+
+
 def make_metrics(before, after, relative, show_complexity, yaml, pull_url=None):
     coverage_good = None
     icon = " |"
@@ -48,18 +54,20 @@ def make_metrics(before, after, relative, show_complexity, yaml, pull_url=None):
             relative=format_number_to_str(
                 yaml, relative.coverage if relative else 0, style="{0}%", if_null="\xf8"
             ),
-            impact=format_number_to_str(
-                yaml,
-                coverage_change,
-                style="{0}%",
-                if_zero="\xf8",
-                if_null="\u2205",
-                plus=True,
-            )
-            if before
-            else "?"
-            if before is None
-            else "\xf8",
+            impact=(
+                format_number_to_str(
+                    yaml,
+                    coverage_change,
+                    style="{0}%",
+                    if_zero="\xf8",
+                    if_null="\u2205",
+                    plus=True,
+                )
+                if before
+                else "?"
+                if before is None
+                else "\xf8"
+            ),
         )
 
         if show_complexity:
@@ -108,9 +116,11 @@ def make_metrics(before, after, relative, show_complexity, yaml, pull_url=None):
             icon = (
                 " :arrow_up: |"
                 if coverage_good
-                else " :arrow_down: |"
-                if coverage_good is False and coverage_change != 0
-                else " |"
+                else (
+                    " :arrow_down: |"
+                    if coverage_good is False and coverage_change != 0
+                    else " |"
+                )
             )
 
     return "".join(("|", coverage, complexity, icon))


### PR DESCRIPTION
As time when by the HeaderSectionWriter is now home for many warnings and details to the users,
and more are on the way.

This SectionWriter has a huge entrypoint function and it's hard to figure out the ordering of the
different lines. Also with the ability to hide project coverage it had more than 1 return value,
however there are messages that need to be written in both branches.

The changes in this commit attemp to unify the 2 branches of the HeaderSectionWriter, and breaks it up
further into HeaderPieces, with a function (or 2 😅) per HeaderPiece.

The objective is to make it easier to figure out the order of lines in the header.
AND to make it easier to change specific HeaderPieces and add more HeaderPieces.

[edit] Why am I doing this, you ask? Because I need to add yet another message to this section: https://github.com/codecov/engineering-team/issues/1622
and I felt bad to add more to the mess... but maybe it would be better to not put the extra message in the Header section after all.
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.