### PR TITLE
fix flake model

### DIFF
--- a/database/base.py
+++ b/database/base.py
@@ -30,3 +30,15 @@ class MixinBaseClass(object):
     @property
     def id(self):
         return self.id_
+
+
+class MixinBaseClassNoExternalID(object):
+    id_ = Column("id", types.BigInteger, primary_key=True)
+    created_at = Column(types.DateTime(timezone=True), default=get_utc_now)
+    updated_at = Column(
+        types.DateTime(timezone=True), onupdate=get_utc_now, default=get_utc_now
+    )
+
+    @property
+    def id(self):
+        return self.id_

--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -9,7 +9,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import backref, relationship
 
-from database.base import CodecovBaseModel, MixinBaseClass
+from database.base import CodecovBaseModel, MixinBaseClass, MixinBaseClassNoExternalID
 from database.models.core import Commit, CompareCommit, Repository
 from database.utils import ArchiveField
 from helpers.clock import get_utc_now
@@ -332,7 +332,7 @@ class ReducedError(CodecovBaseModel, MixinBaseClass):
     message = Column(types.Text)
 
 
-class Flake(CodecovBaseModel, MixinBaseClass):
+class Flake(CodecovBaseModel, MixinBaseClassNoExternalID):
     __tablename__ = "reports_flake"
     repoid = Column(types.Integer, ForeignKey("repos.repoid"))
     repository = relationship("Repository", backref=backref("flakes"))


### PR DESCRIPTION
the Flake model defined in shared uses the `BaseModel` which does not include the `external_id` field.

The `Flake` model defined in worker used the `MixinBaseClass` that included that field, I made a new `MixinBaseClassWithNoExternalID` so that there's an equivalent base class mixin for the `BaseModel` in shared, and changed the `Flake` to use that