### PR TITLE
Properly skip parsing empty JSON

### DIFF
--- a/services/report/report_builder.py
+++ b/services/report/report_builder.py
@@ -251,7 +251,7 @@ class ReportBuilder(object):
         self.sessionid = sessionid
         self.ignored_lines = ignored_lines
         self.path_fixer = path_fixer
-        self.shoud_use_label_index = should_use_label_index
+        self.should_use_label_index = should_use_label_index
 
     @property
     def repo_yaml(self) -> UserYaml:
@@ -259,7 +259,7 @@ class ReportBuilder(object):
         return self.current_yaml
 
     def create_report_builder_session(self, filepath) -> ReportBuilderSession:
-        return ReportBuilderSession(self, filepath, self.shoud_use_label_index)
+        return ReportBuilderSession(self, filepath, self.should_use_label_index)
 
     def supports_labels(self) -> bool:
         """Returns wether a report supports labels.

--- a/services/report/report_processor.py
+++ b/services/report/report_processor.py
@@ -116,12 +116,14 @@ def report_type_matching(
         return raw_report, "plist"
     if not raw_report:
         return raw_report, "txt"
+
     try:
         processed = json.load(report.file_contents)
         if isinstance(processed, dict) or isinstance(processed, list):
             return processed, "json"
     except ValueError:
         pass
+
     try:
         parser = etree.XMLParser(recover=True, resolve_entities=False)
         processed = etree.fromstring(raw_report, parser=parser)
@@ -129,6 +131,7 @@ def report_type_matching(
             return processed, "xml"
     except ValueError:
         pass
+
     return raw_report, "txt"
 
 
@@ -177,7 +180,7 @@ def process_report(
             GoProcessor(),
             XCodeProcessor(),
         ]
-    elif report_type == "json":
+    elif report_type == "json" and parsed_report:
         processors = [
             SalesforceProcessor(),
             ElmProcessor(),

--- a/services/report/tests/unit/test_report_processor.py
+++ b/services/report/tests/unit/test_report_processor.py
@@ -1,10 +1,12 @@
-import json
 from io import BytesIO
 
-from services.report.parser.types import ParsedUploadedReportFile
-from services.report.report_processor import report_type_matching
+import pytest
 
-xcode_report = """/Users/distiller/project/Auth0/A0ChallengeGenerator.m:
+from services.report.languages.helpers import remove_non_ascii
+from services.report.parser.types import ParsedUploadedReportFile
+from services.report.report_processor import process_report, report_type_matching
+
+xcode_report = b"""/Users/distiller/project/Auth0/A0ChallengeGenerator.m:
    28|       |@implementation A0SHA256ChallengeGenerator
    29|       |
    30|      7|- (instancetype)init {
@@ -13,90 +15,51 @@ xcode_report = """/Users/distiller/project/Auth0/A0ChallengeGenerator.m:
 """
 
 
-class TestReportTypeMatching(object):
-    def test_report_type_matching(self):
-        assert (
-            report_type_matching(
-                ParsedUploadedReportFile(filename="name", file_contents=BytesIO(b"")),
-                "",
-            )[1]
-            == "txt"
-        )
-        assert (
-            report_type_matching(
-                ParsedUploadedReportFile(filename="name", file_contents=BytesIO(b"{}")),
-                "{}",
-            )[1]
-            == "json"
-        )
-        assert (
-            report_type_matching(
-                ParsedUploadedReportFile(
-                    filename="name", file_contents=BytesIO(xcode_report.encode())
-                ),
-                "",
-            )[1]
-            == "txt"
-        )
-        assert report_type_matching(
-            ParsedUploadedReportFile(
-                filename="name",
-                file_contents=BytesIO(json.dumps({"value": 1}).encode()),
-            ),
-            "{value: 1}",
-        ) == ({"value": 1}, "json")
-        assert report_type_matching(
-            ParsedUploadedReportFile(
-                filename="name",
-                file_contents=BytesIO(('\n\n{"value": 1}').encode()),
-            ),
-            "",
-        ) == ({"value": 1}, "json")
-        assert (
-            report_type_matching(
-                ParsedUploadedReportFile(
-                    filename="name",
-                    file_contents=BytesIO(
-                        '<?xml version="1.0" ?><statements><statement>source.scala</statement></statements>'.encode()
-                    ),
-                ),
-                "",
-            )[1]
-            == "xml"
-        )
-        assert (
-            report_type_matching(
-                ParsedUploadedReportFile(
-                    filename="name",
-                    file_contents=BytesIO(
-                        '\n\n\n\n\n<?xml version="1.0" ?><statements><statement>source.scala</statement></statements>'.encode()
-                    ),
-                ),
-                "",
-            )[1]
-            == "xml"
-        )
-        assert (
-            report_type_matching(
-                ParsedUploadedReportFile(
-                    filename="name",
-                    file_contents=BytesIO(
-                        '\ufeff<?xml version="1.0" ?><statements><statement>source.scala</statement></statements>'.encode()
-                    ),
-                ),
-                "",
-            )[1]
-            == "xml"
-        )
-        assert report_type_matching(
-            ParsedUploadedReportFile(
-                filename="name", file_contents=BytesIO("normal file".encode())
-            ),
-            "normal file",
-        ) == (b"normal file", "txt")
-        assert report_type_matching(
-            ParsedUploadedReportFile(
-                filename="name", file_contents=BytesIO("1".encode())
-            ),
-            "1",
-        ) == (b"1", "txt")
+@pytest.mark.parametrize(
+    "input,expected_type,expected_content",
+    [
+        (b"", "txt", b""),
+        (b"{}", "json", {}),
+        (xcode_report, "txt", None),
+        (b'{"value":1}', "json", {"value": 1}),
+        (
+            b'<?xml version="1.0" ?><statements><statement>source.scala</statement></statements>',
+            "xml",
+            None,
+        ),
+        (
+            b'\n\n\n\n\n<?xml version="1.0" ?><statements><statement>source.scala</statement></statements>',
+            "xml",
+            None,
+        ),
+        (
+            # NOTE: The `\ufeff` is a BOM (byte-order-mark)
+            '\ufeff<?xml version="1.0" ?><statements><statement>source.scala</statement></statements>'.encode(),
+            "xml",
+            None,
+        ),
+        (b"normal file", "txt", b"normal file"),
+        (b"1", "txt", b"1"),
+    ],
+)
+def test_report_type_matching(input: bytes, expected_type: str, expected_content):
+    report = ParsedUploadedReportFile(filename="name", file_contents=BytesIO(input))
+    first_line = remove_non_ascii(report.get_first_line().decode(errors="replace"))
+
+    content, detected_type = report_type_matching(
+        report,
+        first_line,
+    )
+    assert detected_type == expected_type
+    if expected_content is not None:
+        assert content == expected_content
+
+
+def test_empty_json():
+    raw_report = ParsedUploadedReportFile(filename="name", file_contents=BytesIO(b"{}"))
+    report = process_report(raw_report, None)
+    assert report is None
+
+    raw_report = ParsedUploadedReportFile(filename="name", file_contents=BytesIO(b"[]"))
+    report = process_report(raw_report, None)
+    assert report is None


### PR DESCRIPTION
https://github.com/codecov/worker/pull/666 introduced a regression where an empty JSON object would end up being processed by the `NodeProcessor` and raise an exception in there.

fixes WORKER-P4T