### PR TITLE
fix: BA notify success

### DIFF
--- a/services/bundle_analysis/new_notify/tests/test_notify_service.py
+++ b/services/bundle_analysis/new_notify/tests/test_notify_service.py
@@ -222,6 +222,7 @@ class TestBundleAnalysisNotifyService:
                 NotificationType.COMMIT_STATUS,
                 NotificationType.PR_COMMENT,
             ),
+            notifications_attempted=tuple(),
             notifications_successful=tuple(),
         )
 
@@ -282,15 +283,21 @@ class TestBundleAnalysisNotifyService:
     @pytest.mark.parametrize(
         "result, success_value",
         [
-            (BundleAnalysisNotifyReturn([], []), NotificationSuccess.NOTHING_TO_NOTIFY),
+            (
+                BundleAnalysisNotifyReturn([], [], []),
+                NotificationSuccess.NOTHING_TO_NOTIFY,
+            ),
             (
                 BundleAnalysisNotifyReturn(
-                    [NotificationType.COMMIT_STATUS], [NotificationType.COMMIT_STATUS]
+                    [NotificationType.COMMIT_STATUS],
+                    [NotificationType.COMMIT_STATUS],
+                    [NotificationType.COMMIT_STATUS],
                 ),
                 NotificationSuccess.FULL_SUCCESS,
             ),
             (
                 BundleAnalysisNotifyReturn(
+                    [NotificationType.COMMIT_STATUS, NotificationType.PR_COMMENT],
                     [NotificationType.COMMIT_STATUS, NotificationType.PR_COMMENT],
                     [NotificationType.COMMIT_STATUS],
                 ),

--- a/tasks/tests/unit/test_bundle_analysis_notify_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_notify_task.py
@@ -23,6 +23,7 @@ def test_bundle_analysis_notify_task(
         "services.bundle_analysis.new_notify.BundleAnalysisNotifyService.notify",
         return_value=BundleAnalysisNotifyReturn(
             notifications_configured=(NotificationType.PR_COMMENT,),
+            notifications_attempted=(NotificationType.PR_COMMENT,),
             notifications_successful=(NotificationType.PR_COMMENT,),
         ),
     )


### PR DESCRIPTION
There's no actual checking if the notification was successful.
So the notification service will report FULL_SUCCESS even if notifications
attempted actually failed.
