### PR TITLE
fix: coverage_drop condition

### DIFF
--- a/services/notification/notifiers/comment/conditions.py
+++ b/services/notification/notifiers/comment/conditions.py
@@ -154,7 +154,10 @@ class HasEnoughRequiredChanges(AsyncNotifyCondition):
         project_status_config = read_yaml_field(
             comparison.comparison.current_yaml, ("coverage", "status", "project"), {}
         )
-        threshold = Decimal(project_status_config.get("threshold", 0))
+        threshold = 0
+        if isinstance(project_status_config, dict):
+            # Project status can also be a bool value, so check is needed
+            threshold = Decimal(project_status_config.get("threshold", 0))
         target_coverage = Decimal(
             comparison.project_coverage_base.report.totals.coverage
         ).quantize(Decimal("0.00000"))


### PR DESCRIPTION
The `coverage_drop` comment condition looks for the project status threshold,
but the config might be a simple bool. This causes the notifier to fail with
and exception.

These changes fix that and add some more testing to cover this case (that should
have been added earlier, I know. My bad)

related to: https://github.com/codecov/engineering-team/issues/1966
closes: https://github.com/codecov/engineering-team/issues/2003
<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.