### PR TITLE
Adding flake8 bugbear and flake8 builtins to available linters for Ruff

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -38,7 +38,7 @@ target-version = "py312"
 [lint]
 # Currently only enabled for most F (Pyflakes), Pycodestyle (Error), PERF (Perflint),
 # PyLint (Convention, Error), and I (isort) rules: https://docs.astral.sh/ruff/rules/
-select = ["F", "E", "I", "PLC", "PLE", "PERF"]
+select = ["F", "E", "I", "PLC", "PLE", "PERF", "B", A"]
 ignore = ["F841", "F405", "F403", "E501", "E712"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/ruff.toml
+++ b/ruff.toml
@@ -38,7 +38,7 @@ target-version = "py312"
 [lint]
 # Currently only enabled for most F (Pyflakes), Pycodestyle (Error), PERF (Perflint),
 # PyLint (Convention, Error), and I (isort) rules: https://docs.astral.sh/ruff/rules/
-select = ["F", "E", "I", "PLC", "PLE", "PERF", "B", A"]
+select = ["F", "E", "I", "PLC", "PLE", "PERF", "B", "A"]
 ignore = ["F841", "F405", "F403", "E501", "E712"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.


### PR DESCRIPTION
Maybe we catch more errors - Useful for our static analysis research.

Docs can are linked below to serve as a guide on what types of issues this PR will hopefyully help catch

- https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
- https://docs.astral.sh/ruff/rules/#flake8-builtins-a

Edits on this PR are enabled.


### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.