### PR TITLE
log when raw upload contains no uploaded files

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -926,8 +926,20 @@ class ReportService(BaseReportService):
 
         raw_uploaded_report = parser.parse_raw_report_from_bytes(archive_file)
 
+        raw_report_count = len(raw_uploaded_report.get_uploaded_files())
+        if raw_report_count < 1:
+            log.warning(
+                "Raw upload contains no uploaded files",
+                extra=dict(
+                    commit=upload.report.commit_id,
+                    repoid=repo.repoid,
+                    raw_report_count=raw_report_count,
+                    upload_version=upload_version,
+                    archive_url=archive_url,
+                ),
+            )
         RAW_UPLOAD_RAW_REPORT_COUNT.labels(version=upload_version).observe(
-            len(raw_uploaded_report.get_uploaded_files())
+            raw_report_count
         )
 
         return raw_uploaded_report


### PR DESCRIPTION
looking at the nearby counter metrics in Grafana, the median upload supposedly has no raw report files inside of it. we can search this log in GCS to see specific cases of this to see what's up.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.