### PR TITLE
feat: don't select suspended apps

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -194,6 +194,8 @@ class GithubAppInstallation(CodecovBaseModel, MixinBaseClass):
         Owner, foreign_keys=[ownerid], back_populates="github_app_installations"
     )
 
+    is_suspended = Column(types.Boolean, server_default=FetchedValue())
+
     def repository_queryset(self, dbsession: Session):
         """Returns a query set of repositories covered by this installation"""
         if self.repository_service_ids is None:

--- a/helpers/exceptions.py
+++ b/helpers/exceptions.py
@@ -21,9 +21,12 @@ class OwnerWithoutValidBotError(Exception):
 
 
 class NoConfiguredAppsAvailable(Exception):
-    def __init__(self, apps_count: int, all_rate_limited: bool) -> None:
+    def __init__(
+        self, apps_count: int, rate_limited_count: int, suspended_count: int
+    ) -> None:
         self.apps_count = apps_count
-        self.all_rate_limited = all_rate_limited
+        self.rate_limited_count = rate_limited_count
+        self.suspended_count = suspended_count
 
 
 class CorruptRawReportError(Exception):


### PR DESCRIPTION
Currently we ignore if an app is suspended or not.
An app is suspended by the user.
If we select a suspended app we will fail to get an access_token for it
and eventually fail with `InstallationError`

These changes filter out suspended apps from being selected.
In case all apps for the user are suspended we skip notifications.
Other tasks would fail with `NoConfiguredAppsAvailable`.

closes https://github.com/codecov/internal-issues/issues/519

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.