### PR TITLE
Enforce requests>=2.32

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -31,7 +31,7 @@ python-redis-lock
 PyYAML
 redis>=4.4.4
 regex
-requests>=2.31.0
+requests>=2.32.0
 respx
 sentry-sdk>=1.40.0
 SQLAlchemy-Utils


### PR DESCRIPTION
This is to fix vulnerability: https://github.com/advisories/GHSA-9wx4-h78v-vm56. Currently, we're already using requests>=2.32, so this is just to enforce it when we recompile.

Link to issue: https://github.com/codecov/internal-issues/issues/494

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.