### PR TITLE
Implement fully parallel upload processing

### DIFF
--- a/helpers/parallel.py
+++ b/helpers/parallel.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+from enum import Enum
+
+from rollouts import PARALLEL_UPLOAD_PROCESSING_BY_REPO
+
+"""
+This encapsulates Parallel Upload Processing logic
+
+Upload Processing can run in essentially 4 modes:
+- Completely serial processing
+- Serial processing, but running "experiment" code (`EXPERIMENT_SERIAL`):
+  - In this mode, the final (`is_final`) `UploadProcessor` task saves a copy
+    of the final report for later verification.
+- Parallel processing, but running "experiment" code (`EXPERIMENT_PARALLEL`):
+  - In this mode, another parallel set of `UploadProcessor` tasks runs *after*
+    the main set up tasks.
+  - These tasks are not persisting any of their results in the database,
+    instead the final `UploadFinisher` task will launch the `ParallelVerification` task.
+- Fully parallel processing (`PARALLEL`):
+  - In this mode, the final `UploadFinisher` task is responsible for merging
+    the final report and persisting it.
+
+An example Task chain might look like this, in "experiment" mode:
+- Upload
+  - UploadProcessor
+    - UploadProcessor
+      - UploadProcessor (`EXPERIMENT_SERIAL` (the final one))
+        - UploadFinisher
+          - UploadProcessor (`EXPERIMENT_PARALLEL`)
+          - UploadProcessor (`EXPERIMENT_PARALLEL`)
+          - UploadProcessor (`EXPERIMENT_PARALLEL`)
+            - UploadFinisher (`EXPERIMENT_PARALLEL`)
+              - ParallelVerification
+
+
+The `PARALLEL` mode looks like this:
+- Upload
+  - UploadProcessor (`PARALLEL`)
+  - UploadProcessor (`PARALLEL`)
+  - UploadProcessor (`PARALLEL`)
+    - UploadFinisher (`PARALLEL`)
+"""
+
+
+class ParallelFeature(Enum):
+    SERIAL = "serial"
+    EXPERIMENT = "experiment"
+    PARALLEL = "parallel"
+
+    @classmethod
+    def load(cls, repoid: int) -> ParallelFeature:
+        feature = PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
+            identifier=repoid, default="serial"
+        )
+
+        if feature == "experiment" or feature is True:
+            return ParallelFeature.EXPERIMENT
+        if feature == "parallel":
+            return ParallelFeature.PARALLEL
+        return ParallelFeature.SERIAL
+
+
+class ParallelProcessing(Enum):
+    SERIAL = "serial"
+    EXPERIMENT_SERIAL = "experiment-serial"
+    EXPERIMENT_PARALLEL = "experiment-parallel"
+    PARALLEL = "parallel"
+
+    @property
+    def is_parallel(self) -> bool:
+        return (
+            self is ParallelProcessing.EXPERIMENT_PARALLEL
+            or self is ParallelProcessing.PARALLEL
+        )
+
+    @classmethod
+    def from_task_args(
+        cls,
+        repoid: int,
+        in_parallel: bool = False,
+        is_final: bool = False,
+        **kwargs,
+    ) -> ParallelProcessing:
+        feature = ParallelFeature.load(repoid)
+
+        if feature is ParallelFeature.SERIAL:
+            return ParallelProcessing.SERIAL
+        if feature is ParallelFeature.PARALLEL:
+            return ParallelProcessing.PARALLEL
+
+        if in_parallel:
+            return ParallelProcessing.EXPERIMENT_PARALLEL
+        if is_final:
+            return ParallelProcessing.EXPERIMENT_SERIAL
+        return ParallelProcessing.SERIAL

