### PR TITLE
chore: end sync_pull experiment

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -12,5 +12,3 @@ USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = Feature(
 PARALLEL_UPLOAD_PROCESSING_BY_REPO = Feature("parallel_upload_processing")
 
 CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER = Feature("carryforward_base_search_range")
-
-SYNC_PULL_LOCK_TIMEOUT = Feature("sync_pull_lock_timeout")

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -10,7 +10,6 @@ import sqlalchemy.orm
 from asgiref.sync import async_to_sync
 from redis.exceptions import LockError
 from shared.celery_config import notify_task_name, pulls_task_name
-from shared.metrics import Counter, Histogram
 from shared.reports.types import Change
 from shared.torngit.exceptions import TorngitClientError
 from shared.yaml import UserYaml
@@ -21,7 +20,7 @@ from database.models import Commit, Pull, Repository
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
 from helpers.metrics import metrics
-from rollouts import FLAKY_TEST_DETECTION, SYNC_PULL_LOCK_TIMEOUT
+from rollouts import FLAKY_TEST_DETECTION
 from services.comparison.changes import get_changes
 from services.redis import get_redis_connection
 from services.report import Report, ReportService
@@ -35,43 +34,6 @@ from tasks.base import BaseCodecovTask
 from tasks.process_flakes import process_flakes_task_name
 
 log = logging.getLogger(__name__)
-
-TASK_RUN_COUNT = Counter(
-    "sync_pull_task_run_count",
-    "Number of SyncPull tasks that were executed (per wait group)",
-    ["wait_group"],
-)
-
-TASK_REJECTED_COUNT = Counter(
-    "sync_pull_task_rejected_count",
-    "Number of SyncPull tasks that were _not_ executed because they couldn't get a lock (per wait group)",
-    ["wait_group"],
-)
-
-TIME_FOR_LOCK_HISTOGRAM = Histogram(
-    "sync_pull_time_to_get_lock",
-    "Distribution of the time a SyncPull task was waiting for the lock (per wait group)",
-    ["wait_group"],
-    unit="milliseconds",
-    buckets=[
-        100,
-        200,
-        300,
-        400,
-        500,
-        600,
-        700,
-        800,
-        900,
-        1000,
-        2000,
-        3000,
-        4000,
-        5000,
-        6000,
-        10000,
-    ],
-)
 
 
 class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
@@ -105,21 +67,13 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         pullid = int(pullid)
         repoid = int(repoid)
         lock_name = f"pullsync_{repoid}_{pullid}"
-        wait_for_lock_timeout_seconds, metrics_tag = SYNC_PULL_LOCK_TIMEOUT.check_value(
-            identifier=repoid, default=(5, "long_timeout")
-        )
         start_wait = time.monotonic()
         try:
             with redis_connection.lock(
                 lock_name,
                 timeout=60 * 5,
-                blocking_timeout=wait_for_lock_timeout_seconds,
+                blocking_timeout=0.5,
             ):
-                TASK_RUN_COUNT.labels(wait_group=metrics_tag).inc()
-                time_to_get_lock_seconds = time.monotonic() - start_wait
-                TIME_FOR_LOCK_HISTOGRAM.labels(wait_group=metrics_tag).observe(
-                    time_to_get_lock_seconds * 1000
-                )
                 return self.run_impl_within_lock(
                     db_session,
                     redis_connection,
@@ -133,7 +87,6 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                 "Unable to acquire PullSync lock. Not retrying because pull is being synced already",
                 extra=dict(pullid=pullid, repoid=repoid),
             )
-            TASK_REJECTED_COUNT.labels(wait_group=metrics_tag).inc()
             return {
                 "notifier_called": False,
                 "commit_updates_done": {"merged_count": 0, "soft_deleted_count": 0},


### PR DESCRIPTION
read more on the experiment: https://l.codecov.dev/KvKfel (codecov internal)

Ending the pull_sync experiment.
The conclusion is to reduce blocking timeout to 0.5s (10x smaller). This apparently can reduce up to 10% of the tasks run.

The vast majority of tasks wait less than 100ms for the lock, so there's still plenty room for delays.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.