### PR TITLE
Clean up `UploadXXX` tasks

### DIFF
--- a/tasks/tests/unit/test_preprocess_upload.py
+++ b/tasks/tests/unit/test_preprocess_upload.py
@@ -48,11 +48,11 @@ class TestPreProcessUpload(object):
             }
         }
         mocker.patch(
-            "tasks.preprocess_upload.fetch_commit_yaml_from_provider",
+            "services.repository.fetch_commit_yaml_from_provider",
             return_value=commit_yaml,
         )
         mock_save_commit = mocker.patch(
-            "tasks.preprocess_upload.save_repo_yaml_to_database_if_needed"
+            "services.repository.save_repo_yaml_to_database_if_needed"
         )
         mocker.patch.object(PreProcessUpload, "_is_running", return_value=False)
 

--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -11,7 +11,7 @@ from helpers.checkpoint_logger import CheckpointLogger, _kwargs_key
 from helpers.checkpoint_logger.flows import UploadFlow
 from tasks.upload_finisher import (
     ReportService,
-    ShouldCallNotifResult,
+    ShouldCallNotifyResult,
     UploadFinisherTask,
 )
 
@@ -225,7 +225,7 @@ class TestUploadFinisherTask(object):
             UploadFinisherTask().should_call_notifications(
                 commit, commit_yaml, processing_results, None
             )
-            == ShouldCallNotifResult.NOTIFY
+            == ShouldCallNotifyResult.NOTIFY
         )
 
     def test_should_call_notifications_local_upload(self, dbsession):
@@ -244,7 +244,7 @@ class TestUploadFinisherTask(object):
             UploadFinisherTask().should_call_notifications(
                 commit, commit_yaml, processing_results, "local_report1"
             )
-            == ShouldCallNotifResult.DO_NOT_NOTIFY
+            == ShouldCallNotifyResult.DO_NOT_NOTIFY
         )
 
     def test_should_call_notifications_manual_trigger(self, dbsession):
@@ -263,7 +263,7 @@ class TestUploadFinisherTask(object):
             UploadFinisherTask().should_call_notifications(
                 commit, commit_yaml, processing_results, None
             )
-            == ShouldCallNotifResult.DO_NOT_NOTIFY
+            == ShouldCallNotifyResult.DO_NOT_NOTIFY
         )
 
     def test_should_call_notifications_manual_trigger_off(self, dbsession):
@@ -286,14 +286,14 @@ class TestUploadFinisherTask(object):
             UploadFinisherTask().should_call_notifications(
                 commit, commit_yaml, processing_results, None
             )
-            == ShouldCallNotifResult.NOTIFY
+            == ShouldCallNotifyResult.NOTIFY
         )
 
     @pytest.mark.parametrize(
         "notify_error,result",
         [
-            (True, ShouldCallNotifResult.NOTIFY_ERROR),
-            (False, ShouldCallNotifResult.DO_NOT_NOTIFY),
+            (True, ShouldCallNotifyResult.NOTIFY_ERROR),
+            (False, ShouldCallNotifyResult.DO_NOT_NOTIFY),
         ],
     )
     def test_should_call_notifications_no_successful_reports(
@@ -351,7 +351,7 @@ class TestUploadFinisherTask(object):
             UploadFinisherTask().should_call_notifications(
                 commit, commit_yaml, processing_results, None
             )
-            == ShouldCallNotifResult.DO_NOT_NOTIFY
+            == ShouldCallNotifyResult.DO_NOT_NOTIFY
         )
 
     def test_should_call_notifications_more_than_enough_builds(self, dbsession, mocker):
@@ -380,7 +380,7 @@ class TestUploadFinisherTask(object):
             UploadFinisherTask().should_call_notifications(
                 commit, commit_yaml, processing_results, None
             )
-            == ShouldCallNotifResult.NOTIFY
+            == ShouldCallNotifyResult.NOTIFY
         )
 
     def test_finish_reports_processing(self, dbsession, mocker):

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -26,7 +26,7 @@ from tasks.upload_processor import UploadProcessorTask
 here = Path(__file__)
 
 
