### PR TITLE
chore: update sync_pull experiment

### DIFF
--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -83,9 +83,10 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                     "sync_pull_task_run_count", tags={"wait": metrics_tag}
                 )
                 time_to_get_lock_seconds = time.monotonic() - start_wait
-                sentry_metrics.distribution(
-                    "sync_pull_task_time_to_get_lock_seconds",
-                    time_to_get_lock_seconds,
+                sentry_metrics.gauge(
+                    key="sync_pull_task_time_to_get_lock_seconds",
+                    value=time_to_get_lock_seconds,
+                    unit="seconds",
                     tags={"wait": metrics_tag},
                 )
                 return self.run_impl_within_lock(
@@ -100,6 +101,9 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
             log.info(
                 "Unable to acquire PullSync lock. Not retrying because pull is being synced already",
                 extra=dict(pullid=pullid, repoid=repoid),
+            )
+            sentry_metrics.incr(
+                "sync_pull_task_rejected_count", tags={"wait": metrics_tag}
             )
             return {
                 "notifier_called": False,


### PR DESCRIPTION
This changes the `sync_pull_task_time_to_get_lock_seconds` from "distribution" to "gauge".
Turns out distributions only let you aggregate by average, min and max. I want quantiles.

Also adds a new metric `sync_pull_task_rejected_count` to count how many tasks DONT run
per wait period. After all the goal if this experiment is to see if the reduced wait time
is effective in reducing the number of tasks that run

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.