### PR TITLE
Refactor Upload processing and file rewriting a bit

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -2,12 +2,11 @@ import copy
 import itertools
 import logging
 import sys
-import typing
 import uuid
 from dataclasses import dataclass
 from json import loads
 from time import time
-from typing import Any, Dict, Mapping, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 import sentry_sdk
 from asgiref.sync import async_to_sync
@@ -62,15 +61,17 @@ from services.report.prometheus_metrics import (
     RAW_UPLOAD_RAW_REPORT_COUNT,
     RAW_UPLOAD_SIZE,
 )
-from services.report.raw_upload_processor import process_raw_upload
+from services.report.raw_upload_processor import (
+    process_raw_upload,
+)
 from services.repository import get_repo_provider_service
 from services.yaml.reader import get_paths_from_flags, read_yaml_field
 
 
 @dataclass
-class ProcessingError(object):
+class ProcessingError:
     code: str
-    params: Dict[str, Any]
+    params: dict[str, Any]
     is_retryable: bool = False
 
     def as_dict(self):
@@ -78,32 +79,17 @@ class ProcessingError(object):
 
 
 @dataclass
-class ProcessingResult(object):
-    report: Optional[Report]
+class ProcessingResult:
     session: Session
-    error: Optional[ProcessingError]
-    fully_deleted_sessions: typing.List[int]
-    partially_deleted_sessions: typing.List[int]
-    raw_report: ParsedRawReport
-    upload_obj: Upload
+    report: Report | None = None
+    error: ProcessingError | None = None
 
-    def as_dict(self):
-        # Weird flow for now in order to keep things compatible with previous logging
-        if self.error is not None:
-            return {
-                "successful": False,
-                "error": self.error.as_dict(),
-                "report": self.report,
-                "should_retry": False,
-                "raw_report": self.raw_report,
-                "upload_obj": self.upload_obj,
-            }
-        return {
-            "successful": True,
-            "report": self.report,
-            "raw_report": self.raw_report,
-            "upload_obj": self.upload_obj,
-        }
+
+@dataclass
+class RawReportInfo:
+    raw_report: ParsedRawReport | None = None
+    archive_url: str = ""
+    upload: str = ""
 
 
 log = logging.getLogger(__name__)
@@ -854,7 +840,7 @@ class ReportService(BaseReportService):
 
     @sentry_sdk.trace
     def parse_raw_report_from_storage(
-        self, repo: Repository, upload: Upload, is_parallel=False, is_error_case=False
+        self, repo: Repository, upload: Upload, is_parallel=False
     ) -> ParsedRawReport:
         """Pulls the raw uploaded report from storage and parses it so it's
         easier to access different parts of the raw upload.
@@ -881,7 +867,7 @@ class ReportService(BaseReportService):
         # reports to a human readable version that doesn't include file fixes, so that's why copying is necessary.
         if PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
             identifier=repo.repoid, default=False
-        ) and (not is_error_case):
+        ):
             parallel_url = archive_url.removesuffix(".txt") + "_PARALLEL.txt"
             log.info(
                 "In the parallel experiment for parsing raw report in storage",
@@ -939,19 +925,18 @@ class ReportService(BaseReportService):
 
     @sentry_sdk.trace
     def build_report_from_raw_content(
-        self, master: Optional[Report], upload: Upload, parallel_idx=None
+        self,
+        report: Report,
+        raw_report_info: RawReportInfo,
+        upload: Upload,
+        parallel_idx=None,
     ) -> ProcessingResult:
         """
-            Processes an upload on top of an existing report `master` and returns
-                a result, which could be successful or not
+        Processes an upload on top of an existing report `master` and returns
+        a result, which could be successful or not
 
