### PR TITLE
fix: add user_plan to apply_async options

### DIFF
--- a/celery_task_router.py
+++ b/celery_task_router.py
@@ -148,6 +148,9 @@ def route_task(name, args, kwargs, options, task=None, **kw):
     """Function to dynamically route tasks to the proper queue.
     Docs: https://docs.celeryq.dev/en/stable/userguide/routing.html#routers
     """
-    db_session = get_db_session()
-    user_plan = _get_user_plan_from_task(db_session, name, kwargs)
+
+    user_plan = options.get("user_plan")
+    if user_plan is None:
+        db_session = get_db_session()
+        user_plan = _get_user_plan_from_task(db_session, name, kwargs)
     return route_tasks_based_on_user_plan(name, user_plan)

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -153,6 +153,7 @@ class BaseCodecovTask(celery_app.Task):
         celery_compatible_config = {
             "time_limit": extra_config.get("hard_timelimit", None),
             "soft_time_limit": extra_config.get("soft_timelimit", None),
+            "user_plan": user_plan,
         }
         options = {**options, **celery_compatible_config}
 

--- a/tasks/tests/unit/test_base.py
+++ b/tasks/tests/unit/test_base.py
@@ -532,6 +532,7 @@ class TestBaseCodecovTaskApplyAsyncOverride(object):
             headers=dict(created_timestamp="2023-06-13T10:01:01.000123"),
             time_limit=400,
             soft_time_limit=200,
+            user_plan=mock_celery_task_router(),
         )
 
     @pytest.mark.freeze_time("2023-06-13T10:01:01.000123")
@@ -610,6 +611,7 @@ class TestBaseCodecovTaskApplyAsyncOverride(object):
             soft_time_limit=None,
             headers=dict(created_timestamp="2023-06-13T10:01:01.000123"),
             time_limit=None,
+            user_plan="users-pr-inappm",
         )
 
     @pytest.mark.freeze_time("2023-06-13T10:01:01.000123")
@@ -654,6 +656,7 @@ class TestBaseCodecovTaskApplyAsyncOverride(object):
             soft_time_limit=500,
             headers=dict(created_timestamp="2023-06-13T10:01:01.000123"),
             time_limit=600,
+            user_plan="users-enterprisey",
         )
 
     @pytest.mark.freeze_time("2023-06-13T10:01:01.000123")
@@ -698,4 +701,5 @@ class TestBaseCodecovTaskApplyAsyncOverride(object):
             soft_time_limit=400,
             headers=dict(created_timestamp="2023-06-13T10:01:01.000123"),
             time_limit=450,
+            user_plan="users-enterprisey",
         )


### PR DESCRIPTION
we were previously calling get_user_plan_from_task_name twice, and this function makes a database call which slows things down.

This commit makes it so we call it once in apply_async and pass the value we get back through to the custom task router function.

Fixes: https://github.com/codecov/engineering-team/issues/2258