### PR TITLE
dev: Add E, PLC, and PLE ruff rules

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -297,9 +297,9 @@ class Commit(CodecovBaseModel):
             db_session.query(CommitReport)
             .filter(
                 (CommitReport.commit_id == self.id_)
-                & (CommitReport.code == None)
+                & (CommitReport.code == None)  # noqa: E711
                 & (
-                    (CommitReport.report_type == None)
+                    (CommitReport.report_type == None)  # noqa: E711
                     | (CommitReport.report_type == ReportType.COVERAGE.value)
                 )
             )
@@ -316,7 +316,7 @@ class Commit(CodecovBaseModel):
                 db_session.query(CommitReport)
                 .filter(
                     (CommitReport.commit_id == self.id_)
-                    & (CommitReport.code == None)
+                    & (CommitReport.code == None)  # noqa: E711
                     & (CommitReport.report_type == report_type.value)
                 )
                 .first()
@@ -483,7 +483,7 @@ class Pull(CodecovBaseModel):
             self.repository.pulls.with_entities(
                 Pull.id_, Pull.commentid, Pull.bundle_analysis_commentid
             )
-            .filter(Pull.commentid != None)
+            .filter(Pull.commentid != None)  # noqa: E711
             .order_by(Pull.id_)
             .first()
         )

--- a/database/tests/unit/test_model_utils.py
+++ b/database/tests/unit/test_model_utils.py
@@ -71,7 +71,7 @@ class TestArchiveField(object):
         commit = CommitFactory()
         test_class = self.ClassWithArchiveField(commit, None, "gcs_path")
 
-        assert test_class._archive_field == None
+        assert test_class._archive_field is None
         assert test_class._archive_field_storage_path == "gcs_path"
         assert test_class.archive_field == some_json
         mock_read_file.assert_called_with("gcs_path")
@@ -93,9 +93,9 @@ class TestArchiveField(object):
         commit = CommitFactory()
         test_class = self.ClassWithArchiveField(commit, None, "gcs_path")
 
-        assert test_class._archive_field == None
+        assert test_class._archive_field is None
         assert test_class._archive_field_storage_path == "gcs_path"
-        assert test_class.archive_field == None
+        assert test_class.archive_field is None
         mock_read_file.assert_called_with("gcs_path")
         mock_archive_service.assert_called_with(repository=commit.repository)
 
@@ -122,7 +122,7 @@ class TestArchiveField(object):
         mock_archive_service.return_value.write_json_data_to_storage = mock_write_file
 
         assert test_class._archive_field == "db_value"
-        assert test_class._archive_field_storage_path == None
+        assert test_class._archive_field_storage_path is None
         assert test_class.archive_field == "db_value"
         assert mock_read_file.call_count == 0
 
@@ -132,7 +132,7 @@ class TestArchiveField(object):
 
         # Now we write to the property
         test_class.archive_field = some_json
-        assert test_class._archive_field == None
+        assert test_class._archive_field is None
         assert test_class._archive_field_storage_path == "path/to/written/object"
         assert test_class.archive_field == some_json
         # Cache is updated on write

--- a/helpers/checkpoint_logger/__init__.py
+++ b/helpers/checkpoint_logger/__init__.py
@@ -245,7 +245,9 @@ def subflows(*args: tuple[str, str, str]) -> TClassDecorator:
             # We get our subflows in the form: [(metric, begin, end)]
             # We want them in the form: {end: [(metric, begin)]}
             # The first step of munging is to group by end
-            key_on_end = lambda x: x[2]
+            def key_on_end(x):
+                return x[2]
+
             sorted_by_end = sorted(args, key=key_on_end)
             grouped_by_end = itertools.groupby(args, key=key_on_end)
 

--- a/helpers/tests/pathmap/test_tree.py
+++ b/helpers/tests/pathmap/test_tree.py
@@ -41,7 +41,7 @@ class TestTree(object):
 
         branch = self.tree.instance.get("list.rs")
         results = []