-            Note that this function does not modify the `upload` object, as this should
-                be done by a separate function
-
-        Args:
-            master (Optional[Report]): The current report we are building on top of
-            reports (ParsedRawReport): The uploaded report string fetched and parsed
-            upload (Upload): The upload made by the user that we are processing
+        Note that this function does not modify the `upload` object, as this should
+        be done by a separate function
         """
         commit = upload.report.commit
         flags = upload.flag_names
@@ -973,10 +958,16 @@ class ReportService(BaseReportService):
             archive=archive_url,
             url=build_url,
         )
+        result = ProcessingResult(session=session)
+
+        raw_report_info.archive_url = archive_url
+        raw_report_info.upload = upload.external_id
+
         try:
-            raw_uploaded_report = self.parse_raw_report_from_storage(
+            raw_report = self.parse_raw_report_from_storage(
                 commit.repository, upload, is_parallel=parallel_idx is not None
             )
+            raw_report_info.raw_report = raw_report
         except FileNotInStorageError:
             log.info(
                 "Raw report file was not found",
@@ -989,31 +980,26 @@ class ReportService(BaseReportService):
                     in_parallel=parallel_idx is not None,
                 ),
             )
-            return ProcessingResult(
-                report=None,
-                session=session,
-                error=ProcessingError(
-                    code="file_not_in_storage",
-                    params={"location": archive_url},
-                    is_retryable=True,
-                ),
-                fully_deleted_sessions=None,
-                partially_deleted_sessions=None,
-                raw_report=None,
-                upload_obj=upload,
+            result.error = ProcessingError(
+                code="file_not_in_storage",
+                params={"location": archive_url},
+                is_retryable=True,
             )
+            return result
+
         log.debug("Retrieved report for processing from url %s", archive_url)
         try:
             with metrics.timer(f"{self.metrics_prefix}.process_report") as t:
-                result = process_raw_upload(
+                process_result = process_raw_upload(
                     self.current_yaml,
-                    master,
-                    raw_uploaded_report,
+                    report,
+                    raw_report,
                     flags,
                     session,
                     upload=upload,
                     parallel_idx=parallel_idx,
                 )
+                result.report = process_result.report
             log.info(
                 "Successfully processed report"
                 + (" (in parallel)" if parallel_idx is not None else ""),
@@ -1025,18 +1011,10 @@ class ReportService(BaseReportService):
                     reportid=reportid,
                     commit_yaml=self.current_yaml.to_dict(),
                     timing_ms=t.ms,
-                    content_len=raw_uploaded_report.size,
+                    content_len=raw_report.size,
                 ),
             )
-            return ProcessingResult(
-                report=result.report,
-                session=session,
-                error=None,
-                fully_deleted_sessions=result.fully_deleted_sessions,
-                partially_deleted_sessions=result.partially_deleted_sessions,
-                raw_report=result.raw_report,
-                upload_obj=upload,
-            )
+            return result
         except ReportExpiredException as r:
             log.info(
                 "Report %s is expired",
@@ -1048,30 +1026,16 @@ class ReportService(BaseReportService):
                     file_name=r.filename,
                 ),
             )
-            return ProcessingResult(
-                report=None,
-                session=session,
-                error=ProcessingError(code="report_expired", params={}),
-                fully_deleted_sessions=None,
-                partially_deleted_sessions=None,
-                raw_report=raw_uploaded_report,
-                upload_obj=upload,
-            )
+            result.error = ProcessingError(code="report_expired", params={})
+            return result
         except ReportEmptyError:
             log.warning(
                 "Report %s is empty",
                 reportid,
                 extra=dict(repoid=commit.repoid, commit=commit.commitid),
             )
-            return ProcessingResult(
-                report=None,
-                session=session,
-                error=ProcessingError(code="report_empty", params={}),
-                fully_deleted_sessions=None,
-                partially_deleted_sessions=None,
-                raw_report=raw_uploaded_report,
-                upload_obj=upload,
-            )
+            result.error = ProcessingError(code="report_empty", params={})
+            return result
 
     def update_upload_with_processing_result(
         self, upload_obj: Upload, processing_result: ProcessingResult

--- a/services/report/parser/legacy.py
+++ b/services/report/parser/legacy.py
@@ -1,6 +1,5 @@
 import string
 from io import BytesIO
-from typing import BinaryIO
 
 import sentry_sdk
 
@@ -109,23 +108,12 @@ class LegacyReportParser(object):
     @sentry_sdk.trace
     @metrics.timer("services.report.parser.parse_raw_report_from_bytes")
     def parse_raw_report_from_bytes(self, raw_report: bytes) -> LegacyParsedRawReport:
-        raw_report, _, compat_report_str = raw_report.partition(
+        raw_report, _, _compat_report_str = raw_report.partition(
             self.ignore_from_now_on_marker
         )
         sections = self.cut_sections(raw_report)
         res = self._generate_parsed_report_from_sections(sections)
-        if compat_report_str:
-            compat_report = self._generate_parsed_report_from_sections(
-                self.cut_sections(compat_report_str)
-            )
-            self.compare_compat_and_main_reports(res, compat_report)
         return res
-
-    def compare_compat_and_main_reports(self, actual_result, compat_result):
-        pass
-
-    def parse_raw_report_from_io(self, raw_report: BinaryIO) -> LegacyParsedRawReport:
-        return self.parse_raw_report_from_bytes(raw_report.getvalue())
 
     def _generate_parsed_report_from_sections(self, sections):
         uploaded_files = []

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -4437,13 +4437,8 @@ class TestReportService(BaseTestCase):
         dbsession.flush()
         assert len(upload_obj.errors) == 0
         processing_result = ProcessingResult(
-            report=None,
             session=mocker.MagicMock(),
             error=ProcessingError(code="abclkj", params={"banana": "value"}),
-            fully_deleted_sessions=[],
-            partially_deleted_sessions=[],
-            raw_report=None,
-            upload_obj=upload_obj,
         )
         assert (
             ReportService({}).update_upload_with_processing_result(
@@ -4465,13 +4460,8 @@ class TestReportService(BaseTestCase):
         dbsession.flush()
         assert len(upload_obj.errors) == 0
         processing_result = ProcessingResult(
-            report=Report(),
             session=Session(),
             error=None,
-            fully_deleted_sessions=[],
-            partially_deleted_sessions=[],
-            raw_report=None,
-            upload_obj=upload_obj,
         )
         assert (
             ReportService({}).update_upload_with_processing_result(


### PR DESCRIPTION
This moved some code around and improves type annotations. I tried to make the code related to error handling and "rewrite readable" a bit more readable, but wasn’t fully successful.

This should also slightly improve perf, as it should avoid re-SELECT-ing the `upload` after it has been modified. All in all, I still don’t understand why the upload model is fetched twice, but I guess its just some magic accessor that does this implicitly.
