### PR TITLE
Add db_session to ActivateAccountUserTask

### DIFF
--- a/tasks/activate_account_user.py
+++ b/tasks/activate_account_user.py
@@ -2,6 +2,7 @@ import logging
 
 from shared.celery_config import activate_account_user_task_name
 from shared.django_apps.codecov_auth.models import Account, Owner
+from sqlalchemy.orm.session import Session
 
 from app import celery_app
 from tasks.base import BaseCodecovTask
@@ -12,6 +13,7 @@ log = logging.getLogger(__name__)
 class ActivateAccountUserTask(BaseCodecovTask, name=activate_account_user_task_name):
     def run_impl(
         self,
+        _db_session: Session,
         *,
         user_ownerid: int,
         org_ownerid: int,


### PR DESCRIPTION
This field is needed to `run_impl` properly. See Sentry error: https://codecov.sentry.io/share/issue/62a996975a424922b6ceb9d0d1b91e47/


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.