### PR TITLE
enable sentry profiling

### DIFF
--- a/helpers/sentry.py
+++ b/helpers/sentry.py
@@ -33,7 +33,9 @@ def initialize_sentry() -> None:
         sample_rate=float(os.getenv("SENTRY_PERCENTAGE", 1.0)),
         environment=os.getenv("DD_ENV", "production"),
         traces_sample_rate=float(os.environ.get("SERVICES__SENTRY__SAMPLE_RATE", 1)),
-        profiles_sample_rate=float(os.environ.get("SERVICES__SENTRY__PROFILES_SAMPLE_RATE", 1)),
+        profiles_sample_rate=float(
+            os.environ.get("SERVICES__SENTRY__PROFILES_SAMPLE_RATE", 1)
+        ),
         integrations=[
             CeleryIntegration(monitor_beat_tasks=True),
             SqlalchemyIntegration(),

--- a/helpers/sentry.py
+++ b/helpers/sentry.py
@@ -33,6 +33,7 @@ def initialize_sentry() -> None:
         sample_rate=float(os.getenv("SENTRY_PERCENTAGE", 1.0)),
         environment=os.getenv("DD_ENV", "production"),
         traces_sample_rate=float(os.environ.get("SERVICES__SENTRY__SAMPLE_RATE", 1)),
+        profiles_sample_rate=float(os.environ.get("SERVICES__SENTRY__PROFILES_SAMPLE_RATE", 1)),
         integrations=[
             CeleryIntegration(monitor_beat_tasks=True),
             SqlalchemyIntegration(),

--- a/helpers/tests/unit/test_sentry.py
+++ b/helpers/tests/unit/test_sentry.py
@@ -20,6 +20,7 @@ class TestSentry(object):
             release="worker-FAKE_VERSION_FOR_YOU",
             sample_rate=1.0,
             traces_sample_rate=1.0,
+            profiles_sample_rate=1.0,
             environment="production",
             integrations=[mocker.ANY, mocker.ANY, mocker.ANY, mocker.ANY],
         )


### PR DESCRIPTION
we already have sample rates set for sentry overall + for traces. this PR also sets one for profiling

note: the way the traces/profiles sample rate env vars are named follows how `shared.config` will read configs from env vars, but neither of them is actually part of the installation yaml schema in `shared.validation`

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.