### PR TITLE
chore: reduce log level for step failed

### DIFF
--- a/services/bundle_analysis/new_notify/__init__.py
+++ b/services/bundle_analysis/new_notify/__init__.py
@@ -76,7 +76,7 @@ class BundleAnalysisNotifyService:
                 .get_result()
             )
         except NotificationContextBuildError as exp:
-            log.error(
+            log.warning(
                 "Failed to build NotificationContext",
                 extra=dict(
                     notification_type="base_context", failed_step=exp.failed_step
@@ -120,7 +120,7 @@ class BundleAnalysisNotifyService:
                 message_strategy_class(),
             )
         except NotificationContextBuildError as exp:
-            log.error(
+            log.warning(
                 "Failed to build NotificationContext",
                 extra=dict(
                     notification_type=notification_type, failed_step=exp.failed_step

--- a/services/bundle_analysis/new_notify/tests/test_notify_service.py
+++ b/services/bundle_analysis/new_notify/tests/test_notify_service.py
@@ -177,15 +177,12 @@ class TestBundleAnalysisNotifyService:
             UserYaml.from_dict({"comment": {"require_bundle_changes": False}}),
         )
         result = service.notify()
-        error_logs = [
-            record for record in caplog.records if record.levelname == "ERROR"
-        ]
         warning_logs = [
             record for record in caplog.records if record.levelname == "WARNING"
         ]
         assert any(
-            error.message == "Failed to build NotificationContext"
-            for error in error_logs
+            warning.message == "Failed to build NotificationContext"
+            for warning in warning_logs
         )
         assert any(
             warning.message


### PR DESCRIPTION
When we fail to create the notification context we can't send that
notification, but that is not an error. So warning should suffice to aid in
debugging.

Typically this happens when some information is missing.
For example, a commit that is not part of a PR will fail to build the PR_COMMENT
notification context, simply because there is no PR associated with the commit.
