### PR TITLE
fix: UnboundLocalError

### DIFF
--- a/services/bundle_analysis/new_notify/types.py
+++ b/services/bundle_analysis/new_notify/types.py
@@ -14,6 +14,7 @@ class NotificationType(Enum):
 
 
 class NotificationSuccess(Enum):
+    ALL_ERRORED = "all_processing_results_errored"
     NOTHING_TO_NOTIFY = "nothing_to_notify"
     FULL_SUCCESS = "full_success"
     PARTIAL_SUCCESS = "partial_success"

--- a/tasks/tests/unit/test_bundle_analysis_notify_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_notify_task.py
@@ -38,3 +38,20 @@ def test_bundle_analysis_notify_task(
         "notify_attempted": True,
         "notify_succeeded": NotificationSuccess.FULL_SUCCESS,
     }
+
+
+def test_bundle_analysis_notify_skips_if_all_processing_fail(dbsession):
+    commit = CommitFactory.create()
+    dbsession.add(commit)
+    dbsession.flush()
+    result = BundleAnalysisNotifyTask().run_impl(
+        dbsession,
+        {"results": [{"error": True}]},
+        repoid=commit.repoid,
+        commitid=commit.commitid,
+        commit_yaml={},
+    )
+    assert result == {
+        "notify_attempted": False,
+        "notify_succeeded": NotificationSuccess.ALL_ERRORED,
+    }


### PR DESCRIPTION
Refactor the bundle_analysis_notify task so `result` is always set,
and we early-return if there's nothing to notify on.

Adding a new `NotificationSuccess` value for the early return.
