### PR TITLE
add comment for disabled CARRYFORWARD_BASE_SEARCH_RANGE experiment

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -771,6 +771,11 @@ class ReportService(BaseReportService):
                 repo_id=commit.repoid,
                 owner_id=repo.ownerid,
             )
+
+            # This experiment is inactive because the data went back and forth
+            # on whether it was impactful or not. The `Feature` is left here as
+            # a knob to turn for support requests about carryforward flags, and
+            # maybe we'll revisit a general rollout at a later time.
             max_parenthood_deepness = (
                 await CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER.check_value_async(
                     identifier=repo.ownerid, default=10


### PR DESCRIPTION
as the comment says, the results of this experiment (see them [here](https://l.codecov.dev/DPGxQO)) went back and forth on whether it did anything. there's no particular urgency behind rolling this out anymore, so i'm shutting off the experiment

i'm leaving the `Feature` here as a knob to turn if we get a support request about missing CFFs / maybe it will spark somebody in the future to retry the experiment for more conclusive results

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.