### PR TITLE
feat: flake detection post risky migration changes 

### DIFF
--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -313,6 +313,11 @@ class TestInstance(CodecovBaseModel, MixinBaseClass):
     branch = Column(types.Text, nullable=True)
     commitid = Column(types.Text, nullable=True)
 
+    reduced_error_id = Column(
+        types.Integer, ForeignKey("reports_reducederror.id"), nullable=True
+    )
+    reduced_error = relationship("ReducedError", backref=backref("testinstances"))
+
 
 class TestResultReportTotals(CodecovBaseModel, MixinBaseClass):
     __tablename__ = "reports_testresultreporttotals"

--- a/tasks/process_flakes.py
+++ b/tasks/process_flakes.py
@@ -1,0 +1,103 @@
+import datetime as dt
+import logging
+from typing import Any
+
+from shared.celery_config import process_flakes_task_name
+from shared.django_apps.reports.models import Flake, TestInstance
+
+from app import celery_app
+from tasks.base import BaseCodecovTask
+
+log = logging.getLogger(__name__)
+
+
+FlakeDict = dict[Any, Flake]
+
+
+class ProcessFlakesTask(BaseCodecovTask, name=process_flakes_task_name):
+    """
+    This task is currently called in the test results finisher task and in the sync pulls task
+    """
+
+    def run_impl(
+        self,
+        _db_session,
+        *,
+        repo_id,
+        commit_id_list,
+        branch,
+        **kwargs,
+    ):
+        repo_id = int(repo_id)
+        log.info(
+            "Received process flakes task",
+            extra=dict(repoid=repo_id, commit=commit_id_list),
+        )
+
+        flake_dict = generate_flake_dict(repo_id)
+
+        for commit_id in commit_id_list:
+            test_instances = get_test_instances(commit_id, repo_id, branch)
+            for test_instance in test_instances:
+                if test_instance.outcome == TestInstance.Outcome.PASS.value:
+                    flake = flake_dict.get(test_instance.test_id)
+                    if flake is not None:
+                        update_passed_flakes(flake)
+                elif (
+                    test_instance.outcome == TestInstance.Outcome.FAILURE.value
+                    or test_instance.outcome == TestInstance.Outcome.ERROR.value
+                ):
+                    flake = flake_dict.get(test_instance.test_id)
+                    upserted_flake = upsert_failed_flake(test_instance, repo_id, flake)
+                    if flake is None:
+                        flake_dict[upserted_flake.test_id] = upserted_flake
+
+        return {"successful": True}
+
+
+def get_test_instances(commit_id, repo_id, branch):
+    test_instances = TestInstance.objects.filter(
+        commitid=commit_id, repoid=repo_id, branch=branch
+    ).all()
+    return test_instances
+
+
+def generate_flake_dict(repo_id) -> FlakeDict:
+    flakes = Flake.objects.filter(repository_id=repo_id, end_date__isnull=True).all()
+    flake_dict = dict()
+    for flake in flakes:
+        flake_dict[flake.test_id] = flake
+    return flake_dict
+
+
+def update_passed_flakes(flake: Flake):
+    flake.count += 1
+    flake.recent_passes_count += 1
+    if flake.recent_passes_count == 30:
+        flake.end_date = dt.datetime.now(tz=dt.UTC)
+    flake.save()
+
+
+def upsert_failed_flake(test_instance: TestInstance, repo_id, flake: Flake | None):
+    if flake is None:
+        flake = Flake(
+            repository_id=repo_id,
+            test=test_instance.test,
+            reduced_error=None,
+            count=1,
+            fail_count=1,
+            start_date=dt.datetime.now(dt.UTC),
+            recent_passes_count=0,
+        )
+        flake.save()
+    else:
+        flake.count += 1
+        flake.fail_count += 1
+        flake.recent_passes_count = 0
+        flake.save()
+
+    return flake
+
+
+RegisteredProcessFlakesTask = celery_app.register_task(ProcessFlakesTask())
+process_flakes_task = celery_app.tasks[RegisteredProcessFlakesTask.name]

--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -138,6 +138,7 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
                         failure_message=failure_message,
                         commitid=commitid,
                         branch=branch,
+                        reduced_error_id=None,
                     )
                 )
 

