### PR TITLE
Fix `BundleAnalysisProcessor` task receiving wrong arguments

### DIFF
--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -256,6 +256,7 @@ class TestUploadTaskIntegration(object):
         assert len(uploads) == 1
         upload = dbsession.query(Upload).filter_by(report_id=commit_report.id).first()
         processor_sig = bundle_analysis_processor_task.s(
+            {},
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -771,6 +771,8 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             )
             for params in argument_list
         ]
+        if task_signatures:
+            task_signatures[0].args = ({},)  # this is the first `previous_result`
 
         # it might make sense to eventually have a "finisher" task that
         # does whatever extra stuff + enqueues a notify


### PR DESCRIPTION
Celery `chain` automatically passes a first (non-kw) argument. However only for all the *successive* tasks, not the first one in the chain. So we have to pass that arg manually to the *first* task in that case.

Fixes WORKER-NFC