### PR TITLE
Check for pending uploads outside of lock

### DIFF
--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -1163,6 +1163,7 @@ class TestUploadTaskUnit(object):
         mocked_run_impl_within_lock = mocker.patch.object(
             UploadTask, "run_impl_within_lock", return_value=True
         )
+        mock_redis.keys[f"uploads/{commit.repoid}/{commit.commitid}"] = ["something"]
         task = UploadTask()
         task.request.retries = 0
         with pytest.raises(Retry):
@@ -1182,6 +1183,7 @@ class TestUploadTaskUnit(object):
         mocked_run_impl_within_lock = mocker.patch.object(
             UploadTask, "run_impl_within_lock", return_value={"some": "value"}
         )
+        mock_redis.keys[f"uploads/{commit.repoid}/{commit.commitid}"] = ["something"]
         task = UploadTask()
         task.request.retries = 1
         result = task.run_impl(dbsession, commit.repoid, commit.commitid)


### PR DESCRIPTION
According to traces, it happens quite frequently that an `Upload` task early-returns right after acquiring its upload lock because it does not have any pending tasks.

This moves this check outside of the lock to optimize one case. However it can still happen that concurrent `Upload` tasks "steal" each others pending uploads, so another check is still required within the lock.