### PR TITLE
feat: implement new require_changes for coverage comment

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/e9389719d579d6ed7f8af34182865542127dacdb.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/070433110f7d0ff437bf1ed34d6b552ec6a3031a.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz#egg=test-results-parser
 boto3>=1.34

--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/070433110f7d0ff437bf1ed34d6b552ec6a3031a.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/734a972f2d5087d9597fc9a2538e521e57ce2377.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz#egg=test-results-parser
 boto3>=1.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -368,7 +368,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/e9389719d579d6ed7f8af34182865542127dacdb.tar.gz
+shared @ https://github.com/codecov/shared/archive/070433110f7d0ff437bf1ed34d6b552ec6a3031a.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -368,7 +368,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/070433110f7d0ff437bf1ed34d6b552ec6a3031a.tar.gz
+shared @ https://github.com/codecov/shared/archive/734a972f2d5087d9597fc9a2538e521e57ce2377.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/notification/notifiers/comment/__init__.py
+++ b/services/notification/notifiers/comment/__init__.py
@@ -78,16 +78,6 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
     async def get_diff(self, comparison: Comparison):
         return await comparison.get_diff()
 
-    async def has_enough_changes(self, comparison):
-        diff = await comparison.get_diff()
-        changes = await comparison.get_changes()
-        if changes:
-            return True
-        res = comparison.head.report.calculate_diff(diff)
-        if res is not None and res["general"].lines > 0:
-            return True
-        return False
-
     async def notify(
         self, comparison: ComparisonProxy, **extra_data
     ) -> NotificationResult:

--- a/services/notification/notifiers/comment/conditions.py
+++ b/services/notification/notifiers/comment/conditions.py
@@ -148,7 +148,6 @@ class HasEnoughRequiredChanges(AsyncNotifyCondition):
             # We don't know if there was a coverage drop, because we can't compare BASE and HEAD (missing some info)
             # But we default to showing the comment. It might have info for the user about _what_ info we are missing
             return True
-        print(comparison.head.report.totals.coverage)
         head_coverage = Decimal(comparison.head.report.totals.coverage).quantize(
             Decimal("0.00000")
         )

--- a/services/notification/notifiers/comment/conditions.py
+++ b/services/notification/notifiers/comment/conditions.py
@@ -1,8 +1,13 @@
 import logging
 from abc import ABC, abstractmethod
+from decimal import Decimal
 
 from shared.torngit.exceptions import (
     TorngitClientError,
+)
+from shared.validation.types import (
+    CoverageCommentRequiredChanges,
+    CoverageCommentRequiredChangesORGroup,
 )
 
 from services.comparison import ComparisonProxy
@@ -10,6 +15,7 @@ from services.notification.notifiers.base import (
     AbstractBaseNotifier,
     NotificationResult,
 )
+from services.yaml import read_yaml_field
 
 log = logging.getLogger(__name__)
 
@@ -107,12 +113,113 @@ class HasEnoughBuilds(NotifyCondition):
 class HasEnoughRequiredChanges(AsyncNotifyCondition):
     failure_explanation = "changes_required"
 