--- a/tasks/tests/unit/test_process_flakes.py
+++ b/tasks/tests/unit/test_process_flakes.py
@@ -1,0 +1,346 @@
+import datetime as dt
+from collections import defaultdict
+
+import time_machine
+from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
+from shared.django_apps.reports.models import Flake, TestInstance
+from shared.django_apps.reports.tests.factories import (
+    FlakeFactory,
+    TestFactory,
+    TestInstanceFactory,
+)
+
+from tasks.process_flakes import (
+    ProcessFlakesTask,
+    generate_flake_dict,
+    get_test_instances,
+    update_passed_flakes,
+    upsert_failed_flake,
+)
+
+
+class RepoSimulator:
+    def __init__(self):
+        self.repo = RepositoryFactory()
+        self.repo.save()
+        self.test_count = 0
+        self.branch_name = 0
+
+        self.test_map = defaultdict(lambda: TestFactory(id=self.test_count))
+
+    def create_commit(self):
+        c = CommitFactory(
+            repository=self.repo, merged=False, branch=str(self.branch_name)
+        )
+        c.save()
+        self.branch_name += 1
+        self.test_count = 0
+        return c
+
+    def merge(self, c):
+        c.merged = True
+        c.branch = self.repo.branch
+        c.save()
+        self.test_count = 0
+
+    def add_test_instance(self, c, outcome=TestInstance.Outcome.PASS.value):
+        ti = TestInstanceFactory(
+            commitid=c.commitid,
+            repoid=self.repo.repoid,
+            branch=c.branch,
+            outcome=outcome,
+            test=self.test_map[self.test_count],
+        )
+        print(self.test_map[self.test_count].id)
+        ti.save()
+        self.test_count += 1
+
+    def reset(self):
+        self.repo = RepositoryFactory()
+        self.repo.save()
+        self.test_count = 0
+
+
+def test_generate_flake_dict(transactional_db):
+    repo = RepositoryFactory()
+
+    flake_dict = generate_flake_dict(repo.repoid)
+
+    assert len(flake_dict) == 0
+
+    f = FlakeFactory(repository=repo, test__id="id")
+    f.save()
+
+    flake_dict = generate_flake_dict(repo.repoid)
+
+    assert len(flake_dict) == 1
+    assert "id" in flake_dict
+
+
+def test_get_test_instances(transactional_db):
+    repo = RepositoryFactory()
+    commit = CommitFactory()
+
+    ti = TestInstanceFactory(
+        commitid=commit.commitid, repoid=repo.repoid, branch="main"
+    )
+    ti.save()
+
+    tis = get_test_instances(commit.commitid, repo.repoid, "main")
+    assert len(tis) == 1
+    assert tis[0].commitid
+
+
+def test_update_passed_flakes(transactional_db):
+    repo = RepositoryFactory()
+    test = TestFactory()
+
+    f = FlakeFactory(test=test, repository=repo)
+    f.save()
+    assert f.count == 0
+    assert f.recent_passes_count == 0
+
+    update_passed_flakes(f)
+
+    assert f.count == 1
+    assert f.recent_passes_count == 1
+
+
+def test_upsert_failed_flakes(transactional_db):
+    repo = RepositoryFactory()
+    repo.save()
+    commit = CommitFactory()
+    commit.save()
+    ti = TestInstanceFactory(
+        commitid=commit.commitid, repoid=repo.repoid, branch="main"
+    )
+    ti.save()
+    test = TestFactory()
+    test.save()
+    f = FlakeFactory()
+    f.save()
+
+    upsert_failed_flake(ti, repo.repoid, f)
+
+
+def test_it_does_not_detect_unmerged_tests(transactional_db):
+    rs = RepoSimulator()
+    c1 = rs.create_commit()
+
+    rs.add_test_instance(c1)
+
+    rs.add_test_instance(c1)
+
+    ProcessFlakesTask().run_impl(
+        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
+    )
+
+    assert len(Flake.objects.all()) == 0
+
+
+def test_it_handles_only_passes(transactional_db):
+    rs = RepoSimulator()
+    c1 = rs.create_commit()
+
+    rs.add_test_instance(c1)
+
+    rs.add_test_instance(c1)
+
+    rs.merge(c1)
+
+    ProcessFlakesTask().run_impl(
+        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
+    )
+
+    assert len(Flake.objects.all()) == 0
+
+
+@time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
+def test_it_creates_flakes_from_orig_branch(transactional_db):
+    rs = RepoSimulator()
+    c1 = rs.create_commit()
+    orig_branch = c1.branch
+    rs.add_test_instance(c1)
+    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
+    rs.merge(c1)
+    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
+
+    ProcessFlakesTask().run_impl(
+        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=orig_branch
+    )
+
+    assert len(Flake.objects.all()) == 1
+    assert Flake.objects.first().count == 1
+    assert Flake.objects.first().fail_count == 1
+    assert Flake.objects.first().start_date == dt.datetime.now(dt.UTC)
+
+
+@time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
+def test_it_creates_flakes_from_new_branch_only(transactional_db):
+    rs = RepoSimulator()
+    c1 = rs.create_commit()
+    orig_branch = c1.branch
+    rs.add_test_instance(c1)
+    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
+    rs.merge(c1)
+    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
+
+    ProcessFlakesTask().run_impl(
+        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
+    )
+
+    assert len(Flake.objects.all()) == 1
+    assert Flake.objects.first().count == 1
+    assert Flake.objects.first().fail_count == 1
+    assert Flake.objects.first().start_date == dt.datetime.now(dt.UTC)
+
+
+@time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
+def test_it_creates_flakes_fail_after_merge(transactional_db):
+    rs = RepoSimulator()
+    c1 = rs.create_commit()
+
+    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
+    rs.merge(c1)
+
+    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
+
+    ProcessFlakesTask().run_impl(
+        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
+    )
+
+    assert len(Flake.objects.all()) == 1
+    flake = Flake.objects.first()
+    assert flake.recent_passes_count == 0
+    assert flake.count == 1
+    assert flake.fail_count == 1
+    assert flake.start_date == dt.datetime.now(dt.UTC)
+
+    ProcessFlakesTask().run_impl(
+        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
+    )
+
+    assert len(Flake.objects.all()) == 1
+    flake = Flake.objects.first()
+    assert flake.recent_passes_count == 0
+    assert flake.count == 2
+    assert flake.fail_count == 2
+    assert flake.start_date == dt.datetime.now(dt.UTC)
+
+
+@time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
+def test_it_works_when_processing_commits_together(transactional_db):  # TODO
+    rs = RepoSimulator()
+    c1 = rs.create_commit()
+    rs.merge(c1)
+    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
+
+    c2 = rs.create_commit()
+    rs.merge(c2)
+    rs.add_test_instance(c2, outcome=TestInstance.Outcome.FAILURE.value)
+
+    ProcessFlakesTask().run_impl(
+        None,
+        repo_id=rs.repo.repoid,
+        commit_id_list=[c1.commitid, c2.commitid],
+        branch=c1.branch,
+    )
+
+    assert len(Flake.objects.all()) == 1
+    flake = Flake.objects.first()
+    assert flake.recent_passes_count == 0
+    assert flake.count == 2
+    assert flake.fail_count == 2
+    assert flake.start_date == dt.datetime.now(dt.UTC)
+
+
+@time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
+def test_it_works_when_processing_commits_separately(transactional_db):  # TODO
+    rs = RepoSimulator()
+    c1 = rs.create_commit()
+    rs.merge(c1)
+    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
+
+    ProcessFlakesTask().run_impl(
+        None,
+        repo_id=rs.repo.repoid,
+        commit_id_list=[c1.commitid],
+        branch=c1.branch,
+    )
+
+    c2 = rs.create_commit()
+    rs.merge(c2)
+    rs.add_test_instance(c2, outcome=TestInstance.Outcome.FAILURE.value)
+
+    ProcessFlakesTask().run_impl(
+        None,
+        repo_id=rs.repo.repoid,
+        commit_id_list=[c2.commitid],
+        branch=c2.branch,
+    )
+
+    assert len(Flake.objects.all()) == 1
+    flake = Flake.objects.first()
+    assert flake.recent_passes_count == 0
+    assert flake.count == 2
+    assert flake.fail_count == 2
+    assert flake.start_date == dt.datetime.now(dt.UTC)
+
+
+def test_it_creates_flakes_expires(transactional_db):  # TODO
+    with time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False) as traveller:
+        rs = RepoSimulator()
+        commits = []
+        c1 = rs.create_commit()
+        rs.merge(c1)
+        rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
+
+        ProcessFlakesTask().run_impl(
+            None,
+            repo_id=rs.repo.repoid,
+            commit_id_list=[c1.commitid],
+            branch=rs.repo.branch,
+        )
+
+        old_time = dt.datetime.now(dt.UTC)
+        traveller.shift(dt.timedelta(seconds=100))
+        new_time = dt.datetime.now(dt.UTC)
+
+        print(old_time, new_time)
+
+        for _ in range(0, 29):
+            c = rs.create_commit()
+            rs.merge(c)
+            rs.add_test_instance(c, outcome=TestInstance.Outcome.PASS.value)
+            commits.append(c.commitid)
+
+        ProcessFlakesTask().run_impl(
+            None, repo_id=rs.repo.repoid, commit_id_list=commits, branch=rs.repo.branch
+        )
+
+        assert len(Flake.objects.all()) == 1
+        flake = Flake.objects.first()
+        assert flake.recent_passes_count == 29
+        assert flake.count == 30
+        assert flake.fail_count == 1
+        assert flake.start_date == old_time
+        assert flake.end_date is None
+
+        c = rs.create_commit()
+        rs.merge(c)
+        rs.add_test_instance(c, outcome=TestInstance.Outcome.PASS.value)
+
+        ProcessFlakesTask().run_impl(
+            None,
+            repo_id=rs.repo.repoid,
+            commit_id_list=[c.commitid],
+            branch=rs.repo.branch,
+        )
+
+        assert len(Flake.objects.all()) == 1
+        flake = Flake.objects.first()
+        assert flake.recent_passes_count == 30
+        assert flake.count == 31
+        assert flake.fail_count == 1
+        assert flake.start_date == old_time
+        assert flake.end_date == new_time

