### PR TITLE
add True as default for wait_for_ci

### DIFF
--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -561,7 +561,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
             and commit.commitid != enriched_pull.provider_pull["head"]["commitid"]
         ):
             wait_for_ci = read_yaml_field(
-                current_yaml, ("codecov", "notify", "wait_for_ci")
+                current_yaml, ("codecov", "notify", "wait_for_ci"), True
             )
             manual_trigger = read_yaml_field(
                 current_yaml, ("codecov", "notify", "manual_trigger")


### PR DESCRIPTION
<!-- Describe your PR here. -->
The way it is written, if `wait_for_ci` is not supplied, it evaluates as `False-y`

per [our docs](https://docs.codecov.com/docs/codecovyml-reference#codecovnotifywait_for_ci), `wait_for_ci` default is `True`

This changes the evaluation, so if `wait_for_ci` is not supplied, it evaluates to `True` which follows our intended behavior.