### PR TITLE
Update `shared`, fixing `BundleAnalysisReport` connection leak

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-https://github.com/codecov/shared/archive/c9e07f583a8217a2f61b176a0e15fa6dcce5bc34.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/70b7fe9e8cc75632de6a273843d0c013f02c515c.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz#egg=test-results-parser
 boto3>=1.34

--- a/requirements.txt
+++ b/requirements.txt
@@ -370,7 +370,7 @@ sentry-sdk==1.40.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/c9e07f583a8217a2f61b176a0e15fa6dcce5bc34.tar.gz
+shared @ https://github.com/codecov/shared/archive/70b7fe9e8cc75632de6a273843d0c013f02c515c.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
This primarily pulls in https://github.com/codecov/shared/pull/309, which fixes an error related to `BundleAnalysisReport` keeping a SQLite connection open without properly closing it.