### PR TITLE
add metrics for report_json and chunks file sizes

### DIFF
--- a/helpers/metrics.py
+++ b/helpers/metrics.py
@@ -1,3 +1,6 @@
 from statsd.defaults.env import statsd
 
+KiB = 1024
+MiB = KiB * KiB
+
 metrics = statsd

--- a/services/report/prometheus_metrics.py
+++ b/services/report/prometheus_metrics.py
@@ -1,7 +1,7 @@
 from shared.metrics import Histogram
 
-KiB = 1024
-MiB = KiB * KiB
+from helpers.metrics import KiB, MiB
+
 RAW_UPLOAD_SIZE = Histogram(
     "worker_services_report_raw_upload_size",
     "Size (in bytes) of a raw upload (which may contain several raw reports)",

--- a/services/report/report_processor.py
+++ b/services/report/report_processor.py
@@ -11,6 +11,7 @@ from shared.metrics import Counter, Histogram
 from shared.reports.resources import Report
 
 from helpers.exceptions import CorruptRawReportError
+from helpers.metrics import KiB, MiB
 from services.report.languages import (
     BullseyeProcessor,
     CloverProcessor,
@@ -55,8 +56,6 @@ RAW_REPORT_PROCESSOR_RUNTIME_SECONDS = Histogram(
     buckets=[0.05, 0.1, 0.5, 1, 2, 5, 7.5, 10, 15, 20, 30, 60, 120, 180, 300, 600, 900],
 )
 
-KiB = 1024
-MiB = KiB * KiB
 RAW_REPORT_SIZE = Histogram(
     "worker_services_report_raw_report_size",
     "Size (in bytes) of a raw report",

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -14,6 +14,7 @@ from shared.celery_config import (
     timeseries_save_commit_measurements_task_name,
     upload_finisher_task_name,
 )
+from shared.metrics import Histogram
 from shared.reports.resources import Report
 from shared.storage.exceptions import FileNotInStorageError
 from shared.yaml import UserYaml
@@ -24,9 +25,9 @@ from database.models import Commit, Pull
 from helpers.checkpoint_logger import _kwargs_key
 from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import UploadFlow
-from helpers.metrics import metrics
+from helpers.metrics import KiB, MiB, metrics
 from rollouts import PARALLEL_UPLOAD_PROCESSING_BY_REPO
-from services.archive import MinioEndpoints
+from services.archive import ArchiveService, MinioEndpoints
 from services.comparison import get_or_create_comparison
 from services.redis import get_redis_connection
 from services.report import ReportService
@@ -40,6 +41,34 @@ log = logging.getLogger(__name__)
 
 regexp_ci_skip = re.compile(r"\[(ci|skip| |-){3,}\]")
 merged_pull = re.compile(r".*Merged in [^\s]+ \(pull request \#(\d+)\).*").match
+
+PYREPORT_REPORT_JSON_SIZE = Histogram(
+    "worker_tasks_upload_finisher_report_json_size",
+    "Size (in bytes) of a report's report_json measured in `UploadFinisherTask`. Be aware: if we get more uploads for the same commit after `UploadFinisherTask` finishes, we will emit this metric again without deleting the first value. As a result, aggregate metrics will be biased towards smaller sizes.",
+    buckets=[
+        10 * KiB,
+        100 * KiB,
+        500 * KiB,
+        1 * MiB,
+        10 * MiB,
+        100 * MiB,
+        500 * MiB,
+    ],
+)
+
+PYREPORT_CHUNKS_FILE_SIZE = Histogram(
+    "worker_tasks_upload_finisher_chunks_file_size",
+    "Size (in bytes) of a report's chunks file measured in `UploadFinisherTask`. Be aware: if we get more uploads for the same commit after `UploadFinisherTask` finishes, we will emit this metric again without deleting the first value. As a result, aggregate metrics will be biased towards smaller sizes.",
+    buckets=[
+        100 * KiB,
+        500 * KiB,
+        1 * MiB,
+        10 * MiB,
+        100 * MiB,
+        500 * MiB,
+        1000 * MiB,
+    ],
+)
 
 
 class ShouldCallNotifResult(Enum):
@@ -207,6 +236,30 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 ),
             )
 
+    def _emit_report_size_metrics(self, commit: Commit, report_code: str):
+        # This is only used to emit chunks/report_json size metrics. We have to
+        # do it here instead of in UploadProcessorTask where the report is
+        # normally saved because that task saves after every upload and can't
+        # tell when the report is final.
+        try:
+            if commit.report_json:
+                report_json_size = len(json.dumps(commit.report_json))
+                archive_service = ArchiveService(commit.repository)
+                chunks_size = len(
+                    archive_service.read_chunks(commit.commitid, report_code)
+                )
+
+                PYREPORT_REPORT_JSON_SIZE.observe(report_json_size)
+                PYREPORT_CHUNKS_FILE_SIZE.observe(chunks_size)
+        except Exception as e:
+            log.exception(
+                "Failed to emit report size metrics",
+                extra=dict(
+                    repoid=commit.repoid,
+                    commit=commit.commitid,
+                ),
+            )
+
     def finish_reports_processing(
         self,
         db_session,
@@ -219,6 +272,8 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         log.debug("In finish_reports_processing for commit: %s" % commit)
         commitid = commit.commitid
         repoid = commit.repoid
+
+        self._emit_report_size_metrics(commit, report_code)
 
         # always notify, let the notify handle if it should submit
         notifications_called = False


### PR DESCRIPTION
like https://github.com/codecov/worker/pull/583 and https://github.com/codecov/worker/pull/574

arpad's metrics are already flowing. when this and #583 are deployed, i'll create a dashboard or a few showing p50/p75/p95 for:
- raw upload size + the number of coverage files contained in a single upload
- size of each individual coverage file inside an upload
- the above, grouped by format (cobertura, lcov, jacoco...)
- report_json size and chunks file size