### PR TITLE
Update base image to python:3.12.4-slim-bookworm

### DIFF
--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG PYTHON_IMAGE=python:3.12-slim-bookworm
+ARG PYTHON_IMAGE=python:3.12.4-slim-bookworm
 # BUILD STAGE
 FROM $PYTHON_IMAGE as build
 

--- a/docker/Dockerfile.requirements
+++ b/docker/Dockerfile.requirements
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-ARG PYTHON_IMAGE=python:3.12.2-slim-bookworm
+ARG PYTHON_IMAGE=python:3.12-slim-bookworm
 # BUILD STAGE
 FROM $PYTHON_IMAGE as build
 


### PR DESCRIPTION
Build was failing locally and it seems the base image we were using an out of date base image (`python:3.12.2-slim-bookworm`). Not sure in exactly what way this was breaking things, but using `python:3.12.4-slim-bookworm` fixes the issue.
