### PR TITLE
Gracefully handle nr=0 in JaCoCo report

### DIFF
--- a/services/report/languages/jacoco.py
+++ b/services/report/languages/jacoco.py
@@ -1,3 +1,4 @@
+import logging
 import typing
 from collections import defaultdict
 
@@ -13,6 +14,8 @@ from services.report.report_builder import (
     ReportBuilderSession,
 )
 from services.yaml import read_yaml_field
+
+log = logging.getLogger(__name__)
 
 
 class JacocoProcessor(BaseLanguageProcessor):
@@ -125,16 +128,21 @@ def from_xml(xml, report_builder_session: ReportBuilderSession):
                     cov = 1
 
                 ln = int(line["nr"])
-                complexity = method_complixity.get(ln)
-                if complexity:
-                    coverage_type = CoverageType.method
-                # add line to file
-                report_file_obj[ln] = report_builder_session.create_coverage_line(
-                    filename,
-                    coverage=cov,
-                    coverage_type=coverage_type,
-                    complexity=complexity,
-                )
+                if ln > 0:
+                    complexity = method_complixity.get(ln)
+                    if complexity:
+                        coverage_type = CoverageType.method
+                    # add line to file
+                    report_file_obj[ln] = report_builder_session.create_coverage_line(
+                        filename,
+                        coverage=cov,
+                        coverage_type=coverage_type,
+                        complexity=complexity,
+                    )
+                else:
+                    log.warning(
+                        f"Jacoco report has an invalid coverage line: nr={ln}. Skipping processing line."
+                    )
 
             # append file to report
             report_builder_session.append(report_file_obj)


### PR DESCRIPTION
JaCoCo currently sometimes output line 0 for coverage report, which is a confusing behaviour. This occurs primarily when the Kotlin compiler cannot properly resolve synthetic functions. Although this should ultimately be fixed in the Kotlin-JaCoCo report generation, we're just going to skip the line to allow for the rest of the report processing to work.

ref: https://github.com/codecov/internal-issues/issues/504

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.