### PR TITLE
Add more tracing

### DIFF
--- a/helpers/parallel_upload_processing.py
+++ b/helpers/parallel_upload_processing.py
@@ -1,5 +1,6 @@
 import copy
 
+import sentry_sdk
 from shared.utils.sessions import SessionType
 
 from database.models.reports import Upload
@@ -64,6 +65,7 @@ def get_parallel_session_ids(
     return get_parallel_session_ids
 
 
+@sentry_sdk.trace
 def save_incremental_report_results(
     report_service, commit, report, parallel_idx, report_code
 ):
@@ -96,6 +98,7 @@ def save_incremental_report_results(
 # Saves the result of the an entire serial processing flow to archive storage
 # so that it can be compared for parallel experiment. Not necessarily the final report
 # for the commit, if more uploads are still made.
+@sentry_sdk.trace
 def save_final_serial_report_results(
     report_service, commit, report, report_code, arguments_list
 ):

--- a/helpers/sentry.py
+++ b/helpers/sentry.py
@@ -3,6 +3,7 @@ import os
 import sentry_sdk
 from celery.exceptions import SoftTimeLimitExceeded
 from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.httpx import HttpxIntegration
 from sentry_sdk.integrations.redis import RedisIntegration
 from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
@@ -38,6 +39,7 @@ def initialize_sentry() -> None:
         ),
         integrations=[
             CeleryIntegration(monitor_beat_tasks=True),
+            DjangoIntegration(signals_spans=False),
             SqlalchemyIntegration(),
             RedisIntegration(),
             HttpxIntegration(),

--- a/helpers/tests/unit/test_sentry.py
+++ b/helpers/tests/unit/test_sentry.py
@@ -22,6 +22,6 @@ class TestSentry(object):
             traces_sample_rate=1.0,
             profiles_sample_rate=1.0,
             environment="production",
-            integrations=[mocker.ANY, mocker.ANY, mocker.ANY, mocker.ANY],
+            integrations=mocker.ANY,
         )
         mocked_set_tag.assert_called_with("cluster", cluster)

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -1133,6 +1133,7 @@ class ReportService(BaseReportService):
             db_session.add(error_obj)
             db_session.flush()
 
+    @sentry_sdk.trace
     def save_report(self, commit: Commit, report: Report, report_code=None):
         rounding: str = read_yaml_field(
             self.current_yaml, ("coverage", "round"), "nearest"
@@ -1211,6 +1212,7 @@ class ReportService(BaseReportService):
         )
         return {"url": url}
 
+    @sentry_sdk.trace
     def save_full_report(self, commit: Commit, report: Report, report_code=None):
         """
             Saves the report (into database and storage) AND takes care of backfilling its sessions
@@ -1262,6 +1264,7 @@ class ReportService(BaseReportService):
                 )
         return res
 
+    @sentry_sdk.trace
     async def save_parallel_report_to_archive(
         self, commit: Commit, report: Report, report_code=None
     ):

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -1,6 +1,7 @@
 import logging
 from datetime import datetime
 
+import sentry_sdk
 from celery._state import get_current_task
 from celery.exceptions import SoftTimeLimitExceeded
 from celery.worker.request import Request
@@ -143,6 +144,7 @@ class BaseCodecovTask(celery_app.Task):
             return self.time_limit
         return self.app.conf.task_time_limit or 0
 
+    @sentry_sdk.trace
     def apply_async(self, args=None, kwargs=None, **options):
         db_session = get_db_session()
         user_plan = _get_user_plan_from_task(db_session, self.name, kwargs)

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -6,6 +6,7 @@ from json import loads
 from math import ceil
 from typing import Any, List, Mapping, Optional
 
+import sentry_sdk
 from asgiref.sync import async_to_sync
 from celery import chain, chord
 from redis import Redis
@@ -356,6 +357,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             upload_context.prepare_kwargs_for_retry(kwargs)
             self.retry(max_retries=3, countdown=retry_countdown, kwargs=kwargs)
 
+    @sentry_sdk.trace
     def run_impl_within_lock(
         self,
         db_session,

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -176,6 +176,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 )
                 self.retry(max_retries=5, countdown=retry_in)
 
+    @sentry_sdk.trace
     def process_impl_within_lock(
         self,
         *,


### PR DESCRIPTION
This adds a bit more tracing to Upload related tasks, and task calls, as well as disable spammy signal spans in the automatically enabled Sentry Django integration.
