### PR TITLE
feat: track suspended apps

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -194,6 +194,8 @@ class GithubAppInstallation(CodecovBaseModel, MixinBaseClass):
         Owner, foreign_keys=[ownerid], back_populates="github_app_installations"
     )
 
+    is_suspended = Column(types.Boolean, server_default=FetchedValue())
+
     def repository_queryset(self, dbsession: Session):
         """Returns a query set of repositories covered by this installation"""
         if self.repository_service_ids is None:


### PR DESCRIPTION
This column is part of the model since https://github.com/codecov/shared/pull/237
but was not reflected in the worker yet.

related: https://github.com/codecov/internal-issues/issues/519

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.