### PR TITLE
chore: user config in notifications

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,3 @@
-https://github.com/codecov/shared/archive/1ab8ac9b8875ee2da8b473033772c2377f09bf95.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/shared/archive/1482593343604028ffee5902da080696eb8c14d4.tar.gz#egg=shared
 https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz#egg=test-results-parser

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+https://github.com/codecov/shared/archive/1ab8ac9b8875ee2da8b473033772c2377f09bf95.tar.gz#egg=shared
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
 https://github.com/codecov/shared/archive/1482593343604028ffee5902da080696eb8c14d4.tar.gz#egg=shared
 https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz#egg=test-results-parser

--- a/services/bundle_analysis/new_notify/contexts/tests/test_contexts.py
+++ b/services/bundle_analysis/new_notify/contexts/tests/test_contexts.py
@@ -32,7 +32,7 @@ class TestBaseBundleAnalysisNotificationContextBuild:
             builder._notification_context.commit_report
         assert (
             str(exp.value)
-            == "The property you are trying to access is not loaded. Make sure to build the context before using it."
+            == "Property commit_report is not loaded. Make sure to build the context before using it."
         )
 
     @pytest.mark.parametrize(
@@ -220,6 +220,7 @@ class TestBundleAnalysisPRCommentNotificationContext:
         builder = BundleAnalysisPRCommentContextBuilder().initialize(
             head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
         )
+        builder.load_user_config()
         mock_pull = MagicMock(
             name="fake_pull",
             database_pull=MagicMock(bundle_analysis_commentid=None, id=12),
@@ -275,6 +276,7 @@ class TestBundleAnalysisPRCommentNotificationContext:
         builder = BundleAnalysisPRCommentContextBuilder().initialize(
             head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
         )
+        builder.load_user_config()
         mock_pull = MagicMock(
             name="fake_pull",
             database_pull=MagicMock(bundle_analysis_commentid=None, id=12),
@@ -300,6 +302,7 @@ class TestBundleAnalysisPRCommentNotificationContext:
         builder = BundleAnalysisPRCommentContextBuilder().initialize(
             head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
         )
+        builder.load_user_config()
         mock_pull = MagicMock(
             name="fake_pull",
             database_pull=MagicMock(bundle_analysis_commentid=12345, id=12),
@@ -360,7 +363,7 @@ class TestBundleAnalysisPRCommentNotificationContext:
         context.pull = MagicMock(name="fake_pull")
 
         other_builder = BundleAnalysisPRCommentContextBuilder().initialize_from_context(
-            context
+            user_yaml, context
         )
         other_context = other_builder.get_result()
 

--- a/services/bundle_analysis/new_notify/messages/tests/test_comment.py
+++ b/services/bundle_analysis/new_notify/messages/tests/test_comment.py
@@ -4,6 +4,7 @@ import pytest
 from django.template import loader
 from shared.torngit.exceptions import TorngitClientError
 from shared.typings.torngit import TorngitInstanceData
+from shared.validation.types import BundleThreshold
 from shared.yaml import UserYaml
 
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
@@ -23,6 +24,7 @@ from services.bundle_analysis.new_notify.messages.comment import (
     BundleCommentTemplateContext,
     BundleRow,
 )
+from services.bundle_analysis.new_notify.types import NotificationUserConfig
 from services.notification.notifiers.base import NotificationResult
 
 
@@ -190,9 +192,8 @@ Changes will decrease total bundle size by 372.56kB :arrow_down:
             return_value=fake_repo_provider,
         )
         head_commit, _ = get_commit_pair(dbsession)
-        user_yaml = UserYaml.from_dict({})
         context = BundleAnalysisPRCommentNotificationContext(
-            head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
+            head_commit, GITHUB_APP_INSTALLATION_DEFAULT_NAME
         )
         mock_pull = MagicMock(
             name="fake_pull",
@@ -203,6 +204,12 @@ Changes will decrease total bundle size by 372.56kB :arrow_down:
             ),
         )
         context.__dict__["pull"] = mock_pull
+        context.__dict__["user_config"] = NotificationUserConfig(
+            warning_threshold=BundleThreshold("absolute", 0),
+            required_changes_threshold=BundleThreshold("absolute", 0),
+            required_changes=False,
+            status_level="informational",
+        )
         mock_comparison = MagicMock(name="fake_bundle_analysis_comparison")
         context.__dict__["bundle_analysis_comparison"] = mock_comparison
         message = "carefully crafted message"

--- a/services/bundle_analysis/new_notify/tests/test_notify_service.py
+++ b/services/bundle_analysis/new_notify/tests/test_notify_service.py
@@ -45,7 +45,6 @@ def override_comment_builder_and_message_strategy(mocker):
 def mock_base_context():
     context_requirements = (
         CommitFactory(),
-        UserYaml.from_dict({}),
         GITHUB_APP_INSTALLATION_DEFAULT_NAME,
     )
     context = BaseBundleAnalysisNotificationContext(*context_requirements)
@@ -73,9 +72,8 @@ class TestCreateContextForNotification:
         mock_comment_builder, mock_markdown_strategy = (
             override_comment_builder_and_message_strategy(mocker)
         )
-        service = BundleAnalysisNotifyService(
-            mock_base_context.commit, mock_base_context.current_yaml
-        )
+        current_yaml = UserYaml.from_dict({})
+        service = BundleAnalysisNotifyService(mock_base_context.commit, current_yaml)
         mock_markdown_strategy.return_value = "D. Strategy"
         result = service.create_context_for_notification(
             mock_base_context, NotificationType.PR_COMMENT
@@ -94,9 +92,8 @@ class TestCreateContextForNotification:
     def test_create_contexts_unknown_notification(
         self, mock_base_context, unknown_notification
     ):
-        service = BundleAnalysisNotifyService(
-            mock_base_context.commit, mock_base_context.current_yaml
-        )
+        current_yaml = UserYaml.from_dict({})
+        service = BundleAnalysisNotifyService(mock_base_context.commit, current_yaml)
         assert (
             service.create_context_for_notification(
                 mock_base_context, unknown_notification
@@ -112,13 +109,12 @@ class TestCreateContextForNotification:
         mock_comment_builder.build_context.side_effect = NotificationContextBuildError(
             "mock_failed_step"
         )
+        current_yaml = UserYaml.from_dict({})
         mock_comment_builder = mocker.patch(
             "services.bundle_analysis.new_notify.BundleAnalysisPRCommentContextBuilder",
             return_value=mock_comment_builder,
         )
-        service = BundleAnalysisNotifyService(
-            mock_base_context.commit, mock_base_context.current_yaml
-        )
+        service = BundleAnalysisNotifyService(mock_base_context.commit, current_yaml)
         assert (
             service.create_context_for_notification(
                 mock_base_context, NotificationType.PR_COMMENT

--- a/services/bundle_analysis/new_notify/types.py
+++ b/services/bundle_analysis/new_notify/types.py
@@ -1,4 +1,8 @@
+from dataclasses import dataclass
 from enum import Enum
+from typing import Literal
+
+from shared.validation.types import BundleThreshold
 
 
 class NotificationType(Enum):
@@ -13,3 +17,11 @@ class NotificationSuccess(Enum):
     NOTHING_TO_NOTIFY = "nothing_to_notify"
     FULL_SUCCESS = "full_success"
     PARTIAL_SUCCESS = "partial_success"
+
+
+@dataclass
+class NotificationUserConfig:
+    warning_threshold: BundleThreshold
+    status_level: bool | Literal["informational"]
+    required_changes: bool | Literal["bundle_increase"]
+    required_changes_threshold: BundleThreshold


### PR DESCRIPTION
These changes hide away the current_yaml from the Contexts.
The original idea was to not expose it, but I didn't do that detail correctly the 1st time.
Now it's hidden behind the `user_config` field. Builders still have full access.

The `user_config` field parses the config that will be used for commit statuses,
and also the config already used for the PR comment required changes.

Notice that we have 2 seemingly redundant options with `changes_threshold` and
`required_changes_threshold`. Still waiting on design to clean that up,
but they are technically different things at this time:
* `required_changes_threshold` is the threshold to send the comment;
* `changes_threshold` is the threshold to fail status checks
If they remain separate one of them will be renamed :E