+    async def _check_unexpected_changes(comparison: ComparisonProxy) -> bool:
+        """Returns a bool that indicates wether there are unexpected changes"""
+        changes = await comparison.get_changes()
+        if changes:
+            return True
+        return False
+
+    async def _check_coverage_change(comparison: ComparisonProxy) -> bool:
+        """Returns a bool that indicates wether there is any change in coverage"""
+        diff = await comparison.get_diff()
+        res = comparison.head.report.calculate_diff(diff)
+        if res is not None and res["general"].lines > 0:
+            return True
+        return False
+
+    async def _check_any_change(comparison: ComparisonProxy) -> bool:
+        unexpected_changes = await HasEnoughRequiredChanges._check_unexpected_changes(
+            comparison
+        )
+        coverage_changes = await HasEnoughRequiredChanges._check_coverage_change(
+            comparison
+        )
+        return unexpected_changes or coverage_changes
+
+    async def _check_coverage_drop(comparison: ComparisonProxy) -> bool:
+        no_head_coverage = comparison.head.report.totals.coverage is None
+        no_base_report = comparison.project_coverage_base.report is None
+        no_base_coverage = (
+            no_base_report
+            or comparison.project_coverage_base.report.totals.coverage is None
+        )
+        if no_head_coverage or no_base_coverage:
+            # We don't know if there was a coverage drop, because we can't compare BASE and HEAD (missing some info)
+            # But we default to showing the comment. It might have info for the user about _what_ info we are missing
+            return True
+        print(comparison.head.report.totals.coverage)
+        head_coverage = Decimal(comparison.head.report.totals.coverage).quantize(
+            Decimal("0.00000")
+        )
+        project_status_config = read_yaml_field(
+            comparison.comparison.current_yaml, ("coverage", "status", "project"), {}
+        )
+        threshold = Decimal(project_status_config.get("threshold", 0))
+        target_coverage = Decimal(
+            comparison.project_coverage_base.report.totals.coverage
+        ).quantize(Decimal("0.00000"))
+        diff = head_coverage - target_coverage
+        # Need to take the project threshold into consideration
+        return diff < 0 and abs(diff) >= (threshold + Decimal(0.01))
+
+    async def _check_uncovered_patch(comparison: ComparisonProxy):
+        diff = await comparison.get_diff(use_original_base=True)
+        totals = comparison.head.report.apply_diff(diff)
+        coverage_not_affected_by_patch = totals and totals.lines == 0
+        if totals is None or coverage_not_affected_by_patch:
+            # The patch doesn't affect coverage. So we don't show a comment.
+            # The patch is probably not related to testable files
+            return False
+        coverage = Decimal(totals.coverage).quantize(Decimal("0.00000"))
+        return abs(coverage - Decimal(100).quantize(Decimal("0.00000"))) >= Decimal(
+            0.01
+        )
+
+    async def check_condition_OR_group(
+        condition_group: CoverageCommentRequiredChangesORGroup,
+        comparison: ComparisonProxy,
+    ) -> bool:
+        if condition_group == CoverageCommentRequiredChanges.no_requirements.value:
+            return True
+        cache_results = {
+            individual_condition: None
+            for individual_condition in CoverageCommentRequiredChanges
+        }
+        functions_lookup = {
+            CoverageCommentRequiredChanges.any_change: HasEnoughRequiredChanges._check_any_change,
+            CoverageCommentRequiredChanges.coverage_drop: HasEnoughRequiredChanges._check_coverage_drop,
+            CoverageCommentRequiredChanges.uncovered_patch: HasEnoughRequiredChanges._check_uncovered_patch,
+        }
+        final_result = False
+        for individual_condition in CoverageCommentRequiredChanges:
+            if condition_group & individual_condition.value:
+                if cache_results[individual_condition] is None:
+                    function_to_call = functions_lookup[individual_condition]
+                    cache_results[individual_condition] = await function_to_call(
+                        comparison
+                    )
+                final_result |= cache_results[individual_condition]
+        return final_result
+
     async def check_condition(
         notifier: AbstractBaseNotifier, comparison: ComparisonProxy
     ) -> bool:
-        requires_changes = notifier.notifier_yaml_settings.get("require_changes", False)
-        return (requires_changes == False) or await notifier.has_enough_changes(
-            comparison
+        required_changes = notifier.notifier_yaml_settings.get(
+            "require_changes", [CoverageCommentRequiredChanges.no_requirements.value]
+        )
+        # backwards compatibility (can be removed after full rollout)
+        if isinstance(required_changes, bool):
+            # True --> 1 (any_change)
+            # False --> 0 (no_requirements)
+            required_changes = [int(required_changes)]
+        return all(
+            [
+                await HasEnoughRequiredChanges.check_condition_OR_group(
+                    or_group, comparison
+                )
+                for or_group in required_changes
+            ]
         )
 
     async def on_failure_side_effect(

--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -52,9 +52,11 @@ class MessageMixin(object):
 
         links = {
             "pull": get_pull_url(pull),
-            "base": get_commit_url(comparison.project_coverage_base.commit)
-            if comparison.project_coverage_base.commit is not None
-            else None,
+            "base": (
+                get_commit_url(comparison.project_coverage_base.commit)
+                if comparison.project_coverage_base.commit is not None
+                else None
+            ),
             "head": get_commit_url(comparison.head.commit),
         }
 

--- a/services/notification/notifiers/tests/unit/test_comment_conditions.py
+++ b/services/notification/notifiers/tests/unit/test_comment_conditions.py
@@ -1,0 +1,218 @@
+from typing import Dict, List
+
+import pytest
+from shared.validation.types import (
+    CoverageCommentRequiredChanges,
+    CoverageCommentRequiredChangesANDGroup,
+)
+
+from database.models.core import Repository
+from services.notification.notifiers.comment import CommentNotifier
+from services.notification.notifiers.comment.conditions import HasEnoughRequiredChanges
+
+
+def _get_notifier(
+    repository: Repository, required_changes: CoverageCommentRequiredChangesANDGroup
+):
+    return CommentNotifier(
+        repository=repository,
+        title="title",
+        notifier_yaml_settings={"require_changes": required_changes},
+        notifier_site_settings=True,
+        current_yaml={},
+    )
+
+
+def _get_mock_compare_result(file_affected: str, lines_affected: List[str]) -> Dict:
+    return {
+        "diff": {
+            "files": {
+                file_affected: {
+                    "type": "modified",
+                    "before": None,
+                    "segments": [
+                        {
+                            "header": lines_affected,
+                            "lines": [
+                                " Overview",
+                                " --------",
+                                " ",
+                                "-Main website: `Codecov <https://codecov.io/>`_.",
+                                "-Main website: `Codecov <https://codecov.io/>`_.",
+                                "+",
+                                "+website: `Codecov <https://codecov.io/>`_.",
+                                "+website: `Codecov <https://codecov.io/>`_.",
+                                " ",
+                                " .. code-block:: shell-session",
+                                " ",
+                            ],
+                        },
+                    ],
+                    "stats": {"added": 3, "removed": 3},
+                }
+            }
+        }
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "comparison_name, condition, expected",
+    [
+        pytest.param(
+            "sample_comparison",
+            [CoverageCommentRequiredChanges.any_change.value],
+            True,
+            id="any_change_comparison_with_changes",
+        ),
+        pytest.param(
+            "sample_comparison_without_base_report",
+            [CoverageCommentRequiredChanges.any_change.value],
+            False,
+            id="any_change_comparison_without_base",
+        ),
+        pytest.param(
+            "sample_comparison_no_change",
+            [CoverageCommentRequiredChanges.any_change.value],
+            False,
+            id="any_change_sample_comparison_no_change",
+        ),
+        pytest.param(
+            "sample_comparison",
+            [CoverageCommentRequiredChanges.coverage_drop.value],
+            False,
+            id="coverage_drop_comparison_with_positive_changes",
+        ),
+        pytest.param(
+            "sample_comparison_no_change",
+            [CoverageCommentRequiredChanges.coverage_drop.value],
+            False,
+            id="coverage_drop_sample_comparison_no_change",
+        ),
+        pytest.param(
+            "sample_comparison_without_base_report",
+            [CoverageCommentRequiredChanges.coverage_drop.value],
+            True,
+            id="coverage_drop_comparison_without_base",
+        ),
+    ],
+)
+async def test_condition_different_comparisons_no_diff(
+    comparison_name, condition, expected, mock_repo_provider, request
+):
+    comparison = request.getfixturevalue(comparison_name)
+    # There's no diff between HEAD and BASE so we can't calculate unexpected coverage.
+    # Any change then needs to be a coverage change
+    mock_repo_provider.get_compare.return_value = {"diff": {"files": {}, "commits": []}}
+    notifier = _get_notifier(comparison.head.commit.repository, condition)
+    assert (
+        await HasEnoughRequiredChanges.check_condition(notifier, comparison) == expected
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "condition, expected",
+    [
+        pytest.param(
+            [CoverageCommentRequiredChanges.any_change.value], False, id="any_change"
+        ),
+        pytest.param(
+            [CoverageCommentRequiredChanges.coverage_drop.value],
+            False,
+            id="coverage_drop",
+        ),
+        pytest.param(
+            [CoverageCommentRequiredChanges.uncovered_patch.value],
+            False,
+            id="uncovered_patch",
+        ),
+        pytest.param(
+            [CoverageCommentRequiredChanges.no_requirements.value],
+            True,
+            id="no_requirements",
+        ),
+    ],
+)
+async def test_condition_exact_same_report_coverage_not_affected_by_diff(
+    sample_comparison_no_change, mock_repo_provider, condition, expected
+):
+    mock_repo_provider.get_compare.return_value = _get_mock_compare_result(
+        "README.md", ["5", "8", "5", "9"]
+    )
+    notifier = _get_notifier(
+        sample_comparison_no_change.head.commit.repository, condition
+    )
+    assert (
+        await HasEnoughRequiredChanges.check_condition(
+            notifier, sample_comparison_no_change
+        )
+        == expected
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "condition, expected",
+    [
+        pytest.param(
+            [CoverageCommentRequiredChanges.any_change.value], True, id="any_change"
+        ),
+        pytest.param(
+            [CoverageCommentRequiredChanges.coverage_drop.value],
+            False,
+            id="coverage_drop",
+        ),
+        pytest.param(
+            [CoverageCommentRequiredChanges.uncovered_patch.value],
+            False,
+            id="uncovered_patch",
+        ),
+        pytest.param(
+            [CoverageCommentRequiredChanges.no_requirements.value],
+            True,
+            id="no_requirements",
+        ),
+    ],
+)
+async def test_condition_exact_same_report_coverage_affected_by_diff(
+    sample_comparison_no_change, mock_repo_provider, condition, expected
+):
+    mock_repo_provider.get_compare.return_value = _get_mock_compare_result(
+        "file_1.go", ["4", "8", "4", "8"]
+    )
+    notifier = _get_notifier(
+        sample_comparison_no_change.head.commit.repository, condition
+    )
+    assert (
+        await HasEnoughRequiredChanges.check_condition(
+            notifier, sample_comparison_no_change
+        )
+        == expected
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "affected_lines, expected",
+    [
+        pytest.param(["4", "8", "4", "8"], False, id="patch_100%_covered"),
+        pytest.param(["1", "8", "1", "8"], True, id="patch_NOT_100%_covered"),
+    ],
+)
+async def test_uncovered_patch(
+    sample_comparison_no_change, mock_repo_provider, affected_lines, expected
+):
+    mock_repo_provider.get_compare.return_value = _get_mock_compare_result(
+        "file_1.go", affected_lines
+    )
+    notifier = _get_notifier(
+        sample_comparison_no_change.head.commit.repository,
+        [CoverageCommentRequiredChanges.uncovered_patch.value],
+    )
+    assert (
+        await HasEnoughRequiredChanges.check_condition(
+            notifier, sample_comparison_no_change
+        )
+        == expected
+    )

--- a/services/yaml/tests/test_yaml.py
+++ b/services/yaml/tests/test_yaml.py
@@ -3,6 +3,7 @@ import os
 import mock
 import pytest
 from shared.torngit.exceptions import TorngitClientError, TorngitServerUnreachableError
+from shared.validation.types import CoverageCommentRequiredChanges
 from shared.yaml import UserYaml
 
 from database.tests.factories import CommitFactory
@@ -123,7 +124,9 @@ class TestYamlService(BaseTestCase):
                     "comment": {
                         "behavior": "default",
                         "layout": "header, diff",
-                        "require_changes": False,
+                        "require_changes": [
+                            CoverageCommentRequiredChanges.no_requirements.value
+                        ],
                     }
                 }
             }
