### PR TITLE
fix: type casting

### DIFF
--- a/services/bundle_analysis/new_notify/helpers.py
+++ b/services/bundle_analysis/new_notify/helpers.py
@@ -1,5 +1,5 @@
 import numbers
-from typing import Literal
+from typing import Iterable, Literal
 
 from shared.bundle_analysis import (
     BundleAnalysisComparison,
@@ -80,15 +80,13 @@ def bytes_readable(bytes: int) -> str:
 
 
 def to_BundleThreshold(value: int | float | BundleThreshold) -> BundleThreshold:
-    # Currently the yaml validator returns the raw values, not the BundleThreshold object
-    # Because the changes are not forwards compatible.
-    # https://github.com/codecov/engineering-team/issues/2087 is to fix that
-    # and then this function can be removed too
-    if isinstance(value, BundleThreshold):
-        return value
+    if isinstance(value, Iterable) and value[0] in ["absolute", "percentage"]:
+        return BundleThreshold(*value)
     if isinstance(value, numbers.Integral):
         return BundleThreshold("absolute", value)
-    return BundleThreshold("percentage", value)
+    elif isinstance(value, numbers.Number):
+        return BundleThreshold("percentage", value)
+    raise TypeError(f"Can't parse {value} into BundleThreshold")
 
 
 def is_bundle_change_within_bundle_threshold(

--- a/services/bundle_analysis/new_notify/tests/test_helpers.py
+++ b/services/bundle_analysis/new_notify/tests/test_helpers.py
@@ -143,10 +143,20 @@ def test_get_github_app_used(torngit, expected):
         (100, BundleThreshold("absolute", 100)),
         (0, BundleThreshold("absolute", 0)),
         (14.5, BundleThreshold("percentage", 14.5)),
+        (["percentage", 14.5], BundleThreshold("percentage", 14.5)),
+        (["absolute", 1000], BundleThreshold("absolute", 1000)),
+        (BundleThreshold("absolute", 1000), BundleThreshold("absolute", 1000)),
+        (("absolute", 1000), BundleThreshold("absolute", 1000)),
     ],
 )
 def test_to_BundleThreshold(value, expected):
     assert to_BundleThreshold(value) == expected
+
+
+@pytest.mark.parametrize("value", ["value", [1, 2, 3], None])
+def test_to_BundleThreshold_raises(value):
+    with pytest.raises(TypeError):
+        to_BundleThreshold(value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I was expecting that returning a certain type from yaml validation would keep the type.
Maybe there's some to-from dict transformation happening but the type is being lost,
and then re-casting it is not giving the expected results.

So I'm improving the function to make sure that `["percentage",["absolute",1000.0]]` won't be returned anymore.

Fixes Sentry issue 5767825563
