### PR TITLE
dev: Add Ruff Perf rules to worker

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -38,7 +38,7 @@ target-version = "py312"
 [lint]
 # Currently only enabled for most F (Pyflakes), Pycodestyle (Error), 
 # PyLint (Convention, Error), and I (isort) rules: https://docs.astral.sh/ruff/rules/
-select = ["F", "E", "I", "PLC", "PLE"]
+select = ["F", "E", "I", "PLC", "PLE", "PERF"]
 ignore = ["F841", "F405", "F403", "E501", "E712"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/ruff.toml
+++ b/ruff.toml
@@ -36,7 +36,7 @@ indent-width = 4
 target-version = "py312"
 
 [lint]
-# Currently only enabled for most F (Pyflakes), Pycodestyle (Error), 
+# Currently only enabled for most F (Pyflakes), Pycodestyle (Error), PERF (Perflint),
 # PyLint (Convention, Error), and I (isort) rules: https://docs.astral.sh/ruff/rules/
 select = ["F", "E", "I", "PLC", "PLE", "PERF"]
 ignore = ["F841", "F405", "F403", "E501", "E712"]

--- a/services/flake_detection.py
+++ b/services/flake_detection.py
@@ -98,7 +98,7 @@ class DiffOutcomeDetector(BaseSymptomDetector):
 
     def detect(self):
         for test_id, commit_dict in self.state.items():
-            for _, obj in commit_dict.items():
+            for obj in commit_dict.values():
                 if str(Outcome.Pass) in obj.outcomes and (
                     str(Outcome.Failure) in obj.outcomes
                     or str(Outcome.Error) in obj.outcomes
@@ -142,7 +142,7 @@ class UnrelatedMatchesDetector(BaseSymptomDetector):
 
     def detect(self):
         for test_id, test_dict in self.state.items():
-            for _, obj in test_dict.items():
+            for obj in test_dict.values():
                 if len(obj.branches) > 1:
                     self.res[test_id] += obj.instances
         return self.res

--- a/services/notification/__init__.py
+++ b/services/notification/__init__.py
@@ -251,10 +251,11 @@ class NotificationService(object):
                 repoid=comparison.head.commit.repoid,
             ),
         )
-        notification_instances = []
-        for notifier in self.get_notifiers_instances():
-            if notifier.is_enabled():
-                notification_instances.append(notifier)
+        notification_instances = [
+            notifier
+            for notifier in self.get_notifiers_instances()
+            if notifier.is_enabled()
+        ]
         results = []
         chunk_size = 3
         for i in range(0, len(notification_instances), chunk_size):

--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -214,19 +214,22 @@ class MessageMixin(object):
             f"worker.services.notifications.notifiers.comment.section.{writer_class.name}"
         ):
             # Settings here enable failed tests results for now as a new product
-            for line in writer_class.header_lines(
-                comparison=comparison, diff=diff, settings=settings
-            ):
-                message.append(line)
-            for line in writer_class.middle_lines(
-                comparison=comparison,
-                diff=diff,
-                links=links,
-                current_yaml=current_yaml,
-            ):
-                message.append(line)
-            for line in writer_class.footer_lines():
-                message.append(line)
+            message.extend(
+                line
+                for line in writer_class.header_lines(
+                    comparison=comparison, diff=diff, settings=settings
+                )
+            )
+            message.extend(
+                line
+                for line in writer_class.middle_lines(
+                    comparison=comparison,
+                    diff=diff,
+                    links=links,
+                    current_yaml=current_yaml,
+                )
+            )
+            message.extend(line for line in writer_class.footer_lines())
 
             return message
 

--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -567,17 +567,17 @@ class FlagSectionWriter(BaseSectionWriter):
                     }
                 )
 
