### PR TITLE
Consider contents when choosing between v1/legacy ReportParser

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -917,8 +917,7 @@ class ReportService(BaseReportService):
         else:
             archive_file = archive_service.read_file(archive_url)
 
-        parser = get_proper_parser(upload)
-
+        parser = get_proper_parser(upload, archive_file)
         upload_version = (
             "v1" if isinstance(parser, VersionOneReportParser) else "legacy"
         )

--- a/services/report/parser/__init__.py
+++ b/services/report/parser/__init__.py
@@ -1,9 +1,18 @@
+import sentry_sdk
+
 from database.models.reports import Upload
 from services.report.parser.legacy import LegacyReportParser
 from services.report.parser.version_one import VersionOneReportParser
 
 
-def get_proper_parser(upload: Upload):
+def get_proper_parser(upload: Upload, contents: bytes):
     if upload.upload_extras and upload.upload_extras.get("format_version") == "v1":
-        return VersionOneReportParser()
+        contents = contents.strip()
+        if contents.startswith(b"{") and contents.endswith(b"}"):
+            return VersionOneReportParser()
+        else:
+            with sentry_sdk.configure_scope() as scope:
+                scope.set_extra("upload_extras", upload.upload_extras)
+                scope.set_extra("contents", contents[:64])
+                sentry_sdk.capture_message("Upload `format_version` lied to us")
     return LegacyReportParser()

--- a/services/report/parser/tests/unit/test_parsers.py
+++ b/services/report/parser/tests/unit/test_parsers.py
@@ -9,18 +9,19 @@ from services.report.parser import (
 
 
 @pytest.mark.parametrize(
-    "upload_extras, expected_type",
+    "upload_extras, contents, expected_type",
     [
-        (None, LegacyReportParser),
-        ({}, LegacyReportParser),
-        ({"something": 1}, LegacyReportParser),
-        ({"format_version": "v1"}, VersionOneReportParser),
-        ({"format_version": "v1", "something": "else"}, VersionOneReportParser),
-        ({"format_version": None}, LegacyReportParser),
+        (None, b"", LegacyReportParser),
+        ({}, b"", LegacyReportParser),
+        ({"something": 1}, b"", LegacyReportParser),
+        ({"format_version": "v1"}, b"{}", VersionOneReportParser),
+        ({"format_version": "v1", "something": "else"}, b"{}", VersionOneReportParser),
+        ({"format_version": None}, b"", LegacyReportParser),
+        ({"format_version": "v1"}, b"not/a/v1/format.txt", LegacyReportParser),
     ],
 )
-def test_get_proper_parser(dbsession, upload_extras, expected_type):
+def test_get_proper_parser(dbsession, upload_extras, contents, expected_type):
     upload = UploadFactory.create(upload_extras=upload_extras)
     dbsession.add(upload)
     dbsession.flush()
-    assert isinstance(get_proper_parser(upload), expected_type)
+    assert isinstance(get_proper_parser(upload, contents), expected_type)


### PR DESCRIPTION
We are capturing a couple internal errors where the `VersionOneReportParser` tries to json-parse something that is not JSON.

In particular, this event shows that the reportfile contents look rather like a `Legacy` format: https://codecov.sentry.io/issues/5258384165/events/1c65937e66614ec5b5f56743c3d42132/

To make this more bulletproof, this will now check that the format "looks like" JSON when choosing the parser, before it actually tries to fully json-parse the contents.

Fixes WORKER-MMH