### PR TITLE
add metric for overall report size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ background_app/.report.json
 
 # Pycharm/Intellij
 .idea/
+
+.sl
+.git

--- a/services/report/prometheus_metrics.py
+++ b/services/report/prometheus_metrics.py
@@ -1,0 +1,27 @@
+from shared.metrics import Histogram
+
+KiB = 1024
+MiB = KiB * KiB
+RAW_UPLOAD_SIZE = Histogram(
+    "worker_services_report_raw_upload_size",
+    "Size (in bytes) of a raw upload (which may contain several raw reports)",
+    ["version"],
+    buckets=[
+        100 * KiB,
+        500 * KiB,
+        1 * MiB,
+        5 * MiB,
+        10 * MiB,
+        50 * MiB,
+        100 * MiB,
+        200 * MiB,
+        500 * MiB,
+    ],
+)
+
+RAW_UPLOAD_RAW_REPORT_COUNT = Histogram(
+    "worker_services_report_raw_upload_raw_report_count",
+    "Number of raw coverage files contained in a raw upload",
+    ["version"],
+    buckets=[1, 5, 10, 20, 50],
+)


### PR DESCRIPTION
arpad added one for the individual coverage files inside of an upload in https://github.com/codecov/worker/pull/574. this PR does the same for the overall upload

an upload contains one or more coverage files, but also path fixes and the output of `git ls-files`. so it can be much larger than just the sum of its coverage files. also those coverage files can be b64-encoded which affects the size too

(the .gitignore changes help me use Sapling with this repo and aren't important)