-        assert self.tree._drill(branch, results) == None
+        assert self.tree._drill(branch, results) is None
 
     def test_recursive_lookup(self):
         path = "one/two/three.py"

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,9 +36,10 @@ indent-width = 4
 target-version = "py312"
 
 [lint]
-# Currently only enabled for most F (Pyflakes) and I (isort) rules: https://docs.astral.sh/ruff/rules/
-select = ["F", "I"]
-ignore = ["F841", "F405", "F403"]
+# Currently only enabled for most F (Pyflakes), Pycodestyle (Error), 
+# PyLint (Convention, Error), and I (isort) rules: https://docs.astral.sh/ruff/rules/
+select = ["F", "E", "I", "PLC", "PLE"]
+ignore = ["F841", "F405", "F403", "E501", "E712"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 # The preferred method (for now) w.r.t. fixable rules is to manually update the makefile

--- a/services/commit_status.py
+++ b/services/commit_status.py
@@ -9,7 +9,7 @@ def _ci_providers() -> List[str]:
     providers = get_config("services", "ci_providers")
     if not providers:
         return []
-    elif type(providers) is list:
+    elif isinstance(providers, list):
         return providers
     else:
         return map(lambda p: p.strip(), providers.split(","))

--- a/services/github.py
+++ b/services/github.py
@@ -29,7 +29,10 @@ def get_github_integration_token(
         raise RepositoryWithoutValidBotError()
 
 
-COMMIT_GHAPP_KEY_NAME = lambda commit_id: f"app_to_use_for_commit_{commit_id}"
+def COMMIT_GHAPP_KEY_NAME(commit_id):
+    return f"app_to_use_for_commit_{commit_id}"
+
+
 GHAPP_KEY_EXPIRY_SECONDS = 60 * 60 * 2  # 2h
 
 

--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -241,7 +241,9 @@ class MessageMixin(object):
         write("")
 
     def get_middle_layout_section_names(self, settings):
-        sections = map(lambda l: l.strip(), (settings["layout"] or "").split(","))
+        sections = map(
+            lambda layout: layout.strip(), (settings["layout"] or "").split(",")
+        )
         return [
             section
             for section in sections
@@ -258,7 +260,9 @@ class MessageMixin(object):
         ]
 
     def get_upper_section_names(self, settings):
-        sections = list(map(lambda l: l.strip(), (settings["layout"] or "").split(",")))
+        sections = list(
+            map(lambda layout: layout.strip(), (settings["layout"] or "").split(","))
+        )
         headers = ["newheader", "header", "condensed_header"]
         if all(x not in sections for x in headers):
             sections.insert(0, "condensed_header")

--- a/services/notification/notifiers/mixins/message/helpers.py
+++ b/services/notification/notifiers/mixins/message/helpers.py
@@ -24,9 +24,9 @@ def make_metrics(before, after, relative, show_complexity, yaml, pull_url=None):
         complexity = " |" if show_complexity else ""
 
     else:
-        if type(before) is list:
+        if isinstance(before, list):
             before = ReportTotals(*before)
-        if type(after) is list:
+        if isinstance(after, list):
             after = ReportTotals(*after)
 
         layout = " `{absolute} <{relative}> ({impact})` |"

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -297,7 +297,7 @@ class TestChecksWithFallback(object):
         assert fallback_notifier.title == "title"
         assert fallback_notifier.is_enabled() == True
         assert fallback_notifier.notification_type.value == "checks_patch"
-        assert fallback_notifier.decoration_type == None
+        assert fallback_notifier.decoration_type is None
 
         res = await fallback_notifier.notify(sample_comparison)
         fallback_notifier.store_results(sample_comparison, res)
@@ -306,7 +306,7 @@ class TestChecksWithFallback(object):
         assert fallback_notifier.title == "title"
         assert fallback_notifier.is_enabled() == True
         assert fallback_notifier.notification_type.value == "checks_patch"
-        assert fallback_notifier.decoration_type == None
+        assert fallback_notifier.decoration_type is None
         assert res == "success"
 
     @pytest.mark.asyncio
@@ -341,7 +341,7 @@ class TestChecksWithFallback(object):
         assert fallback_notifier.title == "title"
         assert fallback_notifier.is_enabled() == True
         assert fallback_notifier.notification_type.value == "checks_patch"
-        assert fallback_notifier.decoration_type == None
+        assert fallback_notifier.decoration_type is None
 
         res = await fallback_notifier.notify(sample_comparison)
         assert res.notification_successful == False

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -718,7 +718,7 @@ class TestBaseStatusNotifier(object):
             notifier.determine_status_check_behavior_to_apply(
                 comparison, "flag_coverage_not_uploaded_behavior"
             )
-            == None
+            is None
         )
 
     def test_flag_coverage_was_uploaded_when_none_uploaded(

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -237,7 +237,7 @@ class ReportService(BaseReportService):
             db_session.query(CommitReport)
             .filter_by(commit_id=commit.id_, code=report_code)
             .filter(
-                (CommitReport.report_type == None)
+                (CommitReport.report_type == None)  # noqa: E711
                 | (CommitReport.report_type == ReportType.COVERAGE.value)
             )
             .first()

--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -125,7 +125,7 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                         ("parsers", "cobertura", "handle_missing_conditions"),
                         False,
                     ):
-                        if type(coverage) is str:
+                        if isinstance(coverage, str):
                             covered_conditions, total_conditions = coverage.split("/")
                             if len(conditions) < int(total_conditions):
                                 # <line number="23" hits="0" branch="true" condition-coverage="0% (0/2)">
@@ -150,7 +150,7 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                                 )
                     else:  # previous behaviour
                         if (
-                            type(coverage) is str
+                            isinstance(coverage, str)
                             and coverage[0] == "0"
                             and len(conditions) < int(coverage.split("/")[1])
                         ):