@@ -163,7 +166,9 @@ class TestYamlService(BaseTestCase):
             "comment": {
                 "behavior": "default",
                 "layout": "header, diff",
-                "require_changes": False,
+                "require_changes": [
+                    CoverageCommentRequiredChanges.no_requirements.value
+                ],
             },
         }
 
@@ -175,7 +180,9 @@ class TestYamlService(BaseTestCase):
                     "comment": {
                         "behavior": "default",
                         "layout": "header, diff",
-                        "require_changes": False,
+                        "require_changes": [
+                            CoverageCommentRequiredChanges.no_requirements.value
+                        ],
                     }
                 }
             }
@@ -220,7 +227,9 @@ class TestYamlService(BaseTestCase):
             "comment": {
                 "behavior": "default",
                 "layout": "header, diff",
-                "require_changes": False,
+                "require_changes": [
+                    CoverageCommentRequiredChanges.no_requirements.value
+                ],
             },
         }
 
@@ -234,7 +243,9 @@ class TestYamlService(BaseTestCase):
                     "comment": {
                         "behavior": "default",
                         "layout": "header, diff",
-                        "require_changes": False,
+                        "require_changes": [
+                            CoverageCommentRequiredChanges.no_requirements.value
+                        ],
                     }
                 }
             }
@@ -276,7 +287,9 @@ class TestYamlService(BaseTestCase):
             "comment": {
                 "behavior": "default",
                 "layout": "header, diff",
-                "require_changes": False,
+                "require_changes": [
+                    CoverageCommentRequiredChanges.no_requirements.value
+                ],
             },
         }
 
