### PR TITLE
feat: update bundle_analysis comment requirement

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/390e62c4858ee41ffd035e5d7fe77c71a179d76a.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/3b44680b87559e7fe69b3e9645172a99f6bdbf98.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz#egg=test-results-parser
 boto3>=1.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -370,7 +370,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/390e62c4858ee41ffd035e5d7fe77c71a179d76a.tar.gz
+shared @ https://github.com/codecov/shared/archive/3b44680b87559e7fe69b3e9645172a99f6bdbf98.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via
@@ -432,7 +432,7 @@ tzdata==2024.1
     # via celery
 tzlocal==5.2
     # via timeconvert
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -r requirements.in
     #   botocore

--- a/services/yaml/tests/test_yaml.py
+++ b/services/yaml/tests/test_yaml.py
@@ -47,7 +47,7 @@ class TestYamlService(BaseTestCase):
             mock_configuration, "load_yaml_file", side_effect=FileNotFoundError()
         )
         expected_result = {
-            "codecov": {"require_ci_to_pass": True},
+            "codecov": {"require_ci_to_pass": True, "notify": {"wait_for_ci": True}},
             "coverage": {
                 "precision": 2,
                 "round": "down",


### PR DESCRIPTION
Updates the comment requirements for bundle_analysis.
Respects the `comment.bundle_change_threshold` defined in the YAML
and only notifies if changes are bigger than the threshold.
(threshold is expected to be an int. So technically [this PR](https://github.com/codecov/shared/pull/271) is a dependency of the present changes, because it does the
coercion into an integer, as expected)

Also adds the `"bundle_increase"` as a possible requirements. In this case
on top of the threshold the change also needs to cause the bundle to _increase_
in size for a comment to be sent.

closes: https://github.com/codecov/engineering-team/issues/2021

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.