### PR TITLE
fix: Invalid Escape Sequence on Cobertura parser

### DIFF
--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -97,7 +97,7 @@ def from_xml(xml, report_builder_session: ReportBuilderSession) -> Report:
                 condition_coverage = _line.get("condition-coverage", "")
                 if (
                     branch.lower() == "true"
-                    and re.search("\(\d+\/\d+\)", condition_coverage) is not None
+                    and re.search(r"\(\d+\/\d+\)", condition_coverage) is not None
                 ):
                     coverage = condition_coverage.split(" ", 1)[1][1:-1]  # 1/2
                     _type = CoverageType.branch


### PR DESCRIPTION
Fixes invalid escape sequence...

Related logs: https://console.cloud.google.com/logs/query;query=severity%3DERROR%0A%22worker%2Fservices%2Freport%2Flanguages%2Fcobertura.py%22;pinnedLogId=2024-04-08T19:18:39.852000850Z%2Fgt0cscxqclw9v94d;summaryFields=jsonPayload%252Fusername:false:32:beginning;cursorTimestamp=2024-07-29T22:46:07.456996759Z;duration=P1D?project=genuine-polymer-165712&authuser=1&rapt=AEjHL4M3xuoV-WET7swbpc94gTPEq8p_N0PpuZcCeMOHTb153SKBFmDHhEwYcsqLEueQ06MpwogKmAbmC2EUok6nmXE0zZAHzZQ1RAngRlWdyp8_FqIvqZI

Roughly ~6k instances a day since who knows when

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.