### PR TITLE
perf: reuse pull and comparison

### DIFF
--- a/services/bundle_analysis/notify/helpers.py
+++ b/services/bundle_analysis/notify/helpers.py
@@ -49,8 +49,8 @@ def get_notification_types_configured(
     """Gets a tuple with all the different bundle analysis notifications that we should attempt to send,
     based on the given YAML"""
     notification_types = [
-        is_commit_status_configured(yaml, owner),
         is_comment_configured(yaml, owner),
+        is_commit_status_configured(yaml, owner),
     ]
     return tuple(filter(None, notification_types))
 

--- a/services/bundle_analysis/notify/tests/test_helpers.py
+++ b/services/bundle_analysis/notify/tests/test_helpers.py
@@ -81,19 +81,19 @@ def gitlab_owner(dbsession) -> Owner:
         pytest.param(
             {"comment": {"require_bundle_changes": False}},
             "github_owner_no_apps",
-            (NotificationType.COMMIT_STATUS, NotificationType.PR_COMMENT),
+            (NotificationType.PR_COMMENT, NotificationType.COMMIT_STATUS),
             id="default_values_github_no_apps",
         ),
         pytest.param(
             {"comment": {"require_bundle_changes": False}},
             "github_owner_with_apps",
-            (NotificationType.GITHUB_COMMIT_CHECK, NotificationType.PR_COMMENT),
+            (NotificationType.PR_COMMENT, NotificationType.GITHUB_COMMIT_CHECK),
             id="default_values_github_with_apps",
         ),
         pytest.param(
             {"comment": {"require_bundle_changes": False}},
             "gitlab_owner",
-            (NotificationType.COMMIT_STATUS, NotificationType.PR_COMMENT),
+            (NotificationType.PR_COMMENT, NotificationType.COMMIT_STATUS),
             id="default_values_gitlab",
         ),
         pytest.param(

--- a/services/bundle_analysis/notify/tests/test_notify_service.py
+++ b/services/bundle_analysis/notify/tests/test_notify_service.py
@@ -219,8 +219,8 @@ class TestBundleAnalysisNotifyService:
         )
         assert result == BundleAnalysisNotifyReturn(
             notifications_configured=(
-                NotificationType.COMMIT_STATUS,
                 NotificationType.PR_COMMENT,
+                NotificationType.COMMIT_STATUS,
             ),
             notifications_attempted=tuple(),
             notifications_successful=tuple(),

--- a/services/bundle_analysis/tests/test_bundle_analysis.py
+++ b/services/bundle_analysis/tests/test_bundle_analysis.py
@@ -200,16 +200,16 @@ def test_bundle_analysis_notify(
     success = notifier.notify()
     assert success == BundleAnalysisNotifyReturn(
         notifications_configured=(
-            NotificationType.COMMIT_STATUS,
             NotificationType.PR_COMMENT,
+            NotificationType.COMMIT_STATUS,
         ),
         notifications_attempted=(
-            NotificationType.COMMIT_STATUS,
             NotificationType.PR_COMMENT,
+            NotificationType.COMMIT_STATUS,
         ),
         notifications_successful=(
-            NotificationType.COMMIT_STATUS,
             NotificationType.PR_COMMENT,
+            NotificationType.COMMIT_STATUS,
         ),
     )
 
@@ -221,16 +221,16 @@ def test_bundle_analysis_notify(
     success = notifier.notify()
     assert success == BundleAnalysisNotifyReturn(
         notifications_configured=(
-            NotificationType.COMMIT_STATUS,
             NotificationType.PR_COMMENT,
+            NotificationType.COMMIT_STATUS,
         ),
         notifications_attempted=(
-            NotificationType.COMMIT_STATUS,
             NotificationType.PR_COMMENT,
+            NotificationType.COMMIT_STATUS,
         ),
         notifications_successful=(
-            NotificationType.COMMIT_STATUS,
             NotificationType.PR_COMMENT,
+            NotificationType.COMMIT_STATUS,
         ),
     )
 


### PR DESCRIPTION
The objective here is to re-use the Pull and BundleAnalysisComparison that are loaded
as part of building contexts. Currently both the commit status and the PR comment notifications have to load these things independently.
Plus these just so happen to be the most slow parts of being a notification context.

Why flip the order in which we process the notifications?
Because the PR comment one is more restrictive, in the sense that the PULL cannot be `None`.
For the commit status it's possible that the Pull is `None`.

So by flipping them we can re-use the PR notification context "safely",
whereas the other way around we might run intro issues.
