### PR TITLE
Add message when upload count differs

### DIFF
--- a/services/comparison/__init__.py
+++ b/services/comparison/__init__.py
@@ -302,7 +302,7 @@ class ComparisonProxy(object):
         head_report = self.comparison.head.report
         ops = [(base_report, "base_count"), (head_report, "head_count")]
         for curr_report, curr_counter in ops:
-            for sid, session in curr_report.sessions.items():
+            for session in curr_report.sessions.values():
                 # We ignore carryforward sessions
                 # Because not all commits would upload all flags (potentially)
                 # But they are still carried forward

--- a/services/comparison/__init__.py
+++ b/services/comparison/__init__.py
@@ -302,14 +302,15 @@ class ComparisonProxy(object):
         head_report = self.comparison.head.report
         ops = [(base_report, "base_count"), (head_report, "head_count")]
         for curr_report, curr_counter in ops:
-            for session in curr_report.sessions:
+            for sid, session in curr_report.sessions.items():
                 # We ignore carryforward sessions
                 # Because not all commits would upload all flags (potentially)
                 # But they are still carried forward
                 if session.session_type != SessionType.carriedforward:
-                    if session.flags == []:
-                        session.flags = [""]
-                    for flag in session.flags:
+                    # It's possible that an upload is done without flags.
+                    # In this case we still want to count it in the count, but there's no flag associated to it
+                    session_flags = session.flags or [""]
+                    for flag in session_flags:
                         dict_value = per_flag_dict.get(flag)
                         if dict_value is None:
                             dict_value = ReportUploadedCount(

--- a/services/comparison/tests/unit/test_reports_uploaded_count_diff.py
+++ b/services/comparison/tests/unit/test_reports_uploaded_count_diff.py
@@ -12,24 +12,26 @@ from services.comparison.types import Comparison, FullCommit, ReportUploadedCoun
     "head_sessions, base_sessions, expected_count, expected_diff",
     [
         (
-            [
-                Session(
+            {
+                0: Session(
                     flags=["unit", "local"], session_type=SessionType.carriedforward
                 ),
-                Session(flags=["integration"], session_type=SessionType.uploaded),
-                Session(flags=["unit"], session_type=SessionType.uploaded),
-                Session(flags=["unit"], session_type=SessionType.uploaded),
-                Session(flags=["integration"], session_type=SessionType.uploaded),
-                Session(flags=[], session_type=SessionType.uploaded),
-            ],
-            [
-                Session(
+                1: Session(flags=["integration"], session_type=SessionType.uploaded),
+                2: Session(flags=["unit"], session_type=SessionType.uploaded),
+                3: Session(flags=["unit"], session_type=SessionType.uploaded),
+                4: Session(flags=["integration"], session_type=SessionType.uploaded),
+                5: Session(flags=[], session_type=SessionType.uploaded),
+            },
+            {
+                0: Session(
                     flags=["unit", "local"], session_type=SessionType.carriedforward
                 ),
-                Session(flags=["integration"], session_type=SessionType.carriedforward),
-                Session(flags=["unit"], session_type=SessionType.uploaded),
-                Session(flags=["unit"], session_type=SessionType.uploaded),
-            ],
+                1: Session(
+                    flags=["integration"], session_type=SessionType.carriedforward
+                ),
+                2: Session(flags=["unit"], session_type=SessionType.uploaded),
+                3: Session(flags=["unit"], session_type=SessionType.uploaded),
+            },
             [
                 ReportUploadedCount(flag="unit", base_count=2, head_count=2),
                 ReportUploadedCount(flag="integration", base_count=0, head_count=2),
@@ -38,23 +40,23 @@ from services.comparison.types import Comparison, FullCommit, ReportUploadedCoun
             [],
         ),
         (
-            [
-                Session(
+            {
+                0: Session(
                     flags=["unit", "local"], session_type=SessionType.carriedforward
                 ),
-                Session(flags=["integration"], session_type=SessionType.uploaded),
-                Session(flags=["unit"], session_type=SessionType.uploaded),
-                Session(flags=["unit"], session_type=SessionType.uploaded),
-                Session(flags=["integration"], session_type=SessionType.uploaded),
-                Session(flags=[""], session_type=SessionType.uploaded),
-            ],
-            [
-                Session(flags=["unit", "local"], session_type=SessionType.uploaded),
-                Session(flags=["integration"], session_type=SessionType.uploaded),
-                Session(flags=["unit"], session_type=SessionType.uploaded),
-                Session(flags=["unit"], session_type=SessionType.uploaded),
-                Session(flags=["obscure_flag"], session_type=SessionType.uploaded),
-            ],
+                1: Session(flags=["integration"], session_type=SessionType.uploaded),
+                2: Session(flags=["unit"], session_type=SessionType.uploaded),
+                3: Session(flags=["unit"], session_type=SessionType.uploaded),
+                4: Session(flags=["integration"], session_type=SessionType.uploaded),
+                5: Session(flags=[""], session_type=SessionType.uploaded),
+            },
+            {
+                0: Session(flags=["unit", "local"], session_type=SessionType.uploaded),
+                1: Session(flags=["integration"], session_type=SessionType.uploaded),
+                2: Session(flags=["unit"], session_type=SessionType.uploaded),
+                3: Session(flags=["unit"], session_type=SessionType.uploaded),
+                4: Session(flags=["obscure_flag"], session_type=SessionType.uploaded),
+            },
             [
                 ReportUploadedCount(flag="unit", base_count=3, head_count=2),
                 ReportUploadedCount(flag="local", base_count=1, head_count=0),
@@ -67,8 +69,21 @@ from services.comparison.types import Comparison, FullCommit, ReportUploadedCoun
                 ReportUploadedCount(flag="integration", base_count=1, head_count=2),
             ],
         ),
+        (
+            {0: Session(flags=[], session_type=SessionType.uploaded)},
+            {
+                0: Session(flags=[], session_type=SessionType.uploaded),
+                1: Session(flags=[], session_type=SessionType.uploaded),
+            },
+            [ReportUploadedCount(flag="", base_count=2, head_count=1)],
+            [ReportUploadedCount(flag="", base_count=2, head_count=1)],
+        ),
     ],
-    ids=["flag_counts_no_diff", "flag_count_yes_diff"],
+    ids=[
+        "flag_counts_no_diff",
+        "flag_count_yes_diff",
+        "diff_from_session_with_no_flags",
+    ],
 )
 def test_get_reports_uploaded_count_per_flag(
     head_sessions, base_sessions, expected_count, expected_diff

--- a/services/notification/notifiers/mixins/message/helpers.py
+++ b/services/notification/notifiers/mixins/message/helpers.py
@@ -3,11 +3,51 @@ from decimal import Decimal
 from typing import List, Sequence
 
 from shared.reports.resources import ReportTotals
+from shared.yaml.user_yaml import UserYaml
 
+from services.comparison import ComparisonProxy
 from services.comparison.changes import Change
+from services.yaml import read_yaml_field
 from services.yaml.reader import get_minimum_precision, round_number
 
 zero_change_regex = re.compile("0.0+%?")
+
+
+def has_project_status(yaml: UserYaml) -> bool:
+    project_status_details = read_yaml_field(
+        yaml, ("coverage", "status", "project"), False
+    )
+    if type(project_status_details) == bool:
+        return project_status_details
+    # If it's not a bool, it has to be a dict
+    if type(project_status_details) == dict:
+        if "enabled" in project_status_details:
+            return project_status_details["enabled"]
+        return True
+    # The config is not according to what we expect
+    # So it's an invalid status definition
+    return False
+
+
+def is_coverage_drop_significant(comparison: ComparisonProxy) -> bool:
+    head_coverage = (
+        comparison.head.report.totals.coverage if comparison.has_head_report() else None
+    )
+    base_coverage = (
+        comparison.project_coverage_base.report.totals.coverage
+        if comparison.has_project_coverage_base_report()
+        else None
+    )
+    if head_coverage is None or base_coverage is None:
+        # No change to be significant
+        return False
+    diff = Decimal(head_coverage) - Decimal(base_coverage)
+    change_is_positive = diff >= 0
+    # head_coverage is the percent of the project covered in HEAD
+    # base_coverage is the percent of the project covered in BASE
+    # So "change_is_significant" is checking if the diff between them is more than 5%
+    change_is_significant = abs(diff) >= Decimal(5)
+    return not change_is_positive and change_is_significant
 
 
 def make_metrics(before, after, relative, show_complexity, yaml, pull_url=None):
@@ -48,18 +88,20 @@ def make_metrics(before, after, relative, show_complexity, yaml, pull_url=None):
             relative=format_number_to_str(
                 yaml, relative.coverage if relative else 0, style="{0}%", if_null="\xf8"
             ),
-            impact=format_number_to_str(
-                yaml,
-                coverage_change,
-                style="{0}%",
-                if_zero="\xf8",
-                if_null="\u2205",
-                plus=True,
-            )
-            if before
-            else "?"
-            if before is None
-            else "\xf8",
+            impact=(
+                format_number_to_str(
+                    yaml,
+                    coverage_change,
+                    style="{0}%",
+                    if_zero="\xf8",
+                    if_null="\u2205",
+                    plus=True,
+                )
+                if before
+                else "?"
+                if before is None
+                else "\xf8"
+            ),
         )
 
         if show_complexity:
@@ -108,9 +150,11 @@ def make_metrics(before, after, relative, show_complexity, yaml, pull_url=None):
             icon = (
                 " :arrow_up: |"
                 if coverage_good
-                else " :arrow_down: |"
-                if coverage_good is False and coverage_change != 0
-                else " |"
+                else (
+                    " :arrow_down: |"
+                    if coverage_good is False and coverage_change != 0
+                    else " |"
+                )
             )
 
     return "".join(("|", coverage, complexity, icon))

--- a/services/notification/notifiers/mixins/message/tests/test_helpers.py
+++ b/services/notification/notifiers/mixins/message/tests/test_helpers.py
@@ -1,0 +1,77 @@
+import pytest
+from shared.reports.resources import Report, ReportTotals
+
+from services.comparison import ComparisonProxy
+from services.notification.notifiers.mixins.message.helpers import (
+    has_project_status,
+    is_coverage_drop_significant,
+)
+
+
+@pytest.mark.parametrize(
+    "yaml, expected",
+    [
+        pytest.param(
+            {"coverage": {"status": {"project": False}}},
+            False,
+            id="project_coverage_boolean_disabled",
+        ),
+        pytest.param(
+            {"coverage": {"status": {"project": True}}},
+            True,
+            id="project_coverage_boolean_enabled",
+        ),
+        pytest.param(
+            {"coverage": {"status": {"project": {"enabled": True}}}},
+            True,
+            id="project_coverage_dict_enabled",
+        ),
+        pytest.param(
+            {"coverage": {"status": {"project": {"enabled": False}}}},
+            False,
+            id="project_coverage_dict_disabled",
+        ),
+        pytest.param(
+            {
+                "coverage": {
+                    "status": {"project": {"only_pulls": True, "informational": True}}
+                }
+            },
+            True,
+            id="project_coverage_dict_no_explicit_enabled_value",
+        ),
+        pytest.param(
+            {"coverage": {"status": {"project": "enabled"}}},
+            False,
+            id="project_coverage_invalid_value",
+        ),
+    ],
+)
+def test_has_project_status(yaml: dict, expected: bool):
+    assert has_project_status(yaml) == expected
+
+
+@pytest.mark.parametrize(
+    "head_coverage, base_coverage, expected",
+    [
+        pytest.param(None, None, False, id="no_head_no_base_not_significant_drop"),
+        pytest.param(85.0, None, False, id="no_base_not_significant_drop"),
+        pytest.param(None, 85.0, False, id="no_head_not_significant_drop"),
+        pytest.param(85.0, 85.0, False, id="no_change"),
+        pytest.param(91.0, 85.0, False, id="change_is_significant_but_positive"),
+        pytest.param(86.0, 85.0, False, id="change_not_significant"),
+        pytest.param(80.0, 85.0, True, id="change_is_significant"),
+    ],
+)
+def test_is_coverage_drop_significant(
+    head_coverage: float, base_coverage: float, expected, mocker
+):
+    head_report = Report()
+    head_report._totals = ReportTotals(coverage=head_coverage)
+    base_report = Report()
+    base_report._totals = ReportTotals(coverage=base_coverage)
+    mock_head = mocker.MagicMock(report=head_report)
+    mock_base = mocker.MagicMock(report=base_report)
+    mock_comparison = mocker.MagicMock(head=mock_head, project_coverage_base=mock_base)
+    fake_comparison = ComparisonProxy(comparison=mock_comparison)
+    assert is_coverage_drop_significant(fake_comparison) == expected

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -1191,7 +1191,6 @@ class TestNotifyTask(object):
                                 "Flags with carried forward coverage won't be shown. [Click here](https://docs.codecov.io/docs/carryforward-flags#carryforward-flags-in-the-pull-request-comment) to find out more."
                                 "",
                                 "",
-                                "",
                                 "------",
                                 "",
                                 "[Continue to review full report in Codecov by Sentry](https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/pull/9?dropdown=coverage&src=pr&el=continue).",


### PR DESCRIPTION
These changes include 2 related things:

* refactor: create MessagesToUserSectionWriter
    
Moving the "install github app" message to a dedicated section writer.
I'm doing this because I want to use this new section writer to add the
"number of uploads in your commit differs from base" message afterwards

* feat: add warning if number of uploads differ
    
Introduces a message when the number of uploads differ and there is a significant coverage drop.
The idea is that we can inform users that possibly some upload is missing, and that is the cause of the coverage drop.
    
I had to re-work part of the logic that counts the upload diff because the sessions in a report is a `dict` object, not a `list`. Thankfully we have many tests :E