### PR TITLE
Have the same lock for upload + preprocess task

### DIFF
--- a/tasks/preprocess_upload.py
+++ b/tasks/preprocess_upload.py
@@ -50,7 +50,6 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
             extra=dict(repoid=repoid, commit=commitid, report_code=report_code),
         )
         lock_name = UPLOAD_LOCK_NAME(repoid, commitid)
-        # lock_name = f"preprocess_upload_lock_{repoid}_{commitid}_{report_code}"
         redis_connection = get_redis_connection()
         # This task only needs to run once per commit (per report_code)
         # To generate the report. So if one is already running we don't need another
@@ -65,8 +64,8 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
                 lock_name,
                 timeout=60 * 5,
                 # This is the timeout that this task will wait to wait for the lock. This should
-                # be non-zero as otherwise it waits indefinitely to get the lock, and ideally smaller than
-                # the blocking timeout for the upload task so this one goes first, although it can go second
+                # be non-zero as otherwise it waits indefinitely to get the lock. It's also smaller than
+                # the upload task's blocking timeout to guarantee an Upload tasks runs
                 blocking_timeout=3,
             ):
                 return self.process_impl_within_lock(

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -64,6 +64,8 @@ merged_pull = re.compile(r".*Merged in [^\s]+ \(pull request \#(\d+)\).*").match
 
 CHUNK_SIZE = 3
 
+# Making the upload lock name a constant so it can be shared between the preprocess and
+# the upload task, as they have overlapping logic that collides in some cases
 UPLOAD_LOCK_NAME = lambda repoid, commitid: f"upload_lock_{repoid}_{commitid}"
 
 

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -64,6 +64,8 @@ merged_pull = re.compile(r".*Merged in [^\s]+ \(pull request \#(\d+)\).*").match
 
 CHUNK_SIZE = 3
 
+UPLOAD_LOCK_NAME = lambda repoid, commitid: f"upload_lock_{repoid}_{commitid}"
+
 
 class UploadContext:
     """
@@ -91,7 +93,7 @@ class UploadContext:
             if lock_type == "upload_processing":
                 return UPLOAD_PROCESSING_LOCK_NAME(self.repoid, self.commitid)
             else:
-                return f"{lock_type}_lock_{self.repoid}_{self.commitid}"
+                return UPLOAD_LOCK_NAME(self.repoid, self.commitid)
         else:
             return f"{lock_type}_lock_{self.repoid}_{self.commitid}_{self.report_type.value}"
 


### PR DESCRIPTION
This is an alternative to the solution proposed in this ticket https://github.com/codecov/worker/pull/497 to attempt and correct the problem from the source rather than react to it. 

The idea is to share the same lock for both of these processes to prevent both starting without initializing and saving the report. 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.