@@ -168,7 +168,7 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                     if conditions:
                         missing_branches = conditions
                 if (
-                    type(coverage) is str
+                    isinstance(coverage, str)
                     and not coverage[0] == "0"
                     and read_yaml_field(
                         repo_yaml,

--- a/services/report/languages/node.py
+++ b/services/report/languages/node.py
@@ -72,7 +72,7 @@ def get_location(node):
 
 
 def must_be_dict(value):
-    if type(value) is not dict:
+    if not isinstance(value, dict):
         return {}
     else:
         return value

--- a/services/report/languages/pycoverage.py
+++ b/services/report/languages/pycoverage.py
@@ -23,7 +23,7 @@ class PyCoverageProcessor(BaseLanguageProcessor):
         )
 
     def _normalize_label(self, testname) -> str:
-        if type(testname) == int or type(testname) == float:
+        if isinstance(testname, int) or isinstance(testname, float):
             # This is from a compressed report.
             # Pull label from the labels_table
             # But the labels_table keys are strings, because of JSON format

--- a/services/report/languages/tests/unit/test_go.py
+++ b/services/report/languages/tests/unit/test_go.py
@@ -624,7 +624,7 @@ class TestGo(BaseTestCase):
             [2, 24, 1],
             [24, None, 0],
         ]
