### PR TITLE
feat: pre risky migration flaky test changes

### DIFF
--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -322,3 +322,28 @@ class TestResultReportTotals(CodecovBaseModel, MixinBaseClass):
     skipped = Column(types.Integer)
     failed = Column(types.Integer)
     error = Column(types.String(100), nullable=True)
+
+
+class ReducedError(CodecovBaseModel, MixinBaseClass):
+    __tablename__ = "reports_reducederror"
+    message = Column(types.Text)
+
+
+class Flake(CodecovBaseModel, MixinBaseClass):
+    __tablename__ = "reports_flake"
+    repoid = Column(types.Integer, ForeignKey("repos.repoid"))
+    repository = relationship("Repository", backref=backref("flakes"))
+
+    testid = Column(types.Text, ForeignKey("reports_test.id"))
+    test = relationship(Test, backref=backref("flakes"))
+
+    reduced_error_id = Column(
+        types.Integer, ForeignKey("reports_reducederror.id"), nullable=True
+    )
+    reduced_error = relationship(ReducedError, backref=backref("flakes"))
+
+    recent_passes_count = Column(types.Integer)
+    count = Column(types.Integer)
+    fail_count = Column(types.Integer)
+    start_date = Column(types.DateTime)
+    end_date = Column(types.DateTime, nullable=True)

--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 https://github.com/codecov/shared/archive/390e62c4858ee41ffd035e5d7fe77c71a179d76a.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz#egg=test-results-parser
+https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz#egg=test-results-parser
 boto3>=1.34
 celery>=5.3.6
 click
@@ -38,6 +38,7 @@ SQLAlchemy-Utils
 SQLAlchemy
 statsd
 stripe>=9.6.0
+time-machine
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 urllib3>=1.26.18
 vcrpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -323,6 +323,7 @@ python-dateutil==2.9.0.post0
     #   django-postgres-extra
     #   faker
     #   freezegun
+    #   time-machine
     #   timeconvert
 python-json-logger==0.1.11
     # via -r requirements.in
@@ -403,10 +404,12 @@ statsd==3.3.0
     #   shared
 stripe==9.6.0
     # via -r requirements.in
-test-results-parser @ https://github.com/codecov/test-results-parser/archive/5515e960d5d38881036e9127f86320efca649f13.tar.gz
+test-results-parser @ https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz
     # via -r requirements.in
 text-unidecode==1.3
     # via faker
+time-machine==2.14.1
+    # via -r requirements.in
 timeconvert==3.0.13
     # via excel-base
 timestring @ https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -2,11 +2,9 @@ import mock
 import pytest
 from shared.torngit.exceptions import TorngitClientError
 
