### PR TITLE
fix: only process flakes for head of pull

### DIFF
--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -411,7 +411,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                         )
                     )
                 self.trigger_process_flakes(
-                    repoid, commits_on_pr, pull_dict, current_yaml
+                    repoid, pull.head, pull_dict["head"]["branch"], current_yaml
                 )
 
             # set the rest of the commits to deleted (do not show in the UI)
@@ -476,7 +476,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         return True
 
     def trigger_process_flakes(
-        self, repoid, commits_on_pr, pull_dict, current_yaml: UserYaml
+        self, repoid: int, pull_head: str, branch: str, current_yaml: UserYaml
     ):
         # but only if flake processing is enabled for this repo
         if FLAKY_TEST_DETECTION.check_value(
@@ -484,11 +484,8 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         ) and read_yaml_field(
             current_yaml, ("test_analytics", "flake_detection"), False
         ):
-            branch = pull_dict["head"]["branch"]
             self.app.tasks[process_flakes_task_name].apply_async(
-                kwargs=dict(
-                    repo_id=repoid, commit_id_list=list(commits_on_pr), branch=branch
-                )
+                kwargs=dict(repo_id=repoid, commit_id_list=[pull_head], branch=branch)
             )
 
     def trigger_ai_pr_review(self, enriched_pull: EnrichedPull, current_yaml: UserYaml):

--- a/tasks/tests/unit/test_sync_pull.py
+++ b/tasks/tests/unit/test_sync_pull.py
@@ -90,10 +90,7 @@ class TestPullSyncTask(object):
             apply_async.assert_called_once_with(
                 kwargs=dict(
                     repo_id=repository.repoid,
-                    commit_id_list=[
-                        first_commit.commitid,
-                        third_commit.commitid,
-                    ],
+                    commit_id_list=[head_commit.commitid],
                     branch="thing",
                 )
             )
@@ -486,9 +483,8 @@ class TestPullSyncTask(object):
         repository = RepositoryFactory.create()
         dbsession.add(repository)
         dbsession.flush()
-        commits = [CommitFactory.create(repository=repository) for i in range(3)]
-        for commit in commits:
-            dbsession.add(commit)
+        commit = CommitFactory.create(repository=repository)
+        dbsession.add(commit)
         dbsession.flush()
 
         dbsession.flush()
@@ -505,18 +501,17 @@ class TestPullSyncTask(object):
                 }
             }
         )
-        commit_id_list = [commit.commitid for commit in commits]
         task.trigger_process_flakes(
             repository.repoid,
-            commit_id_list,
-            dict(head=dict(branch="main")),
+            commit.commitid,
+            "main",
             current_yaml,
         )
         if flake_detection:
             apply_async.assert_called_once_with(
                 kwargs=dict(
                     repo_id=repository.repoid,
-                    commit_id_list=commit_id_list,
+                    commit_id_list=[commit.commitid],
                     branch="main",
                 )
             )


### PR DESCRIPTION
instead of processing all the commits on a pull that was merged, it's more correct to process only the testinstances that occurred on the head of the pull, since we can only guarantee that the test instances on the head  of the pull are reflective of the state of the code on main.