--- a/tasks/tests/unit/test_process_flakes.py
+++ b/tasks/tests/unit/test_process_flakes.py
@@ -229,7 +229,7 @@ def test_it_creates_flakes_fail_after_merge(transactional_db):
 
 
 @time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
-def test_it_works_when_processing_commits_together(transactional_db):  # TODO
+def test_it_processes_two_commits_together(transactional_db):
     rs = RepoSimulator()
     c1 = rs.create_commit()
     rs.merge(c1)
@@ -255,7 +255,7 @@ def test_it_works_when_processing_commits_together(transactional_db):  # TODO
 
 
 @time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
-def test_it_works_when_processing_commits_separately(transactional_db):  # TODO
+def test_it_processes_two_commits_separately(transactional_db):
     rs = RepoSimulator()
     c1 = rs.create_commit()
     rs.merge(c1)
@@ -287,7 +287,7 @@ def test_it_works_when_processing_commits_separately(transactional_db):  # TODO
     assert flake.start_date == dt.datetime.now(dt.UTC)
 
 
-def test_it_creates_flakes_expires(transactional_db):  # TODO
+def test_it_creates_flakes_expires(transactional_db):
     with time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False) as traveller:
         rs = RepoSimulator()
         commits = []

--- a/tasks/tests/unit/test_process_flakes.py
+++ b/tasks/tests/unit/test_process_flakes.py
@@ -24,16 +24,16 @@ class RepoSimulator:
         self.repo = RepositoryFactory()
         self.repo.save()
         self.test_count = 0
-        self.branch_name = 0
+        self.branch_number = 0
 
         self.test_map = defaultdict(lambda: TestFactory(id=self.test_count))
 
     def create_commit(self):
         c = CommitFactory(
-            repository=self.repo, merged=False, branch=str(self.branch_name)
+            repository=self.repo, merged=False, branch=str(self.branch_number)
         )
         c.save()
-        self.branch_name += 1
+        self.branch_number += 1
         self.test_count = 0
         return c
 


### PR DESCRIPTION
These changes should be committed after the risky migrations in the
flake detection shared change are run.

- Add reduced_error foreign key to test instance sqlalchemy models
- add the process flakes task which takes in a repoid and list of commit
  ids as input and upserts Flake objects in the DB based on the test
  instances on those commits. This task is what implements the
  flakiness heuristic.
- call the process flakes task in sync pulls on merged commits
- call the process flakes task in the test results finisher when we
  receive test results from the main branch