### PR TITLE
Use the hash version of gha-workflows

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -11,6 +11,6 @@ on:
 jobs:
   patch-typing-check:
     name: Run Patch Type Check
-    uses: codecov/gha-workflows/.github/workflows/mypy.yml@v1.2.21
+    uses: codecov/gha-workflows/.github/workflows/mypy.yml@00043f8fbe820934312f7fade4ea72ea92231b5e
     with:
       extra_config: "--explicit-package-bases"


### PR DESCRIPTION
This is to pull the latest version of the mypy changes because it keeps giving me an error:

```
 Invalid workflow file: .github/workflows/mypy.yml#L16
The workflow is not valid. .github/workflows/mypy.yml (Line: 16, Col: 21): Invalid input, extra_config is not defined...
```

This should fix the issue.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.