### PR TITLE
Update Rust toolchain to latest stable, using the minimal profile

### DIFF
--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -3,12 +3,6 @@ ARG PYTHON_IMAGE=python:3.12.2-slim-bookworm
 # BUILD STAGE
 FROM $PYTHON_IMAGE as build
 
-# Pinning a specific nightly version so that builds don't suddenly break if a
-# "this feature is now stabilized" warning is promoted to an error or something.
-# We would like to keep up with nightly if we can.
-ARG RUST_VERSION=nightly-2023-02-22
-ENV RUST_VERSION=${RUST_VERSION}
-
 RUN apt-get update
 RUN apt-get install -y \
     build-essential \
@@ -19,8 +13,11 @@ RUN apt-get install -y \
     curl
 
 # Install Rust
+ARG RUST_VERSION=stable
+ENV RUST_VERSION=${RUST_VERSION}
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
-    | bash -s -- -y --default-toolchain $RUST_VERSION
+    | bash -s -- -y --profile minimal --default-toolchain $RUST_VERSION
 ENV PATH="/root/.cargo/bin:$PATH"
 
 COPY requirements.txt /


### PR DESCRIPTION
If I am not mistaken, `test-results-parser` is the only Rust package that is built from source, as `codecov-ribs` is consumed as a prebuilt binary from PyPI.
As `test-results-parser` does not use any nightly features, this switches to the latest `stable` instead of pulling in an outdated nightly.

Using the `minimal` profile here means that clippy, rustfmt or other tools are not being installed, speedings things up slightly.

---

Going forward, I would recommend also consuming `test-results-parser` via prebuilt packages, in which case no Rust compiler would be needed in this docker image at all.