@@ -293,7 +306,9 @@ class TestYamlService(BaseTestCase):
                     "comment": {
                         "behavior": "default",
                         "layout": "header, diff",
-                        "require_changes": False,
+                        "require_changes": [
+                            CoverageCommentRequiredChanges.no_requirements.value
+                        ],
                     }
                 }
             }
@@ -325,7 +340,9 @@ class TestYamlService(BaseTestCase):
             "comment": {
                 "behavior": "default",
                 "layout": "header, diff",
-                "require_changes": False,
+                "require_changes": [
+                    CoverageCommentRequiredChanges.no_requirements.value
+                ],
             },
         }
 
@@ -339,7 +356,9 @@ class TestYamlService(BaseTestCase):
                     "comment": {
                         "behavior": "default",
                         "layout": "header, diff",
-                        "require_changes": False,
+                        "require_changes": [
+                            CoverageCommentRequiredChanges.no_requirements.value
+                        ],
                     }
                 }
             }
@@ -371,6 +390,8 @@ class TestYamlService(BaseTestCase):
             "comment": {
                 "behavior": "default",
                 "layout": "header, diff",
-                "require_changes": False,
+                "require_changes": [
+                    CoverageCommentRequiredChanges.no_requirements.value
+                ],
             },
         }

--- a/services/yaml/tests/test_yaml_parsing.py
+++ b/services/yaml/tests/test_yaml_parsing.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 from shared.validation.exceptions import InvalidYamlException
+from shared.validation.types import CoverageCommentRequiredChanges
 
 from services.yaml.parser import parse_yaml_file
 from test_utils.base import BaseTestCase
@@ -35,7 +36,9 @@ class TestYamlSavingService(BaseTestCase):
             "comment": {
                 "behavior": "default",
                 "layout": "header, diff",
-                "require_changes": False,
+                "require_changes": [
+                    CoverageCommentRequiredChanges.no_requirements.value
+                ],
             },
             "parsers": {
                 "gcov": {

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 from mock import PropertyMock
+from shared.validation.types import CoverageCommentRequiredChanges
 
 from database.models import Pull
 from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
@@ -845,7 +846,9 @@ class TestNotifyTask(object):
                 "comment": {
                     "layout": "reach, diff, flags, files, footer",
                     "behavior": "default",
-                    "require_changes": False,
+                    "require_changes": [
+                        CoverageCommentRequiredChanges.no_requirements.value
+                    ],
                     "require_base": False,
                     "require_head": True,
                 },


### PR DESCRIPTION
As you can see, this is a big change.
It implements the changes from https://github.com/codecov/shared/pull/259 into the worker.

It does make the require changes condition way more complex. I also took the time to audit the unit tests, but I think they are valid now. Perhaps I should add more integration tests just in case...

> [!IMPORTANT]
> This depends on https://github.com/codecov/shared/pull/259, but it would be a bad idea to merge that and take a long time to merge this (being a breaking change and all)
> So I will hold off merging that one until this one is approved.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.