-        for flag in missing_flags:
-            flags.append(
-                {
-                    "name": flag,
-                    "before": base_flags[flag],
-                    "after": None,
-                    "diff": None,
-                    "carriedforward": False,
-                    "carriedforward_from": None,
-                }
-            )
+        flags.extend(
+            {
+                "name": flag,
+                "before": base_flags[flag],
+                "after": None,
+                "diff": None,
+                "carriedforward": False,
+                "carriedforward_from": None,
+            }
+            for flag in missing_flags
+        )
 
         # TODO: get icons working
         # flag_icon_url = ""

--- a/services/notification/notifiers/slack.py
+++ b/services/notification/notifiers/slack.py
@@ -27,21 +27,19 @@ class SlackNotifier(RequestsYamlBasedNotifier):
         message = self.generate_message(comparison)
         compare_dict = self.generate_compare_dict(comparison)
         color = "good" if compare_dict["notation"] in ("", "+") else "bad"
-        attachments = []
-        if self.notifier_yaml_settings.get("attachments"):
-            for attachment_type in self.notifier_yaml_settings["attachments"]:
-                if attachment_type == "sunburst":
-                    attachments.append(
-                        {
-                            "fallback": "Commit sunburst attachment",
-                            "color": color,
-                            "title": "Commit Sunburst",
-                            "title_link": get_commit_url(comparison.head.commit),
-                            "image_url": get_graph_url(
-                                comparison.head.commit, "sunburst.svg", size=100
-                            ),
-                        }
-                    )
+        attachments = [
+            {
+                "fallback": "Commit sunburst attachment",
+                "color": color,
+                "title": "Commit Sunburst",
+                "title_link": get_commit_url(comparison.head.commit),
+                "image_url": get_graph_url(
+                    comparison.head.commit, "sunburst.svg", size=100
+                ),
+            }
+            for attachment_type in self.notifier_yaml_settings.get("attachments", [])
+            if attachment_type == "sunburst"
+        ]
         return {
             "text": message,
             "author_name": "Codecov",

--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -132,7 +132,7 @@ class StatusNotifier(AbstractBaseNotifier):
             flag_configuration = self.current_yaml.get_flag_configuration(flag)
             if flag_configuration and head_report and head_report.sessions:
                 number_of_occ = 0
-                for sid, session in head_report.sessions.items():
+                for session in head_report.sessions.values():
                     if session.flags and flag in session.flags:
                         number_of_occ += 1
                 needed_builds = flag_configuration.get("after_n_builds", 0)

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -805,11 +805,11 @@ class ReportService(BaseReportService):
                     ),
                 )
                 return Report()
-            flags_to_carryforward = []
-            report_flags = parent_report.get_flag_names()
-            for flag_name in report_flags:
-                if self.current_yaml.flag_has_carryfoward(flag_name):
-                    flags_to_carryforward.append(flag_name)
+            flags_to_carryforward = [
+                flag_name
+                for flag_name in parent_report.get_flag_names()
+                if self.current_yaml.flag_has_carryfoward(flag_name)
+            ]
             if not flags_to_carryforward:
                 return Report()
             paths_to_carryforward = get_paths_from_flags(

--- a/services/report/languages/jetbrainsxml.py
+++ b/services/report/languages/jetbrainsxml.py
@@ -64,7 +64,7 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                     ),
                 )
 
-    for fid, content in file_by_id.items():
+    for content in file_by_id.values():
         report_builder_session.append(content)
 
     return report_builder_session.output_report()

--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List
 
 from asgiref.sync import async_to_sync
 from shared.celery_config import compute_comparison_task_name

--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -97,7 +97,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
     def create_or_update_flag_comparisons(
         self,
         db_session,
-        head_report_flags: List[Flag],
+        head_report_flags: dict[str, Flag],
         comparison: CompareCommit,
         comparison_proxy: ComparisonProxy,
     ):

--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -102,7 +102,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
         comparison_proxy: ComparisonProxy,
     ):
         repository_id = comparison.compare_commit.repository.repoid
