### PR TITLE
bump shared (fix issue with migrations)

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/a6676d38943592827eb2576f02b81f0ff586ab70.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/e9389719d579d6ed7f8af34182865542127dacdb.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz#egg=test-results-parser
 boto3>=1.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -357,9 +357,7 @@ requests==2.32.3
 respx==0.20.2
     # via -r requirements.in
 rfc3986[idna2008]==1.4.0
-    # via
-    #   httpx
-    #   rfc3986
+    # via httpx
 rsa==4.7.2
     # via google-auth
 s3transfer==0.10.1
@@ -370,7 +368,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/a6676d38943592827eb2576f02b81f0ff586ab70.tar.gz
+shared @ https://github.com/codecov/shared/archive/e9389719d579d6ed7f8af34182865542127dacdb.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
<!-- Describe your PR here. -->
previous deploys were rolling back because they didn't have access to a settings variable - added it to shared so worker can access it that way