-from database.enums import FlakeSymptomType
 from database.models.core import Commit
 from services.test_results import (
     TestResultsNotificationFailure,
-    TestResultsNotificationFlake,
     TestResultsNotificationPayload,
     TestResultsNotifier,
     generate_flags_hash,
@@ -130,11 +128,8 @@ def test_build_message_with_flake(tn):
     fail = TestResultsNotificationFailure(
         "hello world", "testsuite", "testname", [], test_id
     )
-    flake = TestResultsNotificationFlake(
-        [FlakeSymptomType.FAILED_IN_DEFAULT_BRANCH],
-        True,
-    )
-    payload = TestResultsNotificationPayload(1, 2, 3, [fail], {test_id: flake})
+
+    payload = TestResultsNotificationPayload(1, 2, 3, [fail], {test_id})
     res = tn.build_message(payload)
 
     assert (
@@ -142,8 +137,7 @@ def test_build_message_with_flake(tn):
         == """**Test Failures Detected**: Due to failing tests, we cannot provide coverage reports at this time.
 
 ### :x: Failed Test Results: 
-Completed 6 tests with **`1 failed`**(1 newly detected flaky), 2 passed and 3 skipped.
-- Total :snowflake:**1 flaky tests.**
+Completed 6 tests with **`1 failed`**(1 known flakes hit), 2 passed and 3 skipped.
 <details><summary>View the full list of flaky tests</summary>
 
 ## testsuite

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -9,23 +9,14 @@ from test_results_parser import Outcome
 
 from app import celery_app
 from database.enums import FlakeSymptomType, ReportType, TestResultsProcessingError
-from database.models import Commit, TestResultReportTotals
+from database.models import Commit, Flake, TestResultReportTotals
 from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import TestResultsFlow
 from helpers.string import EscapeEnum, Replacement, StringEscaper, shorten_file_paths
 from rollouts import FLAKY_TEST_DETECTION
-from services.failure_normalizer import FailureNormalizer
-from services.flake_detection import (
-    DefaultBranchFailureDetector,
-    DiffOutcomeDetector,
-    FlakeDetectionEngine,
-    FlakeDetectionResult,
-    UnrelatedMatchesDetector,
-)
 from services.lock_manager import LockManager, LockRetry, LockType
 from services.test_results import (
     TestResultsNotificationFailure,
-    TestResultsNotificationFlake,
     TestResultsNotificationPayload,
     TestResultsNotifier,
     latest_test_instances_for_a_given_commit,
@@ -71,13 +62,15 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         repoid = int(repoid)
         commit_yaml = UserYaml.from_dict(commit_yaml)
 
+        self.extra_dict = {
+            "repoid": repoid,
+            "commit": commitid,
+            "commit_yaml": commit_yaml,
+        }
+
         log.info(
             "Starting test results finisher task",
-            extra=dict(
-                repoid=repoid,
-                commit=commitid,
-                commit_yaml=commit_yaml,
-            ),
+            extra=self.extra_dict,
         )
 
         lock_manager = LockManager(
@@ -129,12 +122,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
     ):
         log.info(
             "Running test results finishers",
-            extra=dict(
-                repoid=repoid,
-                commit=commitid,
-                commit_yaml=commit_yaml,
-                parent_task=self.request.parent_id,
-            ),
+            extra=self.extra_dict,
         )
 
         checkpoints = checkpoints_from_kwargs(TestResultsFlow, kwargs)
@@ -155,6 +143,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         commit: Commit = (
             db_session.query(Commit).filter_by(repoid=repoid, commitid=commitid).first()
         )
+
         assert commit, "commit not found"
 
         notifier = TestResultsNotifier(commit, commit_yaml)
@@ -277,11 +266,13 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             "test_results.finisher",
             tags={"status": "success", "reason": "tests_failed"},
         )
-        flaky_tests = None
-        if FLAKY_TEST_DETECTION.check_value(identifier=repoid):
-            flaky_tests = dict()
+
+        flaky_tests = self.get_flaky_tests(
+            db_session, commit_yaml, repoid, commit, failures
+        )
 
         failures = sorted(failures, key=lambda x: x.testsuite + x.testname)
+
         payload = TestResultsNotificationPayload(
             failed_tests, passed_tests, skipped_tests, failures, flaky_tests
         )
@@ -300,15 +291,10 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             )
             success, reason = async_to_sync(notifier.notify)(payload)
 
+        self.extra_dict["success"] = success
         log.info(
             "Finished test results notify",
-            extra=dict(
-                repoid=repoid,
-                commit=commitid,
-                commit_yaml=commit_yaml,
-                parent_task=self.request.parent_id,
-                success=success,
-            ),
+            extra=self.extra_dict,
         )
 
         # using a var as a tag here will be fine as it's a boolean
@@ -317,132 +303,27 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             tags={"status": success, "reason": reason},
         )
 
-        if FLAKY_TEST_DETECTION.check_value(identifier=repoid):
-            log.info(
-                "Running flaky test detection",
-                extra=dict(
-                    repoid=repoid,
-                    commit=commitid,
-                    commit_yaml=commit_yaml,
-                    parent_task=self.request.parent_id,
-                ),
-            )
-            with metrics.timing("test_results.finisher.run_flaky_test_detection"):
-                success, reason = self.run_flaky_test_detection(
-                    db_session, repoid, notifier, payload, checkpoints=checkpoints
-                )
-
-            metrics.incr(
-                "test_results.finisher.flaky_test_detection",
-                tags={"status": success, "reason": reason},
-            )
-
         return {
             "notify_attempted": True,
             "notify_succeeded": success,
             QUEUE_NOTIFY_KEY: False,
         }
 
-    def run_flaky_test_detection(
-        self,
-        db_session,
-        repoid,
-        notifier: TestResultsNotifier,
-        payload: TestResultsNotificationPayload,
-        checkpoints=None,
-    ):
-        ignore_predefined = read_yaml_field(
-            "test_analytics", "ignore_predefined", _else=False
-        )
+    def get_flaky_tests(self, db_session, commit_yaml, repoid, commit, failures):
+        if FLAKY_TEST_DETECTION.check_value(
+            identifier=repoid, default=True
+        ) and read_yaml_field(commit_yaml, ("test_analytics", "flake_detection"), True):
+            flaky_tests = set()
+            repo_flakes = db_session.query(Flake).filter_by(repoid=repoid).all()
+            failure_dict = {failure.test_id: failure for failure in failures}
 
-        user_normalization_regex = read_yaml_field(
-            "test_analytics", "normalization_regex", _else=dict()
-        )
+            for flake in repo_flakes:
+                if flake.testid in failure_dict:
+                    flaky_tests.add(flake.testid)
 
-        failure_normalizer = FailureNormalizer(
-            user_normalization_regex, ignore_predefined
-        )
+            return flaky_tests
 
-        default_branch_failure_detector = DefaultBranchFailureDetector(
-            db_session, repoid, "main"
-        )
-        unrelated_matches_detector = UnrelatedMatchesDetector(failure_normalizer)
-        diff_outcome_detector = DiffOutcomeDetector()
-
-        flake_detection_engine = FlakeDetectionEngine(
-            db_session,
-            repoid,
-            [
-                default_branch_failure_detector,
-                unrelated_matches_detector,
-                diff_outcome_detector,
-            ],
-        )
-
-        log.info(
-            "Starting flake detection",
-            extra=dict(
-                repoid=repoid,
-                parent_task=self.request.parent_id,
-            ),
-        )
-        current_state_of_repo_flakes = flake_detection_engine.detect_flakes()
-
-        for test_id, symptoms in current_state_of_repo_flakes.items():
-            log.info(
-                "Discovered flaky test",
-                extra=dict(
-                    repoid=repoid,
-                    parent_task=self.request.parent_id,
-                    test_id=test_id,
-                    symptoms=list(symptoms),
-                ),
-            )
-            payload.flaky_tests[test_id] = TestResultsNotificationFlake(
-                list(symptoms),
-                True,
-            )
-            db_session.flush()
-
-        if checkpoints:
-            checkpoints.log(TestResultsFlow.FLAKE_DETECTION_NOTIFY)
-
-            # TODO: remove this later, we can do this now because there aren't many users using this
-            metrics.distribution(
-                "test_results_processing_time",
-                checkpoints._subflow_duration(
-                    TestResultsFlow.TEST_RESULTS_NOTIFY,
-                    TestResultsFlow.FLAKE_DETECTION_NOTIFY,
-                ),
-                unit="millisecond",
-                tags={"repoid": repoid},
-            )
-        success, reason = async_to_sync(notifier.notify)(payload)
-        log.info(
-            "Added flaky test information to the PR comment",
-            extra=dict(
-                repoid=repoid,
-                parent_task=self.request.parent_id,
-                success=success,
-                reason=reason,
-            ),
-        )
-
-        return success, reason
-
-    def get_flake_diff(
-        self,
-        newly_calculated_flakes: FlakeDetectionResult,
-        existing_flakes_from_db: dict[str, TestResultsNotificationFlake],
-    ):
-        newly_discovered_flakes = set(newly_calculated_flakes.keys()) - set(
-            existing_flakes_from_db.keys()
-        )
-        no_longer_flakes = set(existing_flakes_from_db.keys()) - set(
-            newly_calculated_flakes.keys()
-        )
-
-        return list(newly_discovered_flakes), list(no_longer_flakes)
+        return None
 
     def check_if_no_success(self, previous_result):
         return all(

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -311,8 +311,10 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
 
     def get_flaky_tests(self, db_session, commit_yaml, repoid, commit, failures):
         if FLAKY_TEST_DETECTION.check_value(
-            identifier=repoid, default=True
-        ) and read_yaml_field(commit_yaml, ("test_analytics", "flake_detection"), True):
+            identifier=repoid, default=False
+        ) and read_yaml_field(
+            commit_yaml, ("test_analytics", "flake_detection"), False
+        ):
             flaky_tests = set()
             repo_flakes = db_session.query(Flake).filter_by(repoid=repoid).all()
             failure_dict = {failure.test_id: failure for failure in failures}

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -324,7 +324,14 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             commit_yaml, ("test_analytics", "flake_detection"), False
         ):
             flaky_tests = set()
-            repo_flakes = db_session.query(Flake).filter_by(repoid=repoid).all()
+            repo_flakes = (
+                db_session.query(Flake)
+                .filter(  # type:ignore
+                    Flake.repoid == repoid,
+                    Flake.end_date.is_(None),
+                )
+                .all()
+            )
             failure_dict = {failure.test_id: failure for failure in failures}
 
             for flake in repo_flakes:

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -89,7 +89,8 @@ class TestUploadTestProcessorTask(object):
             == """def test_divide():\n&gt;       assert Calculator.divide(1, 2) == 0.5\nE       assert 1.0 == 0.5\nE        +  where 1.0 = &lt;function Calculator.divide at 0x104c9eb90&gt;(1, 2)\nE        +    where &lt;function Calculator.divide at 0x104c9eb90&gt; = Calculator.divide\n\napi/temp/calculator/test_calculator.py:30: AssertionError"""
         )
         assert (
-            failures[0].test.name == "api.temp.calculator.test_calculator::test_divide"
+            failures[0].test.name
+            == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
         assert expected_result == result
         assert commit.message == "hello world"
@@ -545,13 +546,13 @@ class TestUploadTestProcessorTask(object):
         test_id = generate_test_id(
             repoid,
             "pytest",
-            "api.temp.calculator.test_calculator::test_divide",
+            "api.temp.calculator.test_calculator\x1ftest_divide",
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         )
         existing_test = Test(
             repoid=repoid,
             flags_hash="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            name="api.temp.calculator.test_calculator::test_divide",
+            name="api.temp.calculator.test_calculator\x1ftest_divide",
             testsuite="pytest",
             id_=test_id,
         )
@@ -585,7 +586,8 @@ class TestUploadTestProcessorTask(object):
             == """def test_divide():\n&gt;       assert Calculator.divide(1, 2) == 0.5\nE       assert 1.0 == 0.5\nE        +  where 1.0 = &lt;function Calculator.divide at 0x104c9eb90&gt;(1, 2)\nE        +    where &lt;function Calculator.divide at 0x104c9eb90&gt; = Calculator.divide\n\napi/temp/calculator/test_calculator.py:30: AssertionError"""
         )
         assert (
-            failures[0].test.name == "api.temp.calculator.test_calculator::test_divide"
+            failures[0].test.name
+            == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
         assert expected_result == result
         assert commit.message == "hello world"
@@ -631,13 +633,13 @@ class TestUploadTestProcessorTask(object):
         test_id = generate_test_id(
             repoid,
             "pytest",
-            "api.temp.calculator.test_calculator::test_divide",
+            "api.temp.calculator.test_calculator\x1ftest_divide",
             "",
         )
         existing_test = Test(
             repoid=repoid,
             flags_hash="",
-            name="api.temp.calculator.test_calculator::test_divide",
+            name="api.temp.calculator.test_calculator\x1ftest_divide",
             testsuite="pytest",
             id_=test_id,
         )
@@ -673,7 +675,8 @@ class TestUploadTestProcessorTask(object):
             == """def test_divide():\n&gt;       assert Calculator.divide(1, 2) == 0.5\nE       assert 1.0 == 0.5\nE        +  where 1.0 = &lt;function Calculator.divide at 0x104c9eb90&gt;(1, 2)\nE        +    where &lt;function Calculator.divide at 0x104c9eb90&gt; = Calculator.divide\n\napi/temp/calculator/test_calculator.py:30: AssertionError"""
         )
         assert (
-            failures[0].test.name == "api.temp.calculator.test_calculator::test_divide"
+            failures[0].test.name
+            == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
         assert expected_result == result
         assert commit.message == "hello world"


### PR DESCRIPTION
This commit makes the changes possible before the risky migrations in the supporting shared PR are done.

- update shared version
- update test results parser version
- add time-machine as a dependency
- add Flake and ReducedError sqlalchemy models
- modify TestResultsNotificationPayload to contain a set of flaky test ids instead of a dict[str, TestResultsNotificationFlake]
- change flaky test results comment format
- change flake detection in test results finisher to gather the Flake objects for a given repo and compare their test ids to the test ids of the failures relevant to the test results comment