-        for flag_name, _ in head_report_flags.items():
+        for flag_name in head_report_flags.keys():
             totals = self.get_flag_comparison_totals(flag_name, comparison_proxy)
             repositoryflag = (
                 db_session.query(RepositoryFlag)

--- a/tasks/tests/unit/test_preprocess_upload.py
+++ b/tasks/tests/unit/test_preprocess_upload.py
@@ -153,7 +153,7 @@ class TestPreProcessUpload(object):
                 "diff_totals": None,
             },
         ]
-        for sess_id, session in sample_report.sessions.items():
+        for sess_id in sample_report.sessions.keys():
             upload = (
                 dbsession.query(Upload)
                 .filter_by(report_id=commit.report.id_, order_number=sess_id)

--- a/tasks/tests/unit/test_sync_repos_task.py
+++ b/tasks/tests/unit/test_sync_repos_task.py
@@ -555,17 +555,16 @@ class TestSyncReposTaskUnit(object):
 
         # Three of the four repositories we can see are already in the database.
         # Will we update `using_integration` correctly?
-        preseeded_repos = []
-        for repo in mock_repos[:-1]:
-            preseeded_repos.append(
-                RepositoryFactory.create(
-                    private=repo["repo"]["private"],
-                    name=repo["repo"]["name"],
-                    using_integration=repo["_using_integration"],
-                    service_id=repo["repo"]["service_id"],
-                    owner=user,
-                )
+        preseeded_repos = [
+            RepositoryFactory.create(
+                private=repo["repo"]["private"],
+                name=repo["repo"]["name"],
+                using_integration=repo["_using_integration"],
+                service_id=repo["repo"]["service_id"],
+                owner=user,
             )
+            for repo in mock_repos[:-1]
+        ]
 
         for repo in preseeded_repos:
             dbsession.add(repo)
@@ -809,17 +808,16 @@ class TestSyncReposTaskUnit(object):
 
         # Three of the four repositories we can see are already in the database.
         # Will we update `using_integration` correctly?
-        preseeded_repos = []
-        for repo in mock_repos[:-1]:
-            preseeded_repos.append(
-                RepositoryFactory.create(
-                    private=repo["repo"]["private"],
-                    name=repo["repo"]["name"],
-                    using_integration=repo["_using_integration"],
-                    service_id=repo["repo"]["service_id"],
-                    owner=user,
-                )
+        preseeded_repos = [
+            RepositoryFactory.create(
+                private=repo["repo"]["private"],
+                name=repo["repo"]["name"],
+                using_integration=repo["_using_integration"],
+                service_id=repo["repo"]["service_id"],
+                owner=user,
             )
+            for repo in mock_repos[:-1]
+        ]
 
         for repo in preseeded_repos:
             dbsession.add(repo)
@@ -908,17 +906,16 @@ class TestSyncReposTaskUnit(object):
             mock_repos
         ]
 
-        preseeded_repos = []
-        for repo in mock_repos[:-1]:
-            preseeded_repos.append(
-                RepositoryFactory.create(
-                    private=repo["repo"]["private"],
-                    name=repo["repo"]["name"],
-                    using_integration=repo["_using_integration"],
-                    service_id=repo["repo"]["service_id"],
-                    owner=user,
-                )
+        preseeded_repos = [
+            RepositoryFactory.create(
+                private=repo["repo"]["private"],
+                name=repo["repo"]["name"],
+                using_integration=repo["_using_integration"],
+                service_id=repo["repo"]["service_id"],
+                owner=user,
             )
+            for repo in mock_repos[:-1]
+        ]
 
         for repo in preseeded_repos:
             dbsession.add(repo)


### PR DESCRIPTION
### Purpose/Motivation

Part of the [lint enhancement epic,](https://github.com/codecov/engineering-team/issues/1716) this PR aims to add the Perflint PERF rules, with the fixes majorly being around creating list comprehensions or using .keys() or .values() instead of .items() for dictionaries

These can be found here:
- https://docs.astral.sh/ruff/rules/#perflint-perf


### Links to relevant tickets

Closes https://github.com/codecov/engineering-team/issues/2050

### What does this PR do?

This PR adds the rules listed above and fixes any errors that stemmed from them.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.