### PR TITLE
add database events to be executed

### DIFF
--- a/database/engine.py
+++ b/database/engine.py
@@ -7,6 +7,7 @@ from shared.utils.ReportEncoder import ReportEncoder
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, scoped_session, sessionmaker
 
+import database.events  # noqa: F401
 from database.models.timeseries import TimeseriesBaseModel
 from helpers.timeseries import timeseries_enabled
 


### PR DESCRIPTION
We have @events running in worker for whenever a repository is changed - these sync the data bw postgres db and shelter. While those are defined, those are never ran/acknowledged unless you import them, hence, this pr

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.