### PR TITLE
fix: rewrite raw uploads empty and expired

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -1023,7 +1023,7 @@ class ReportService(BaseReportService):
                 error=ProcessingError(code="report_expired", params={}),
                 fully_deleted_sessions=None,
                 partially_deleted_sessions=None,
-                raw_report=None,
+                raw_report=raw_uploaded_report,
                 upload_obj=upload,
             )
         except ReportEmptyError:
@@ -1038,7 +1038,7 @@ class ReportService(BaseReportService):
                 error=ProcessingError(code="report_empty", params={}),
                 fully_deleted_sessions=None,
                 partially_deleted_sessions=None,
-                raw_report=None,
+                raw_report=raw_uploaded_report,
                 upload_obj=upload,
             )
 


### PR DESCRIPTION
The re-write on readable format is currently not working for expired or empty reports.
This is because we don't returned the raw report (that despite the name does have a little
but of processing to it) in the case that the report is empty or expired.
By passing the raw_parsed_report we should start rewriting them in the readable format.

This didn't fall in the "rewrite in error" cathegory because these scenarios are not
treated as errors.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.