-        assert go.combine_partials([(2, 2, 1), (2, 2, 0)]) == None
+        assert go.combine_partials([(2, 2, 1), (2, 2, 0)]) is None
         assert go.combine_partials([(0, None, 28), (0, None, 0)]) == [[0, None, 28]]
         assert go.combine_partials([(2, 35, 1), (35, None, 1)]) == [[2, None, 1]]
         assert go.combine_partials([(2, 35, "1/2"), (35, None, "1/2")]) == [

--- a/services/report/languages/tests/unit/test_xcode.py
+++ b/services/report/languages/tests/unit/test_xcode.py
@@ -16,7 +16,7 @@ txt = b"""/source:
     |   1|line
   1k|   2|line
          warning: The file '/Users/Jack/Documents/Coupgon/sdk-ios/Source/CPGCoupgonsViewController.swift' isn't covered.
-  \033[0;36m/file:\033[0m
+  \033\x1b[0;36m/file:\033[0m
   1m|   3|line
    1|   4|   }
 

--- a/services/report/languages/tests/unit/test_xcode2.py
+++ b/services/report/languages/tests/unit/test_xcode2.py
@@ -16,7 +16,7 @@ txt = b"""/source:
     1|   |line
     2|   1k|line
            warning: The file '/Users/Jack/Documents/Coupgon/sdk-ios/Source/CPGCoupgonsViewController.swift' isn't covered.
-    \033[0;36m/file:\033[0m
+    \033\x1b[0;36m/file:\033[0m
     3|   1m|line
     4|   1|   }
 

--- a/services/report/languages/v1.py
+++ b/services/report/languages/v1.py
@@ -32,7 +32,7 @@ def _list_to_dict(lines):
     in:  [None, 1] || {"1": 1}
     out: {"1": 1}
     """
-    if type(lines) is list:
+    if isinstance(lines, list):
         if len(lines) > 1:
             return dict(
                 [
@@ -53,7 +53,7 @@ def _list_to_dict(lines):
 
 
 def from_json(json, report_builder_session: ReportBuilderSession) -> Report:
-    if type(json["coverage"]) is dict:
+    if isinstance(json["coverage"], dict):
         # messages = json.get('messages', {})
         for fn, lns in json["coverage"].items():
             fn = report_builder_session.path_fixer(fn)

--- a/services/report/languages/xcode.py
+++ b/services/report/languages/xcode.py
@@ -15,7 +15,7 @@ from services.report.report_builder import (
 
 START_PARTIAL = "\033[0;41m"
 END_PARTIAL = "\033[0m"
-NAME_COLOR = "\033[0;36m"
+NAME_COLOR = "\033\x1b[0;36m"
 
 
 class XCodeProcessor(BaseLanguageProcessor):

--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -26,10 +26,12 @@ GLOBAL_LEVEL_LABEL = (
     SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label
 )
 
+
 # This is a lambda function to return different objects
-DEFAULT_LABEL_INDEX = lambda: {
-    SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_index: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label
-}
+def DEFAULT_LABEL_INDEX():
+    return {
+        SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_index: SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label
+    }
 
 
 def invert_pattern(string: str) -> str:
@@ -240,7 +242,7 @@ def make_sure_orginal_report_is_using_label_ids(original_report: Report) -> bool
         ] = SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label
 
     def possibly_translate_label(label_or_id: typing.Union[str, int]) -> int:
-        if type(label_or_id) == int:
+        if isinstance(label_or_id, int):
             return label_or_id
         if label_or_id in reverse_index_cache:
             return reverse_index_cache[label_or_id]

--- a/services/tests/test_github.py
+++ b/services/tests/test_github.py
@@ -75,9 +75,9 @@ class TestGetSetGithubAppsToCommits(object):
         mock_redis.get.side_effect = lambda key: redis_keys.get(key)
         assert get_github_app_for_commit(fake_commit_12) == "1200"
         assert get_github_app_for_commit(fake_commit_10) == "1000"
-        assert get_github_app_for_commit(fake_commit_50) == None
+        assert get_github_app_for_commit(fake_commit_50) is None
         # This feature is Github-exclusive, so we skip checking for commits that are in repos of other providers
-        assert get_github_app_for_commit(fake_commit_gitlab) == None
+        assert get_github_app_for_commit(fake_commit_gitlab) is None
 
     def test_get_app_for_commit_error(self, mock_redis):
         repo_github = RepositoryFactory(owner__service="github")
@@ -85,7 +85,7 @@ class TestGetSetGithubAppsToCommits(object):
         fake_commit_12 = MagicMock(
             name="fake_commit", **{"id": 12, "repository": repo_github}
         )
-        assert get_github_app_for_commit(fake_commit_12) == None
+        assert get_github_app_for_commit(fake_commit_12) is None
         mock_redis.get.assert_called_with("app_to_use_for_commit_12")
 
     @pytest.mark.integration

--- a/services/tests/test_timeseries.py
+++ b/services/tests/test_timeseries.py
@@ -552,7 +552,7 @@ class TestTimeseriesService(object):
             )
             .one_or_none()
         )
-        assert path_not_found_measurements == None
+        assert path_not_found_measurements is None
 
         empty_path_measurements = (
             dbsession.query(Measurement)
@@ -564,7 +564,7 @@ class TestTimeseriesService(object):
             )
             .one_or_none()
         )
-        assert empty_path_measurements == None
+        assert empty_path_measurements is None
 
     def test_commit_measurement_update_component(
         self, dbsession, sample_report_for_components, repository, mocker

--- a/tasks/backfill_commit_data_to_storage.py
+++ b/tasks/backfill_commit_data_to_storage.py
@@ -82,7 +82,7 @@ class BackfillCommitDataToStorageTask(
             db_session.query(CommitReport)
             .filter_by(commit_id=commit.id_)
             .filter(
-                (CommitReport.report_type == None)
+                (CommitReport.report_type == None)  # noqa: E711
                 | (CommitReport.report_type == ReportType.COVERAGE.value)
             )
             .all()

--- a/tasks/backfill_existing_gh_app_installations.py
+++ b/tasks/backfill_existing_gh_app_installations.py
@@ -116,7 +116,7 @@ class BackfillExistingIndividualGHAppInstallationTask(
                 extra=dict(ownerid=ownerid, parent_id=self.request.parent_id),
             )
             return {"successful": True, "reason": "backfill task finished"}
-        except:
+        except Exception:
             log.info(
                 "Backfill unsuccessful for this owner",
                 extra=dict(ownerid=ownerid, parent_id=self.request.parent_id),

--- a/tasks/backfill_owners_without_gh_app_installations.py
+++ b/tasks/backfill_owners_without_gh_app_installations.py
@@ -40,7 +40,7 @@ class BackfillOwnersWithoutGHAppInstallations(
                 Owner.ownerid == GithubAppInstallation.ownerid,
             )
             .filter(
-                GithubAppInstallation.ownerid == None,
+                GithubAppInstallation.ownerid == None,  # noqa: E711
                 Owner.integration_id.isnot(None),
                 Owner.service == "github",
             )
@@ -90,7 +90,7 @@ class BackfillOwnersWithoutGHAppInstallations(
                         gh_app_installation=gh_app_installation,
                     )
                 log.info("Successful backfill", extra=dict(ownerid=ownerid))
-            except:
+            except Exception:
                 log.info(
                     "Backfill unsuccessful for this owner", extra=dict(ownerid=ownerid)
                 )
@@ -115,7 +115,7 @@ class BackfillOwnersWithoutGHAppInstallations(
                 Owner.ownerid == GithubAppInstallation.ownerid,
             )
             .filter(
-                GithubAppInstallation.ownerid == None,
+                GithubAppInstallation.ownerid is None,
                 Owner.integration_id.isnot(None),
                 Owner.service == "github",
             )
@@ -200,7 +200,7 @@ class BackfillOwnersWithoutGHAppInstallationIndividual(
                 extra=dict(ownerid=ownerid, parent_id=self.request.parent_id),
             )
             return {"successful": True, "reason": "backfill task finished"}
-        except:
+        except Exception:
             log.info(
                 "Backfill unsuccessful for this owner",
                 extra=dict(ownerid=ownerid, parent_id=self.request.parent_id),

--- a/tasks/label_analysis.py
+++ b/tasks/label_analysis.py
@@ -142,9 +142,11 @@ class LabelAnalysisRequestProcessingTask(
                 )
                 if existing_labels.are_labels_encoded:
                     # Translate label_ids
-                    partial_fn_to_apply = lambda label_id_set: self._lookup_label_ids(
-                        report=base_report, label_ids=label_id_set
-                    )
+                    def partial_fn_to_apply(label_id_set):
+                        return self._lookup_label_ids(
+                            report=base_report, label_ids=label_id_set
+                        )
+
                     existing_labels = ExistingLabelSetsNotEncoded(
                         all_report_labels=partial_fn_to_apply(
                             existing_labels.all_report_labels
@@ -314,7 +316,7 @@ class LabelAnalysisRequestProcessingTask(
         if len(all_report_labels) > 0:
             # Check if report labels are encoded or not
             test_label = all_report_labels.pop()
-            are_labels_encoded = type(test_label) == int
+            are_labels_encoded = isinstance(test_label, int)
             all_report_labels.add(test_label)
         else:
             # There are no labels in the report

--- a/tasks/manual_trigger.py
+++ b/tasks/manual_trigger.py
@@ -91,7 +91,7 @@ class ManualTriggerTask(
             .filter(
                 CommitReport.code == report_code,
                 CommitReport.commit == commit,
-                (CommitReport.report_type == None)
+                (CommitReport.report_type == None)  # noqa: E711
                 | (CommitReport.report_type == ReportType.COVERAGE.value),
             )
         )

--- a/tasks/save_report_results.py
+++ b/tasks/save_report_results.py
@@ -150,7 +150,7 @@ class SaveReportResultsTask(
             db_session.query(CommitReport)
             .filter_by(commit_id=commit.id_, code=report_code)
             .filter(
-                (CommitReport.report_type == None)
+                (CommitReport.report_type == None)  # noqa: E711
                 | (CommitReport.report_type == ReportType.COVERAGE.value)
             )
             .first()

--- a/tasks/tests/integration/test_ghm_sync_plans.py
+++ b/tasks/tests/integration/test_ghm_sync_plans.py
@@ -218,7 +218,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         assert owner.plan_provider == "github"
         assert owner.plan == "users-basic"
         assert owner.plan_user_count == 1
-        assert owner.plan_activated_users == None
+        assert owner.plan_activated_users is None
 
         repos = (
             dbsession.query(Repository)

--- a/tasks/tests/unit/test_backfill_existing_gh_app_installations.py
+++ b/tasks/tests/unit/test_backfill_existing_gh_app_installations.py
@@ -65,7 +65,7 @@ class TestBackfillWithPreviousGHAppInstallation(object):
             .first()
         )
         assert gh_app_installation.owner == owner
-        assert gh_app_installation.repository_service_ids == None
+        assert gh_app_installation.repository_service_ids is None
 
     def test_gh_app_with_specific_owner_ids(
         self, mocker, mock_repo_provider, dbsession: Session
@@ -114,7 +114,7 @@ class TestBackfillWithPreviousGHAppInstallation(object):
             .first()
         )
         assert db_gh_app_installation_one.owner == owner
-        assert db_gh_app_installation_one.repository_service_ids == None
+        assert db_gh_app_installation_one.repository_service_ids is None
 
         # This one should have the same values as when it started
         db_gh_app_installation_two = (

--- a/tasks/tests/unit/test_compute_comparison.py
+++ b/tasks/tests/unit/test_compute_comparison.py
@@ -562,9 +562,9 @@ class TestComputeComparisonTask(object):
         )
         assert len(component_comparisons) == 2
         for comparison in component_comparisons:
-            assert comparison.patch_totals == None
+            assert comparison.patch_totals is None
 
         flag_comparisons = dbsession.query(CompareFlag).all()
         assert len(flag_comparisons) == 2
         for comparison in flag_comparisons:
-            assert comparison.patch_totals == None
+            assert comparison.patch_totals is None

--- a/tasks/tests/unit/test_ghm_sync_plans.py
+++ b/tasks/tests/unit/test_ghm_sync_plans.py
@@ -29,7 +29,7 @@ class TestGHMarketplaceSyncPlansTaskUnit(object):
         assert not ghm_service.get_user.called
         assert owner.plan == BillingPlan.users_basic.value
         assert owner.plan_user_count == 1
-        assert owner.plan_activated_users == None
+        assert owner.plan_activated_users is None
         # Owner was already created, we don't update this value
         assert owner.createstamp is None
 

--- a/tasks/tests/unit/test_label_analysis.py
+++ b/tasks/tests/unit/test_label_analysis.py
@@ -943,7 +943,7 @@ def test__get_parsed_git_diff_error(mock_parse_diff, dbsession, mock_repo_provid
     task.errors = []
     task.dbsession = dbsession
     parsed_diff = task._get_parsed_git_diff(larq)
-    assert parsed_diff == None
+    assert parsed_diff is None
     mock_parse_diff.assert_not_called()
     mock_repo_provider.get_compare.assert_called_with(
         larq.base_commit.commitid, larq.head_commit.commitid
@@ -996,6 +996,6 @@ def test__get_lines_relevant_to_diff_error(
     dbsession.flush()
     task = LabelAnalysisRequestProcessingTask()
     lines = task._get_lines_relevant_to_diff(larq)
-    assert lines == None
+    assert lines is None
     mock_parse_diff.assert_called_with(larq)
     mock_get_relevant_lines.assert_not_called()

--- a/tasks/tests/unit/test_label_analysis_encoded_labels.py
+++ b/tasks/tests/unit/test_label_analysis_encoded_labels.py
@@ -965,7 +965,7 @@ def test__get_parsed_git_diff_error(mock_parse_diff, dbsession, mock_repo_provid
     task.errors = []
     task.dbsession = dbsession
     parsed_diff = task._get_parsed_git_diff(larq)
-    assert parsed_diff == None
+    assert parsed_diff is None
     mock_parse_diff.assert_not_called()
     mock_repo_provider.get_compare.assert_called_with(
         larq.base_commit.commitid, larq.head_commit.commitid
@@ -1018,7 +1018,7 @@ def test__get_lines_relevant_to_diff_error(
     dbsession.flush()
     task = LabelAnalysisRequestProcessingTask()
     lines = task._get_lines_relevant_to_diff(larq)
-    assert lines == None
+    assert lines is None
     mock_parse_diff.assert_called_with(larq)
     mock_get_relevant_lines.assert_not_called()
 

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -307,10 +307,10 @@ class TestNotifyTaskHelpers(object):
         task = NotifyTask()
         assert (
             task._possibly_pin_commit_to_github_app(commit, torngit_with_installation)
-            == None
+            is None
         )
         mock_refresh_selection.assert_not_called()
-        assert task._possibly_pin_commit_to_github_app(commit_from_gh, torngit) == None
+        assert task._possibly_pin_commit_to_github_app(commit_from_gh, torngit) is None
         mock_refresh_selection.assert_called_with(commit_from_gh)
 
     def test_possibly_pin_commit_to_github_app_new_selection(self, mocker, dbsession):

--- a/tasks/tests/unit/test_sync_repo_languages.py
+++ b/tasks/tests/unit/test_sync_repo_languages.py
@@ -130,7 +130,7 @@ class TestSyncRepoLanguages(object):
 
         task = SyncRepoLanguagesTask()
         assert (
-            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
+            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) is None
         )
 
     def test_languages_no_intersection_and_synced_beyond_threshold(
@@ -164,7 +164,7 @@ class TestSyncRepoLanguages(object):
 
         task = SyncRepoLanguagesTask()
         assert (
-            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
+            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) is None
         )
 
     def test_languages_intersection_and_synced_beyond_threshold(
@@ -180,7 +180,7 @@ class TestSyncRepoLanguages(object):
 
         task = SyncRepoLanguagesTask()
         assert (
-            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
+            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) is None
         )
 
     def test_languages_intersection_and_synced_beyond_threshold_with_languages(
@@ -196,7 +196,7 @@ class TestSyncRepoLanguages(object):
 
         task = SyncRepoLanguagesTask()
         assert (
-            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == None
+            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) is None
         )
 
     def test_languages_intersection_and_synced_with_manual_trigger(

--- a/tasks/tests/unit/test_trial_expiration.py
+++ b/tasks/tests/unit/test_trial_expiration.py
@@ -14,9 +14,9 @@ class TestTrialExpiration(object):
         assert task.run_impl(dbsession, owner.ownerid) == {"successful": True}
 
         assert owner.plan == BillingPlan.users_basic.value
-        assert owner.plan_activated_users == None
+        assert owner.plan_activated_users is None
         assert owner.plan_user_count == 5
-        assert owner.stripe_subscription_id == None
+        assert owner.stripe_subscription_id is None
         assert owner.trial_status == TrialStatus.EXPIRED.value
 
     def test_trial_expiration_task_without_pretrial_users_count(
@@ -30,9 +30,9 @@ class TestTrialExpiration(object):
         assert task.run_impl(dbsession, owner.ownerid) == {"successful": True}
 
         assert owner.plan == BillingPlan.users_basic.value
-        assert owner.plan_activated_users == None
+        assert owner.plan_activated_users is None
         assert owner.plan_user_count == 1
-        assert owner.stripe_subscription_id == None
+        assert owner.stripe_subscription_id is None
         assert owner.trial_status == TrialStatus.EXPIRED.value
 
     def test_trial_expiration_task_with_trial_fired_by(self, dbsession, mocker):
@@ -45,5 +45,5 @@ class TestTrialExpiration(object):
 
         assert owner.plan == BillingPlan.users_basic.value
         assert owner.plan_activated_users == [9]
-        assert owner.stripe_subscription_id == None
+        assert owner.stripe_subscription_id is None
         assert owner.trial_status == TrialStatus.EXPIRED.value

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -46,9 +46,10 @@ FIRST_RETRY_DELAY = 20
     This is used by the Upload, Notify and UploadCleanLabelsIndex tasks as well to
     verify if an upload for the commit is currently being processed.
 """
-UPLOAD_PROCESSING_LOCK_NAME = (
-    lambda repoid, commitid: f"upload_processing_lock_{repoid}_{commitid}"
-)
+
+
+def UPLOAD_PROCESSING_LOCK_NAME(repoid, commitid):
+    return f"upload_processing_lock_{repoid}_{commitid}"
 
 
 class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):


### PR DESCRIPTION
### Purpose/Motivation

Part of the[ lint enhancement epic](https://github.com/codecov/engineering-team/issues/1716), this PR aims to add the Pycodestyle error rules, and the Pylint Convention and Pylint Error rules.
These can be found here:
- https://docs.astral.sh/ruff/rules/#error-e
- https://docs.astral.sh/ruff/rules/#error-e_1
- https://docs.astral.sh/ruff/rules/#convention-c

A majority of the fixes were related to E721 (isinstance comparisons), E722 (bare except), E713 (test for membership should be not in), and E711 (Comparison to None should be cond is None)

**NOTE:** I added ignores to all the SQL Alchemy code because it **BREAKS** when using is None vs. == None. This is because of how the "SQL" is parsed with == vs. the Python specific "is."

### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/1930

### What does this PR do?

This PR adds the rules listed above and fixes any errors that stemmed from them.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.