### PR TITLE
tests: extend upload e2e test

### DIFF
--- a/tasks/tests/utils.py
+++ b/tasks/tests/utils.py
@@ -37,6 +37,7 @@ GLOBALS_USING_REPO_PROVIDER = [
     "tasks.notify.get_repo_provider_service",
     "tasks.upload_processor.get_repo_provider_service",
     "tasks.upload.get_repo_provider_service",
+    "services.comparison.get_repo_provider_service",
 ]
 
 


### PR DESCRIPTION
Extends the upload e2e test to also take into account the Comparison
that is generated when the commit is part of a PR.