--- a/tasks/tests/integration/test_upload_e2e.py
+++ b/tasks/tests/integration/test_upload_e2e.py
@@ -161,10 +161,10 @@ def setup_mocks(
 
 @pytest.mark.integration
 @pytest.mark.django_db()
-@pytest.mark.parametrize("do_parallel_processing", [False, True])
+@pytest.mark.parametrize("parallel_processing", ["serial", "experiment", "parallel"])
 def test_full_upload(
     dbsession: DbSession,
-    do_parallel_processing: bool,
+    parallel_processing: str,
     mocker,
     mock_repo_provider,
     mock_storage,
@@ -176,7 +176,7 @@ def test_full_upload(
     mocker.patch.object(
         PARALLEL_UPLOAD_PROCESSING_BY_REPO,
         "check_value",
-        return_value=do_parallel_processing,
+        return_value=parallel_processing,
     )
 
     repository = RepositoryFactory.create()
@@ -360,10 +360,10 @@ end_of_record
 
 @pytest.mark.integration
 @pytest.mark.django_db()
-@pytest.mark.parametrize("do_parallel_processing", [False, True])
+@pytest.mark.parametrize("parallel_processing", ["serial", "experiment", "parallel"])
 def test_full_carryforward(
     dbsession: DbSession,
-    do_parallel_processing: bool,
+    parallel_processing: bool,
     mocker,
     mock_repo_provider,
     mock_storage,
@@ -378,7 +378,7 @@ def test_full_carryforward(
     mocker.patch.object(
         PARALLEL_UPLOAD_PROCESSING_BY_REPO,
         "check_value",
-        return_value=do_parallel_processing,
+        return_value=parallel_processing,
     )
 
     repository = RepositoryFactory.create()

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -32,9 +32,9 @@ from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import TestResultsFlow, UploadFlow
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
+from helpers.parallel import ParallelFeature
 from helpers.reports import delete_archive_setting
 from helpers.save_commit_error import save_commit_error
-from rollouts import PARALLEL_UPLOAD_PROCESSING_BY_REPO
 from services.archive import ArchiveService
 from services.bundle_analysis.report import BundleAnalysisReportService
 from services.redis import download_archive_from_redis, get_redis_connection
@@ -606,9 +606,24 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
     ):
         checkpoints.log(UploadFlow.INITIAL_PROCESSING_COMPLETE)
 
-        do_parallel_processing = PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
-            identifier=commit.repository.repoid
-        ) and not delete_archive_setting(commit_yaml)
+        parallel_feature = ParallelFeature.load(upload_context.repoid)
+        if parallel_feature is ParallelFeature.EXPERIMENT and delete_archive_setting(
+            commit_yaml
+        ):
+            parallel_feature = ParallelFeature.SERIAL
+
+        if parallel_feature is not ParallelFeature.SERIAL:
+            parallel_tasks = self.create_parallel_tasks(
+                commit,
+                commit_yaml,
+                argument_list,
+                commit_report,
+                checkpoints,
+                parallel_feature is ParallelFeature.PARALLEL,
+            )
+
+            if parallel_feature is ParallelFeature.PARALLEL:
+                return parallel_tasks.apply_async()
 
         processing_tasks = [
             upload_processor_task.s(
@@ -623,7 +638,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             for chunk in itertools.batched(argument_list, CHUNK_SIZE)
         ]
         processing_tasks[0].args = ({},)  # this is the first `previous_results`
-        if do_parallel_processing:
+        if parallel_feature is ParallelFeature.EXPERIMENT:
             processing_tasks[-1].kwargs.update(is_final=True)
 
         processing_tasks.append(
@@ -638,12 +653,24 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 },
             )
         )
-
         serial_tasks = chain(processing_tasks)
 
-        if not do_parallel_processing:
-            return serial_tasks.apply_async()
+        if parallel_feature is ParallelFeature.EXPERIMENT:
+            parallel_shadow_experiment = serial_tasks | parallel_tasks
+            return parallel_shadow_experiment.apply_async()
 
+        return serial_tasks.apply_async()
+
+    @sentry_sdk.trace
+    def create_parallel_tasks(
+        self,
+        commit: Commit,
+        commit_yaml: dict,
+        argument_list: list[dict],
+        commit_report: CommitReport,
+        checkpoints: CheckpointLogger,
+        run_fully_parallel: bool,
+    ):
         parallel_processing_tasks = [
             upload_processor_task.s(
                 repoid=commit.repoid,
@@ -657,6 +684,11 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             )
             for arguments in argument_list
         ]
+        if run_fully_parallel:
+            for task in parallel_processing_tasks:
+                # this is the `previous_results`, which celery provides when running
+                # in a chain as part of the experiment, otherwise we have to provide this.
+                task.args = ({},)
 
         finish_parallel_sig = upload_finisher_task.signature(
             kwargs={
@@ -670,8 +702,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         )
 
         parallel_tasks = chord(parallel_processing_tasks, finish_parallel_sig)
-        parallel_shadow_experiment = serial_tasks | parallel_tasks
-        return parallel_shadow_experiment.apply_async()
+        return parallel_tasks
 
     def _schedule_bundle_analysis_processing_task(
         self,

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -15,6 +15,7 @@ from shared.celery_config import (
 )
 from shared.metrics import Histogram
 from shared.reports.editable import EditableReport, EditableReportFile
+from shared.reports.enums import UploadState
 from shared.reports.resources import Report
 from shared.storage.exceptions import FileNotInStorageError
 from shared.yaml import UserYaml
@@ -23,20 +24,25 @@ from app import celery_app
 from celery_config import notify_error_task_name
 from database.models import Commit, Pull
 from database.models.core import Repository
+from database.models.reports import Upload
 from helpers.checkpoint_logger import _kwargs_key
 from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import UploadFlow
 from helpers.metrics import KiB, MiB
-from rollouts import PARALLEL_UPLOAD_PROCESSING_BY_REPO
+from helpers.parallel import ParallelProcessing
 from services.archive import ArchiveService, MinioEndpoints
 from services.comparison import get_or_create_comparison
 from services.redis import get_redis_connection
-from services.report import ReportService
-from services.report.raw_upload_processor import clear_carryforward_sessions
+from services.report import ReportService, delete_uploads_by_sessionid
+from services.report.raw_upload_processor import (
+    SessionAdjustmentResult,
+    clear_carryforward_sessions,
+)
 from services.yaml import read_yaml_field
 from tasks.base import BaseCodecovTask
 from tasks.parallel_verification import parallel_verification_task
 from tasks.upload_clean_labels_index import task_name as clean_labels_index_task_name
+from tasks.upload_processor import UploadProcessorTask
 
 log = logging.getLogger(__name__)
 
@@ -101,7 +107,6 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         repoid,
         commitid,
         commit_yaml,
-        in_parallel=False,
         report_code=None,
         **kwargs,
     ):
@@ -129,10 +134,11 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         assert commit, "Commit not found in database."
         repository = commit.repository
 
-        if (
-            PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(identifier=repository.repoid)
-            and in_parallel
-        ):
+        parallel_processing = ParallelProcessing.from_task_args(repoid, **kwargs)
+
+        if parallel_processing.is_parallel:
+            # need to transform processing_results produced by chord to get it into the
+            # same format as the processing_results produced from chain
             processing_results = {
                 "processings_so_far": [
                     task["processings_so_far"][0] for task in processing_results
@@ -149,6 +155,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 commit,
                 report_service,
                 processing_results,
+                parallel_processing,
             )
 
             log.info(
@@ -161,28 +168,42 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 ),
             )
 
-            parallel_paths = report_service.save_parallel_report_to_archive(
-                commit, report, report_code
-            )
-            # now that we've built the report and stored it to GCS, we have what we need to
-            # compare the results with the current upload pipeline. We end execution of the
-            # finisher task here so that we don't cause any additional side-effects
+            if parallel_processing is ParallelProcessing.PARALLEL:
+                pr = processing_results["processings_so_far"][0]["arguments"].get("pr")
+                processor_task = UploadProcessorTask()
+                processor_task.save_report_results(
+                    db_session,
+                    report_service,
+                    repository,
+                    commit,
+                    report,
+                    pr,
+                    report_code,
+                )
 
-            # The verification task that will compare the results of the serial flow and
-            # the parallel flow, and log the result to determine if parallel flow is
-            # working properly.
-            parallel_verification_task.apply_async(
-                kwargs=dict(
-                    repoid=repoid,
-                    commitid=commitid,
-                    commit_yaml=commit_yaml,
-                    report_code=report_code,
-                    parallel_paths=parallel_paths,
-                    processing_results=processing_results,
-                ),
-            )
+            else:
+                parallel_paths = report_service.save_parallel_report_to_archive(
+                    commit, report, report_code
+                )
+                # now that we've built the report and stored it to GCS, we have what we need to
+                # compare the results with the current upload pipeline. We end execution of the
+                # finisher task here so that we don't cause any additional side-effects
 
-            return
+                # The verification task that will compare the results of the serial flow and
+                # the parallel flow, and log the result to determine if parallel flow is
+                # working properly.
+                parallel_verification_task.apply_async(
+                    kwargs=dict(
+                        repoid=repoid,
+                        commitid=commitid,
+                        commit_yaml=commit_yaml,
+                        report_code=report_code,
+                        parallel_paths=parallel_paths,
+                        processing_results=processing_results,
+                    ),
+                )
+
+                return
 
         lock_name = f"upload_finisher_lock_{repoid}_{commitid}"
         redis_connection = get_redis_connection()
@@ -253,7 +274,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         db_session,
         commit: Commit,
         commit_yaml: UserYaml,
-        processing_results,
+        processing_results: dict,
         report_code,
         checkpoints,
     ):
@@ -370,7 +391,9 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
 
         return {"notifications_called": notifications_called}
 
-    def should_clean_labels_index(self, commit_yaml: UserYaml, processing_results):
+    def should_clean_labels_index(
+        self, commit_yaml: UserYaml, processing_results: dict
+    ):
         """Returns True if any of the successful processings was uploaded using a flag
         that implies labels were uploaded with the report.
         """
@@ -389,7 +412,11 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         return any(map(should_clean_for_processing_result, actual_processing_results))
 
     def should_call_notifications(
-        self, commit: Commit, commit_yaml: UserYaml, processing_results, report_code
+        self,
+        commit: Commit,
+        commit_yaml: UserYaml,
+        processing_results: dict,
+        report_code,
     ) -> ShouldCallNotifyResult:
         extra_dict = {
             "repoid": commit.repoid,
@@ -473,41 +500,52 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         commit: Commit,
         report_service: ReportService,
         processing_results: dict,
+        parallel_processing: ParallelProcessing,
     ):
         archive_service = report_service.get_archive_service(repository)
         repoid = repository.repoid
         commitid = commit.id
 
-        fas_path = MinioEndpoints.parallel_upload_experiment.get_path(
-            version="v4",
-            repo_hash=archive_service.get_archive_hash(repository),
-            commitid=commit.commitid,
-            file_name="files_and_sessions",
-        )
-        chunks_path = MinioEndpoints.parallel_upload_experiment.get_path(
-            version="v4",
-            repo_hash=archive_service.get_archive_hash(repository),
-            commitid=commit.commitid,
-            file_name="chunks",
-        )
+        if parallel_processing is ParallelProcessing.PARALLEL:
+            report = report_service.get_existing_report_for_commit(commit)
+            if report is None:
+                log.info(
+                    "No base report found for parallel upload processing, using an empty report",
+                    extra=dict(commit=commitid, repoid=repoid),
+                )
+                report = Report()
 
-        try:
-            files_and_sessions = json.loads(archive_service.read_file(fas_path))
-            chunks = archive_service.read_file(chunks_path).decode(errors="replace")
-            report = report_service.build_report(
-                chunks,
-                files_and_sessions["files"],
-                files_and_sessions["sessions"],
-                None,
+        else:
+            fas_path = MinioEndpoints.parallel_upload_experiment.get_path(
+                version="v4",
+                repo_hash=archive_service.get_archive_hash(repository),
+                commitid=commit.commitid,
+                file_name="files_and_sessions",
             )
-        except (
-            FileNotInStorageError
-        ):  # there were no CFFs, so no report was stored in GCS
-            log.info(
-                "No base report found for parallel upload processing, using an empty report",
-                extra=dict(commit=commitid, repoid=repoid),
+            chunks_path = MinioEndpoints.parallel_upload_experiment.get_path(
+                version="v4",
+                repo_hash=archive_service.get_archive_hash(repository),
+                commitid=commit.commitid,
+                file_name="chunks",
             )
-            report = Report()
+
+            try:
+                files_and_sessions = json.loads(archive_service.read_file(fas_path))
+                chunks = archive_service.read_file(chunks_path).decode(errors="replace")
+                report = report_service.build_report(
+                    chunks,
+                    files_and_sessions["files"],
+                    files_and_sessions["sessions"],
+                    None,
+                )
+            except (
+                FileNotInStorageError
+            ):  # there were no CFFs, so no report was stored in GCS
+                log.info(
+                    "No base report found for parallel upload processing, using an empty report",
+                    extra=dict(commit=commitid, repoid=repoid),
+                )
+                report = Report()
 
         log.info(
             "Downloading %s incremental reports that were processed in parallel",
@@ -564,18 +602,30 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 session, use_id_from_session=True
             )
 
+            session_adjustment = SessionAdjustmentResult([], [])
             if flags := session.flags:
-                clear_carryforward_sessions(
+                session_adjustment = clear_carryforward_sessions(
                     cumulative_report, incremental_report, flags, UserYaml(commit_yaml)
                 )
-            # ReportService.update_upload_with_processing_result should use this result
-            # to update the state of Upload. Once the experiment is finished, Upload.state should
-            # be set to: parallel_processed (instead of processed)
 
             cumulative_report.merge(incremental_report)
 
-            # once the experiment is finished, we should be modifying the Upload here
-            # moving it's state from: parallel_processed -> processed
+            if parallel_processing is ParallelProcessing.PARALLEL:
+                # When we are fully parallel, we need to update the `Upload` in the database
+                # with the final session_id (aka `order_number`) and other statuses
+                db_session = commit.get_db_session()
+                upload = (
+                    db_session.query(Upload)
+                    .filter(Upload.id_ == obj["upload_pk"])
+                    .first()
+                )
+                upload.state_id = UploadState.PROCESSED.db_id
+                upload.state = "processed"
+                upload.order_number = new_sessionid
+                delete_uploads_by_sessionid(
+                    upload, session_adjustment.fully_deleted_sessions
+                )
+                db_session.flush()
 
             return cumulative_report
 
@@ -596,6 +646,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
             ),
         )
         report = functools.reduce(merge_report, unmerged_reports, report)
+        commit.get_db_session().flush()
         return report
 
 

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from typing import Any
 
 import sentry_sdk
 from asgiref.sync import async_to_sync
@@ -17,14 +18,13 @@ from database.models import Commit, Upload
 from database.models.core import Pull, Repository
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
-from helpers.metrics import metrics
+from helpers.parallel import ParallelProcessing
 from helpers.parallel_upload_processing import (
     save_final_serial_report_results,
     save_incremental_report_results,
 )
 from helpers.reports import delete_archive_setting
 from helpers.save_commit_error import save_commit_error
-from rollouts import PARALLEL_UPLOAD_PROCESSING_BY_REPO
 from services.redis import get_redis_connection
 from services.report import ProcessingResult, RawReportInfo, Report, ReportService
 from services.report.parser.types import VersionOneParsedRawReport
@@ -79,22 +79,19 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         commit_yaml,
         arguments_list,
         report_code=None,
-        parallel_idx=None,
-        in_parallel=False,
-        is_final=False,
         **kwargs,
     ):
         repoid = int(repoid)
         log.info(
             "Received upload processor task",
-            extra=dict(repoid=repoid, commit=commitid, in_parallel=in_parallel),
+            extra=dict(
+                repoid=repoid, commit=commitid, in_parallel=kwargs.get("in_parallel")
+            ),
         )
 
-        in_parallel = in_parallel and PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
-            identifier=repoid
-        )
+        parallel_processing = ParallelProcessing.from_task_args(repoid, **kwargs)
 
-        if in_parallel:
+        if parallel_processing.is_parallel:
             log.info(
                 "Using parallel upload processing, skip acquiring upload processing lock",
                 extra=dict(
@@ -105,18 +102,15 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 ),
             )
 
-            # This function is named `within_lock` but we gate any concurrency-
-            # unsafe operations with `PARALLEL_UPLOAD_PROCESSING_BY_REPO`.
-            return self.process_impl_within_lock(
+            return self.process_upload(
                 db_session=db_session,
                 previous_results={},
                 repoid=repoid,
                 commitid=commitid,
                 commit_yaml=commit_yaml,
                 arguments_list=arguments_list,
-                parallel_idx=parallel_idx,
                 report_code=report_code,
-                in_parallel=in_parallel,
+                parallel_processing=parallel_processing,
             )
 
         lock_name = UPLOAD_PROCESSING_LOCK_NAME(repoid, commitid)
@@ -147,7 +141,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                     ),
                 )
 
