### PR TITLE
re-export shared bot exceptions instead of redefining them

### DIFF
--- a/helpers/exceptions.py
+++ b/helpers/exceptions.py
@@ -1,3 +1,11 @@
+import shared.bots.exceptions
+
+RepositoryWithoutValidBotError = shared.bots.exceptions.RepositoryWithoutValidBotError
+OwnerWithoutValidBotError = shared.bots.exceptions.OwnerWithoutValidBotError
+RequestedGithubAppNotFound = shared.bots.exceptions.RequestedGithubAppNotFound
+NoConfiguredAppsAvailable = shared.bots.exceptions.NoConfiguredAppsAvailable
+
+
 class ReportExpiredException(Exception):
     def __init__(self, message=None, filename=None) -> None:
         super().__init__(message)
@@ -6,27 +14,6 @@ class ReportExpiredException(Exception):
 
 class ReportEmptyError(Exception):
     pass
-
-
-class RepositoryWithoutValidBotError(Exception):
-    pass
-
-
-class RequestedGithubAppNotFound(Exception):
-    pass
-
-
-class OwnerWithoutValidBotError(Exception):
-    pass
-
-
-class NoConfiguredAppsAvailable(Exception):
-    def __init__(
-        self, apps_count: int, rate_limited_count: int, suspended_count: int
-    ) -> None:
-        self.apps_count = apps_count
-        self.rate_limited_count = rate_limited_count
-        self.suspended_count = suspended_count
 
 
 class CorruptRawReportError(Exception):


### PR DESCRIPTION
worker copy/pastes the definitions of exception types that live in shared now. worker code tries to catch the worker redefinitions, but shared is throwing the original shared definitions. even though they're named/defined identically, they're totally unrelated types. so the exceptions aren't caught

i added a unit test for the specific case i saw where an exception was not getting caught. there may be others