-def test_default_acks_late():
+def test_default_acks_late() -> None:
     task = UploadProcessorTask()
     # task.acks_late is defined at import time, so it's difficult to test
     # This test ensures that, in the absence of config the default is False

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -727,7 +727,7 @@ class TestUploadProcessorTask(object):
             report_service=ReportService({"codecov": {"max_report_age": False}}),
             commit=commit,
             report=false_report,
-            upload_obj=upload,
+            upload=upload,
         )
         expected_result = {
             "error": {
@@ -780,7 +780,7 @@ class TestUploadProcessorTask(object):
                 report_service=ReportService({"codecov": {"max_report_age": False}}),
                 commit=commit,
                 report=false_report,
-                upload_obj=upload,
+                upload=upload,
             )
         mock_schedule_for_later_try.assert_called_with()
 

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -303,7 +303,7 @@ class TestUploadProcessorTask(object):
 
     @pytest.mark.django_db(databases={"default"})
     def test_upload_processor_call_with_upload_obj(
-        self, mocker, mock_configuration, dbsession, mock_storage, mock_redis
+        self, mocker, mock_configuration, dbsession, mock_storage
     ):
         mocker.patch.object(
             USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID,
@@ -346,7 +346,6 @@ class TestUploadProcessorTask(object):
         mocked_3.send_task.return_value = True
         result = UploadProcessorTask().process_impl_within_lock(
             db_session=dbsession,
-            redis_connection=mock_redis,
             previous_results={},
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -510,9 +509,7 @@ class TestUploadProcessorTask(object):
     ):
         mocked_1 = mocker.patch.object(ArchiveService, "read_chunks")
         mocked_1.return_value = None
-        mocked_2 = mocker.patch.object(
-            UploadProcessorTask, "do_process_individual_report"
-        )
+        mocked_2 = mocker.patch.object(ReportService, "build_report_from_raw_content")
         mocked_2.side_effect = Exception("first", "aruba", "digimon")
         # Mocking retry to also raise the exception so we can see how it is called
         mocked_3 = mocker.patch.object(UploadProcessorTask, "retry")
@@ -548,9 +545,7 @@ class TestUploadProcessorTask(object):
                 arguments_list=redis_queue,
             )
         assert exc.value.args == ("first", "aruba", "digimon")
-        mocked_2.assert_called_with(
-            mocker.ANY, mocker.ANY, upload=upload, parallel_idx=mocker.ANY
-        )
+        mocked_2.assert_called_with(mocker.ANY, upload=upload, parallel_idx=mocker.ANY)
         assert upload.state_id == UploadState.ERROR.db_id
         assert upload.state == "error"
         assert not mocked_3.called

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -166,19 +166,19 @@ class TestUploadTaskIntegration(object):
             .first()
         )
         t1 = upload_processor_task.s(
-                repoid=commit.repoid,
-                commitid="abf6d4df662c47e32460020ab14abf9303581429",
-                commit_yaml={"codecov": {"max_report_age": "1y ago"}},
-                arguments_list=[
-                    {
-                        "url": url,
-                        "build": "some_random_build",
-                        "upload_pk": first_session.id,
-                    }
-                ],
-                report_code=None,
-                in_parallel=False,
-                is_final=True,
+            repoid=commit.repoid,
+            commitid="abf6d4df662c47e32460020ab14abf9303581429",
+            commit_yaml={"codecov": {"max_report_age": "1y ago"}},
+            arguments_list=[
+                {
+                    "url": url,
+                    "build": "some_random_build",
+                    "upload_pk": first_session.id,
+                }
+            ],
+            report_code=None,
+            in_parallel=False,
+            is_final=True,
         )
         kwargs = dict(
             repoid=commit.repoid,
@@ -255,19 +255,19 @@ class TestUploadTaskIntegration(object):
         assert len(uploads) == 1
         upload = dbsession.query(Upload).filter_by(report_id=commit_report.id).first()
         processor_sig = bundle_analysis_processor_task.s(
-                repoid=commit.repoid,
-                commitid=commit.commitid,
-                commit_yaml={"codecov": {"max_report_age": "1y ago"}},
-                params={
-                    "url": storage_path,
-                    "build_code": "some_random_build",
-                    "upload_pk": upload.id,
-                },
+            repoid=commit.repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": "1y ago"}},
+            params={
+                "url": storage_path,
+                "build_code": "some_random_build",
+                "upload_pk": upload.id,
+            },
         )
         notify_sig = bundle_analysis_notify_task.s(
-                repoid=commit.repoid,
-                commitid=commit.commitid,
-                commit_yaml={"codecov": {"max_report_age": "1y ago"}},
+            repoid=commit.repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": "1y ago"}},
         )
         chain.assert_called_with([processor_sig, notify_sig])
 
@@ -319,17 +319,17 @@ class TestUploadTaskIntegration(object):
         assert len(uploads) == 1
         upload = dbsession.query(Upload).filter_by(report_id=commit_report.id).first()
         processor_sig = test_results_processor_task.s(
-                repoid=commit.repoid,
-                commitid=commit.commitid,
-                commit_yaml={"codecov": {"max_report_age": "1y ago"}},
-                arguments_list=[
-                    {
-                        "url": storage_path,
-                        "build_code": "some_random_build",
-                        "upload_pk": upload.id,
-                    }
-                ],
-                report_code=None,
+            repoid=commit.repoid,
+            commitid=commit.commitid,
+            commit_yaml={"codecov": {"max_report_age": "1y ago"}},
+            arguments_list=[
+                {
+                    "url": storage_path,
+                    "build_code": "some_random_build",
+                    "upload_pk": upload.id,
+                }
+            ],
+            report_code=None,
         )
         kwargs = dict(
             repoid=commit.repoid,
@@ -560,42 +560,42 @@ class TestUploadTaskIntegration(object):
         assert commit.message == "dsidsahdsahdsa"
         assert commit.parent_commit_id is None
         t1 = upload_processor_task.s(
-                repoid=commit.repoid,
-                commitid="abf6d4df662c47e32460020ab14abf9303581429",
-                commit_yaml={"codecov": {"max_report_age": "1y ago"}},
-                arguments_list=[
-                    {"build": "part1", "url": "someurl1", "upload_pk": mocker.ANY},
-                    {"build": "part2", "url": "someurl2", "upload_pk": mocker.ANY},
-                    {"build": "part3", "url": "someurl3", "upload_pk": mocker.ANY},
-                ],
-                report_code=None,
-                in_parallel=False,
-                is_final=False,
+            repoid=commit.repoid,
+            commitid="abf6d4df662c47e32460020ab14abf9303581429",
+            commit_yaml={"codecov": {"max_report_age": "1y ago"}},
+            arguments_list=[
+                {"build": "part1", "url": "someurl1", "upload_pk": mocker.ANY},
+                {"build": "part2", "url": "someurl2", "upload_pk": mocker.ANY},
+                {"build": "part3", "url": "someurl3", "upload_pk": mocker.ANY},
+            ],
+            report_code=None,
+            in_parallel=False,
+            is_final=False,
         )
         t2 = upload_processor_task.s(
-                repoid=commit.repoid,
-                commitid="abf6d4df662c47e32460020ab14abf9303581429",
-                commit_yaml={"codecov": {"max_report_age": "1y ago"}},
-                arguments_list=[
-                    {"build": "part4", "url": "someurl4", "upload_pk": mocker.ANY},
-                    {"build": "part5", "url": "someurl5", "upload_pk": mocker.ANY},
-                    {"build": "part6", "url": "someurl6", "upload_pk": mocker.ANY},
-                ],
-                report_code=None,
-                in_parallel=False,
-                is_final=False,
+            repoid=commit.repoid,
+            commitid="abf6d4df662c47e32460020ab14abf9303581429",
+            commit_yaml={"codecov": {"max_report_age": "1y ago"}},
+            arguments_list=[
+                {"build": "part4", "url": "someurl4", "upload_pk": mocker.ANY},
+                {"build": "part5", "url": "someurl5", "upload_pk": mocker.ANY},
+                {"build": "part6", "url": "someurl6", "upload_pk": mocker.ANY},
+            ],
+            report_code=None,
+            in_parallel=False,
+            is_final=False,
         )
         t3 = upload_processor_task.s(
-                repoid=commit.repoid,
-                commitid="abf6d4df662c47e32460020ab14abf9303581429",
-                commit_yaml={"codecov": {"max_report_age": "1y ago"}},
-                arguments_list=[
-                    {"build": "part7", "url": "someurl7", "upload_pk": mocker.ANY},
-                    {"build": "part8", "url": "someurl8", "upload_pk": mocker.ANY},
-                ],
-                report_code=None,
-                in_parallel=False,
-                is_final=True,
+            repoid=commit.repoid,
+            commitid="abf6d4df662c47e32460020ab14abf9303581429",
+            commit_yaml={"codecov": {"max_report_age": "1y ago"}},
+            arguments_list=[
+                {"build": "part7", "url": "someurl7", "upload_pk": mocker.ANY},
+                {"build": "part8", "url": "someurl8", "upload_pk": mocker.ANY},
+            ],
+            report_code=None,
+            in_parallel=False,
+            is_final=True,
         )
         kwargs = dict(
             repoid=commit.repoid,
@@ -1101,13 +1101,13 @@ class TestUploadTaskUnit(object):
         )
         assert result == mocked_chain.return_value.apply_async.return_value
         t1 = upload_processor_task.s(
-                repoid=commit.repoid,
-                commitid=commit.commitid,
-                commit_yaml=commit_yaml.to_dict(),
-                arguments_list=argument_list,
-                report_code=None,
-                in_parallel=False,
-                is_final=True,
+            repoid=commit.repoid,
+            commitid=commit.commitid,
+            commit_yaml=commit_yaml.to_dict(),
+            arguments_list=argument_list,
+            report_code=None,
+            in_parallel=False,
+            is_final=True,
         )
         t2 = upload_finisher_task.signature(
             kwargs={

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -391,7 +391,6 @@ class TestUploadTaskIntegration(object):
             "tasks.upload.possibly_update_commit_from_provider_info", return_value=True
         )
         mocker.patch.object(UploadTask, "possibly_setup_webhooks", return_value=True)
-        mocker.patch.object(UploadTask, "fetch_commit_yaml_and_possibly_store")
         mock_configuration.set_params({"setup": {"upload_processing_delay": 1000}})
         mocker.patch.object(UploadTask, "app", celery_app)
         redis_queue = [
@@ -438,7 +437,6 @@ class TestUploadTaskIntegration(object):
             "tasks.upload.possibly_update_commit_from_provider_info", return_value=True
         )
         mocker.patch.object(UploadTask, "possibly_setup_webhooks", return_value=True)
-        mocker.patch.object(UploadTask, "fetch_commit_yaml_and_possibly_store")
         commit = CommitFactory.create(
             parent_commit_id=None,
             message="",
@@ -454,7 +452,6 @@ class TestUploadTaskIntegration(object):
         mock_configuration.set_params({"setup": {"upload_processing_delay": 1000}})
         mocker.patch.object(UploadTask, "app", celery_app)
         mocker.patch.object(UploadTask, "possibly_setup_webhooks", return_value=True)
-        mocker.patch.object(UploadTask, "fetch_commit_yaml_and_possibly_store")
         mocked_chain = mocker.patch("tasks.upload.chain")
         redis_queue = [
             {"build": "part1", "url": "someurl1"},
@@ -488,7 +485,6 @@ class TestUploadTaskIntegration(object):
             "tasks.upload.possibly_update_commit_from_provider_info", return_value=True
         )
         mocker.patch.object(UploadTask, "possibly_setup_webhooks", return_value=True)
-        mocker.patch.object(UploadTask, "fetch_commit_yaml_and_possibly_store")
         mocked_chain = mocker.patch("tasks.upload.chain")
         redis_queue = [
             {"build": "part1", "url": "someurl1"},
@@ -695,8 +691,8 @@ class TestUploadTaskIntegration(object):
     ):
         mocked_1 = mocker.patch.object(UploadTask, "schedule_task")
         mocker.patch.object(UploadTask, "app", celery_app)
-        mocked_fetch_yaml = mocker.patch.object(
-            UploadTask, "fetch_commit_yaml_and_possibly_store"
+        mocked_fetch_yaml = mocker.patch(
+            "services.repository.fetch_commit_yaml_and_possibly_store"
         )
         redis_queue = [
             {"build": "part1", "url": "url1"},
@@ -750,8 +746,8 @@ class TestUploadTaskIntegration(object):
     ):
         mocked_1 = mocker.patch.object(UploadTask, "schedule_task")
         mocker.patch.object(UploadTask, "app", celery_app)
-        mocked_fetch_yaml = mocker.patch.object(
-            UploadTask, "fetch_commit_yaml_and_possibly_store"
+        mocked_fetch_yaml = mocker.patch(
+            "services.repository.fetch_commit_yaml_and_possibly_store"
         )
         redis_queue = [
             {"build": "part1", "url": "url1"},
@@ -1217,183 +1213,6 @@ class TestUploadTaskUnit(object):
         task.request.retries = 0
         with pytest.raises(Retry):
             task.run_impl(dbsession, commit.repoid, commit.commitid)
-
-    def test_fetch_commit_yaml_and_possibly_store_only_commit_yaml(
-        self, dbsession, mocker, mock_configuration
-    ):
-        commit = CommitFactory.create()
-        get_source_result = {
-            "content": "\n".join(
-                ["codecov:", "  notify:", "    require_ci_to_pass: yes"]
-            )
-        }
-        list_top_level_files_result = [
-            {"name": ".gitignore", "path": ".gitignore", "type": "file"},
-            {"name": ".travis.yml", "path": ".travis.yml", "type": "file"},
-            {"name": "README.rst", "path": "README.rst", "type": "file"},
-            {"name": "awesome", "path": "awesome", "type": "folder"},
-            {"name": "codecov", "path": "codecov", "type": "file"},
-            {"name": "codecov.yaml", "path": "codecov.yaml", "type": "file"},
-            {"name": "tests", "path": "tests", "type": "folder"},
-        ]
-        repository_service = mocker.MagicMock(
-            list_top_level_files=mock.AsyncMock(
-                return_value=list_top_level_files_result
-            ),
-            get_source=mock.AsyncMock(return_value=get_source_result),
-        )
-
-        result = UploadTask().fetch_commit_yaml_and_possibly_store(
-            commit, repository_service
-        )
-        expected_result = {"codecov": {"notify": {}, "require_ci_to_pass": True}}
-        assert result.to_dict() == expected_result
-        repository_service.get_source.assert_called_with(
-            "codecov.yaml", commit.commitid
-        )
-        repository_service.list_top_level_files.assert_called_with(commit.commitid)
-
-    def test_fetch_commit_yaml_and_possibly_store_commit_yaml_and_base_yaml(
-        self, dbsession, mock_configuration, mocker
-    ):
-        mock_configuration.set_params({"site": {"coverage": {"precision": 14}}})
-        commit = CommitFactory.create()
-        get_source_result = {
-            "content": "\n".join(
-                ["codecov:", "  notify:", "    require_ci_to_pass: yes"]
-            )
-        }
-        list_top_level_files_result = [
-            {"name": ".travis.yml", "path": ".travis.yml", "type": "file"},
-            {"name": "awesome", "path": "awesome", "type": "folder"},
-            {"name": ".codecov.yaml", "path": ".codecov.yaml", "type": "file"},
-        ]
-        repository_service = mocker.MagicMock(
-            list_top_level_files=mock.AsyncMock(
-                return_value=list_top_level_files_result
-            ),
-            get_source=mock.AsyncMock(return_value=get_source_result),
-        )
-
-        result = UploadTask().fetch_commit_yaml_and_possibly_store(
-            commit, repository_service
-        )
-        expected_result = {
-            "codecov": {"notify": {}, "require_ci_to_pass": True},
-            "coverage": {"precision": 14},
-        }
-        assert result.to_dict() == expected_result
-        repository_service.get_source.assert_called_with(
-            ".codecov.yaml", commit.commitid
-        )
-        repository_service.list_top_level_files.assert_called_with(commit.commitid)
-
-    def test_fetch_commit_yaml_and_possibly_store_commit_yaml_and_repo_yaml(
-        self, dbsession, mock_configuration, mocker
-    ):
-        mock_configuration.set_params({"site": {"coverage": {"precision": 14}}})
-        commit = CommitFactory.create(
-            repository__yaml={"codecov": {"max_report_age": "1y ago"}},
-            repository__branch="supeduperbranch",
-            branch="supeduperbranch",
-        )
-        get_source_result = {
-            "content": "\n".join(
-                ["codecov:", "  notify:", "    require_ci_to_pass: yes"]
-            )
-        }
-        list_top_level_files_result = [
-            {"name": ".gitignore", "path": ".gitignore", "type": "file"},
-            {"name": ".codecov.yaml", "path": ".codecov.yaml", "type": "file"},
-            {"name": "tests", "path": "tests", "type": "folder"},
-        ]
-        repository_service = mocker.MagicMock(
-            list_top_level_files=mock.AsyncMock(
-                return_value=list_top_level_files_result
-            ),
-            get_source=mock.AsyncMock(return_value=get_source_result),
-        )
-
-        result = UploadTask().fetch_commit_yaml_and_possibly_store(
-            commit, repository_service
-        )
-        expected_result = {
-            "codecov": {"notify": {}, "require_ci_to_pass": True},
-            "coverage": {"precision": 14},
-        }
-        assert result.to_dict() == expected_result
-        assert commit.repository.yaml == {
-            "codecov": {"notify": {}, "require_ci_to_pass": True}
-        }
-        repository_service.get_source.assert_called_with(
-            ".codecov.yaml", commit.commitid
-        )
-        repository_service.list_top_level_files.assert_called_with(commit.commitid)
-
-    def test_fetch_commit_yaml_and_possibly_store_commit_yaml_no_commit_yaml(
-        self, dbsession, mock_configuration, mocker
-    ):
-        mock_configuration.set_params({"site": {"coverage": {"round": "up"}}})
-        commit = CommitFactory.create(
-            repository__owner__yaml={"coverage": {"precision": 2}},
-            repository__yaml={"codecov": {"max_report_age": "1y ago"}},
-            repository__branch="supeduperbranch",
-            branch="supeduperbranch",
-        )
-        repository_service = mocker.MagicMock(
-            list_top_level_files=mock.AsyncMock(
-                side_effect=TorngitClientError(404, "fake_response", "message")
-            )
-        )
-
-        result = UploadTask().fetch_commit_yaml_and_possibly_store(
-            commit, repository_service
-        )
-        expected_result = {
-            "coverage": {"precision": 2, "round": "up"},
-            "codecov": {"max_report_age": "1y ago"},
-        }
-        assert result.to_dict() == expected_result
-        assert commit.repository.yaml == {"codecov": {"max_report_age": "1y ago"}}
-
-    def test_fetch_commit_yaml_and_possibly_store_commit_yaml_invalid_commit_yaml(
-        self, dbsession, mock_configuration, mocker
-    ):
-        mock_configuration.set_params({"site": {"comment": {"behavior": "new"}}})
-        commit = CommitFactory.create(
-            repository__owner__yaml={"coverage": {"precision": 2}},
-            repository__yaml={"codecov": {"max_report_age": "1y ago"}},
-            repository__branch="supeduperbranch",
-            branch="supeduperbranch",
-        )
-        dbsession.add(commit)
-        get_source_result = {
-            "content": "\n".join(
-                ["bad_key:", "  notify:", "    require_ci_to_pass: yes"]
-            )
-        }
-        list_top_level_files_result = [
-            {"name": ".gitignore", "path": ".gitignore", "type": "file"},
-            {"name": ".codecov.yaml", "path": ".codecov.yaml", "type": "file"},
-            {"name": "tests", "path": "tests", "type": "folder"},
-        ]
-        repository_service = mocker.MagicMock(
-            list_top_level_files=mock.AsyncMock(
-                return_value=list_top_level_files_result
-            ),
-            get_source=mock.AsyncMock(return_value=get_source_result),
-        )
-
-        result = UploadTask().fetch_commit_yaml_and_possibly_store(
-            commit, repository_service
-        )
-        expected_result = {
-            "coverage": {"precision": 2},
-            "codecov": {"max_report_age": "1y ago"},
-            "comment": {"behavior": "new"},
-        }
-        assert result.to_dict() == expected_result
-        assert commit.repository.yaml == {"codecov": {"max_report_age": "1y ago"}}
 
     def test_possibly_setup_webhooks_public_repo(
         self, mocker, mock_configuration, mock_repo_provider

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -155,10 +155,8 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 commit_yaml,
                 repository,
                 commit,
-                report_code,
                 report_service,
                 processing_results,
-                db_session,
             )
 
             log.info(
@@ -479,13 +477,11 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
 
     def merge_incremental_reports(
         self,
-        commit_yaml,
+        commit_yaml: dict,
         repository,
-        commit,
-        report_code,
-        report_service,
+        commit: Commit,
+        report_service: ReportService,
         processing_results,
-        db_session,
     ):
         archive_service = report_service.get_archive_service(repository)
         repoid = repository.repoid
@@ -575,7 +571,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
             )
             session.id = session_id
 
-            session_manipulation_result = _adjust_sessions(
+            _adjust_sessions(
                 cumulative_report, incremental_report, session, UserYaml(commit_yaml)
             )
             # ReportService.update_upload_with_processing_result should use this result

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -40,7 +40,6 @@ from tasks.upload_clean_labels_index import task_name as clean_labels_index_task
 log = logging.getLogger(__name__)
 
 regexp_ci_skip = re.compile(r"\[(ci|skip| |-){3,}\]")
-merged_pull = re.compile(r".*Merged in [^\s]+ \(pull request \#(\d+)\).*").match
 
 PYREPORT_REPORT_JSON_SIZE = Histogram(
     "worker_tasks_upload_finisher_report_json_size",

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -441,7 +441,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
     def _possibly_delete_archive(
         self, processing_result: dict, report_service: ReportService, commit: Commit
     ):
-        if not self.should_delete_archive(report_service.current_yaml):
+        if self.should_delete_archive(report_service.current_yaml):
             upload = processing_result.get("upload_obj")
             archive_url = upload.storage_path
             if archive_url and not archive_url.startswith("http"):

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -1,6 +1,5 @@
 import logging
 import random
-import re
 from copy import deepcopy
 from typing import Optional
 
@@ -35,8 +34,6 @@ from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
 
-regexp_ci_skip = re.compile(r"\[(ci|skip| |-){3,}\]").search
-merged_pull = re.compile(r".*Merged in [^\s]+ \(pull request \#(\d+)\).*").match
 FIRST_RETRY_DELAY = 20
 
 """ The upload_processing_lock.


### PR DESCRIPTION
Various improvements like fixing typos, adding types and using more modern code patterns

For the `Upload` task in particular:
- Use a `LoggerAdapter` to simplify adding more logging context
- Use a custom `chunks` generator together with list comprehension instead of manual loops
  - ☝🏻 this also fixes a problem where previously the last chunk/task would not be properly flagged as `is_final`

---

As this re-indents a bunch of code, I highly recommend to use "ignore whitespace" when reviewing.