### PR TITLE
Move `fetch_commit_yaml_and_possibly_store` to `services.repository`

### DIFF
--- a/tasks/tests/unit/test_preprocess_upload.py
+++ b/tasks/tests/unit/test_preprocess_upload.py
@@ -48,11 +48,11 @@ class TestPreProcessUpload(object):
             }
         }
         mocker.patch(
-            "tasks.preprocess_upload.fetch_commit_yaml_from_provider",
+            "services.repository.fetch_commit_yaml_from_provider",
             return_value=commit_yaml,
         )
         mock_save_commit = mocker.patch(
-            "tasks.preprocess_upload.save_repo_yaml_to_database_if_needed"
+            "services.repository.save_repo_yaml_to_database_if_needed"
         )
         mocker.patch.object(PreProcessUpload, "_is_running", return_value=False)
 

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -19,7 +19,6 @@ from shared.torngit.exceptions import (
     TorngitClientError,
     TorngitRepoNotFoundError,
 )
-from shared.validation.exceptions import InvalidYamlException
 from shared.yaml import UserYaml
 from shared.yaml.user_yaml import OwnerContext
 
@@ -49,13 +48,12 @@ from services.redis import (
 from services.report import NotReadyToBuildReportYetError, ReportService
 from services.repository import (
     create_webhook_on_provider,
+    fetch_commit_yaml_and_possibly_store,
     get_repo_provider_service,
     gitlab_webhook_update,
     possibly_update_commit_from_provider_info,
 )
 from services.test_results import TestResultsReportService
-from services.yaml import save_repo_yaml_to_database_if_needed
-from services.yaml.fetcher import fetch_commit_yaml_from_provider
 from tasks.base import BaseCodecovTask
 from tasks.bundle_analysis_notify import bundle_analysis_notify_task
 from tasks.bundle_analysis_processor import bundle_analysis_processor_task
@@ -468,7 +466,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 exc_info=True,
             )
         if repository_service:
-            commit_yaml = self.fetch_commit_yaml_and_possibly_store(
+            commit_yaml = fetch_commit_yaml_and_possibly_store(
                 commit, repository_service
             )
         else:
@@ -561,56 +559,6 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 ),
             )
         return {"was_setup": was_setup, "was_updated": was_updated}
-
-    def fetch_commit_yaml_and_possibly_store(self, commit, repository_service):
-        repository = commit.repository
-        try:
-            log.info(
-                "Fetching commit yaml from provider for commit",
-                extra=dict(repoid=commit.repoid, commit=commit.commitid),
-            )
-            commit_yaml = async_to_sync(fetch_commit_yaml_from_provider)(
-                commit, repository_service
-            )
-            save_repo_yaml_to_database_if_needed(commit, commit_yaml)
-        except InvalidYamlException as ex:
-            save_commit_error(
-                commit,
-                error_code=CommitErrorTypes.INVALID_YAML.value,
-                error_params=dict(
-                    repoid=repository.repoid,
-                    commit=commit.commitid,
-                    error_location=ex.error_location,
-                ),
-            )
-            log.warning(
-                "Unable to use yaml from commit because it is invalid",
-                extra=dict(
-                    repoid=repository.repoid,
-                    commit=commit.commitid,
-                    error_location=ex.error_location,
-                ),
-                exc_info=True,
-            )
-            commit_yaml = None
-        except TorngitClientError:
-            log.warning(
-                "Unable to use yaml from commit because it cannot be fetched",
-                extra=dict(repoid=repository.repoid, commit=commit.commitid),
-                exc_info=True,
-            )
-            commit_yaml = None
-        context = OwnerContext(
-            owner_onboarding_date=repository.owner.createstamp,
-            owner_plan=repository.owner.plan,
-            ownerid=repository.ownerid,
-        )
-        return UserYaml.get_final_yaml(
-            owner_yaml=repository.owner.yaml,
-            repo_yaml=repository.yaml,
-            commit_yaml=commit_yaml,
-            owner_context=context,
-        )
 
     def schedule_task(
         self,


### PR DESCRIPTION
This function was copy-pasted across two different classes although it was not depending on any `self` class members.

The function is deduplicated and moved to a different place, along with its tests.

---

This PR was extracted from https://github.com/codecov/worker/pull/592, as its a simple standalone change.