### PR TITLE
Make `ReportService` sync

### DIFF
--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -93,7 +93,7 @@ class ProcessingResult:
 
 
 class BundleAnalysisReportService(BaseReportService):
-    async def initialize_and_save_report(
+    def initialize_and_save_report(
         self, commit: Commit, report_code: str = None
     ) -> CommitReport:
         db_session = commit.get_db_session()

--- a/services/notification/notifiers/tests/conftest.py
+++ b/services/notification/notifiers/tests/conftest.py
@@ -346,7 +346,7 @@ def sample_comparison(dbsession, request, sample_report, mocker):
 
 
 @pytest.fixture
-async def sample_comparison_coverage_carriedforward(
+def sample_comparison_coverage_carriedforward(
     dbsession, request, sample_commit_with_report_already_carriedforward, mocker
 ):
     mocker.patch(
@@ -368,7 +368,7 @@ async def sample_comparison_coverage_carriedforward(
     dbsession.flush()
 
     yaml_dict = {"flags": {"enterprise": {"carryforward": True}}}
-    report = await ReportService(yaml_dict).build_report_from_commit(head_commit)
+    report = ReportService(yaml_dict).build_report_from_commit(head_commit)
     report._totals = (
         None  # need to reset the report to get it to recalculate totals correctly
     )

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -32,7 +32,7 @@ class TestResultsReportService(BaseReportService):
         super().__init__(current_yaml)
         self.flag_dict = None
 
-    async def initialize_and_save_report(
+    def initialize_and_save_report(
         self, commit: Commit, report_code: str = None
     ) -> CommitReport:
         db_session = commit.get_db_session()

--- a/tasks/preprocess_upload.py
+++ b/tasks/preprocess_upload.py
@@ -114,9 +114,7 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
             commit_yaml, gh_app_installation_name=installation_name_to_use
         )
         # For parallel upload processing experiment, saving the report to GCS happens here
-        commit_report = async_to_sync(report_service.initialize_and_save_report)(
-            commit, report_code
-        )
+        commit_report = report_service.initialize_and_save_report(commit, report_code)
         # Persist changes from within the lock
         db_session.flush()
         return {

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -482,7 +482,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
 
         try:
             log.info("Initializing and saving report", extra=upload_context.log_extra())
-            commit_report = async_to_sync(report_service.initialize_and_save_report)(
+            commit_report = report_service.initialize_and_save_report(
                 commit,
                 upload_context.report_code,
             )


### PR DESCRIPTION
It looks like historically there is a mix of sync/async code.
The consensus(?) seems to favor sync code as celery is fundamentally sync.
Async code also does not play as well with profiling, which will not show the async code directly in a flamegraph, instead just inserting a `wait` for the async code running in a different thread.