-                return self.process_impl_within_lock(
+                return self.process_upload(
                     db_session=db_session,
                     previous_results=previous_results,
                     repoid=repoid,
@@ -155,9 +149,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                     commit_yaml=commit_yaml,
                     arguments_list=arguments_list,
                     report_code=report_code,
-                    parallel_idx=parallel_idx,
-                    in_parallel=in_parallel,
-                    is_final=is_final,
+                    parallel_processing=parallel_processing,
                 )
         except LockError:
             max_retry = 200 * 3**self.request.retries
@@ -175,18 +167,16 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             self.retry(max_retries=MAX_RETRIES, countdown=retry_in)
 
     @sentry_sdk.trace
-    def process_impl_within_lock(
+    def process_upload(
         self,
         db_session,
-        previous_results,
+        previous_results: dict,
         repoid: int,
-        commitid,
+        commitid: str,
         commit_yaml: dict,
-        arguments_list,
+        arguments_list: list[dict],
         report_code,
-        parallel_idx=None,
-        in_parallel=False,
-        is_final=False,
+        parallel_processing: ParallelProcessing,
     ):
         processings_so_far: list[dict] = previous_results.get("processings_so_far", [])
         n_processed = 0
@@ -202,6 +192,8 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         pr = None
         report_service = ReportService(UserYaml(commit_yaml))
 
+        in_parallel = parallel_processing.is_parallel
+
         if in_parallel:
             log.info(
                 "Creating empty report to store incremental result",
@@ -209,16 +201,15 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             )
             report = Report()
         else:
-            with metrics.timer(f"{self.metrics_prefix}.build_original_report"):
-                report = report_service.get_existing_report_for_commit(
-                    commit, report_code=report_code
+            report = report_service.get_existing_report_for_commit(
+                commit, report_code=report_code
+            )
+            if report is None:
+                log.info(
+                    "No existing report for commit",
+                    extra=dict(commit=commit.commitid),
                 )
-                if report is None:
-                    log.info(
-                        "No existing report for commit",
-                        extra=dict(commit=commit.commitid),
-                    )
-                    report = Report()
+                report = Report()
 
         raw_reports: list[RawReportInfo] = []
         try:
@@ -242,24 +233,21 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                         in_parallel=in_parallel,
                     ),
                 )
-                individual_info = {"arguments": arguments}
+                individual_info: dict[str, Any] = {"arguments": arguments}
                 try:
-                    with metrics.timer(
-                        f"{self.metrics_prefix}.process_individual_report"
-                    ):
-                        raw_report_info = RawReportInfo()
-                        processing_result = self.process_individual_report(
-                            report_service,
-                            commit,
-                            report,
-                            upload_obj,
-                            raw_report_info,
-                            in_parallel=in_parallel,
-                        )
-                        # NOTE: this is only used because test mocking messes with the return value here.
-                        # in normal flow, the function mutates the argument instead.
-                        if processing_result.report:
-                            report = processing_result.report
+                    raw_report_info = RawReportInfo()
+                    processing_result = self.process_individual_report(
+                        report_service,
+                        commit,
+                        report,
+                        upload_obj,
+                        raw_report_info,
+                        parallel_processing,
+                    )
+                    # NOTE: this is only used because test mocking messes with the return value here.
+                    # in normal flow, the function mutates the argument instead.
+                    if processing_result.report:
+                        report = processing_result.report
                 except (CeleryError, SoftTimeLimitExceeded, SQLAlchemyError):
                     raise
 
@@ -290,12 +278,15 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             parallel_incremental_result = None
             results_dict = {}
             if in_parallel:
+                upload_id = arguments_list[0].get("upload_pk")
                 parallel_incremental_result = save_incremental_report_results(
-                    report_service, commit, report, parallel_idx, report_code
+                    report_service,
+                    commit,
+                    report,
+                    upload_id,
+                    report_code,
                 )
-                parallel_incremental_result["upload_pk"] = arguments_list[0].get(
-                    "upload_pk"
-                )
+                parallel_incremental_result["upload_pk"] = upload_id
 
                 log.info(
                     "Saved incremental report results to storage",
@@ -320,7 +311,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                 # ParallelVerification task to compare with later, for the parallel
                 # experiment. The report being saved is not necessarily the final
                 # report for the commit, as more uploads can still be made.
-                if is_final:
+                if parallel_processing is ParallelProcessing.EXPERIMENT_SERIAL:
                     final_serial_report_url = save_final_serial_report_results(
                         report_service, commit, report, report_code, arguments_list
                     )
@@ -376,10 +367,10 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         report: Report,
         upload: Upload,
         raw_report_info: RawReportInfo,
-        in_parallel=False,
+        parallel_processing: ParallelProcessing,
     ) -> ProcessingResult:
         processing_result = report_service.build_report_from_raw_content(
-            report, raw_report_info, upload=upload
+            report, raw_report_info, upload
         )
         if (
             processing_result.error is not None
@@ -401,7 +392,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
 
         # for the parallel experiment, we don't want to modify anything in the
         # database, so we disable it here
-        if not in_parallel:
+        if parallel_processing is not ParallelProcessing.EXPERIMENT_PARALLEL:
             report_service.update_upload_with_processing_result(
                 upload, processing_result
             )


### PR DESCRIPTION
This adds another variant to the `PARALLEL_PROCESSING` feature/rollout flag which prefers the parallel upload processing pipeline in favor of running it as an experiment.

Upload Processing can run in essentially 4 modes:
- Completely serial processing
- Serial processing, but running "experiment" code (`EXPERIMENT_SERIAL`):
  - In this mode, the final (`is_final`) `UploadProcessor` task saves a copy
    of the final report for later verification.
- Parallel processing, but running "experiment" code (`EXPERIMENT_PARALLEL`):
  - In this mode, another parallel set of `UploadProcessor` tasks runs *after*
    the main set up tasks.
  - These tasks are not persisting any of their results in the database,
    instead the final `UploadFinisher` task will launch the `ParallelVerification` task.
- Fully parallel processing (`PARALLEL`):
  - In this mode, the final `UploadFinisher` task is responsible for merging
    the final report and persisting it.

An example Task chain might look like this, in "experiment" mode:
- Upload
  - UploadProcessor
    - UploadProcessor
      - UploadProcessor (`EXPERIMENT_SERIAL` (the final one))
        - UploadFinisher
          - UploadProcessor (`EXPERIMENT_PARALLEL`)
          - UploadProcessor (`EXPERIMENT_PARALLEL`)
          - UploadProcessor (`EXPERIMENT_PARALLEL`)
            - UploadFinisher (`EXPERIMENT_PARALLEL`)
              - ParallelVerification

The `PARALLEL` mode looks like this:
- Upload
  - UploadProcessor (`PARALLEL`)
  - UploadProcessor (`PARALLEL`)
  - UploadProcessor (`PARALLEL`)
    - UploadFinisher (`PARALLEL`)