### PR TITLE
Update flaky shadow mode

### DIFF
--- a/database/tests/factories/reports.py
+++ b/database/tests/factories/reports.py
@@ -1,6 +1,6 @@
 import factory
 
-from database.models.reports import CompareFlag, RepositoryFlag
+from database.models.reports import CompareFlag, RepositoryFlag, Test
 from database.tests.factories.core import CompareCommitFactory, RepositoryFactory
 
 
@@ -18,3 +18,14 @@ class CompareFlagFactory(factory.Factory):
 
     commit_comparison = factory.SubFactory(CompareCommitFactory)
     repositoryflag = factory.SubFactory(RepositoryFlagFactory)
+
+
+class TestFactory(factory.Factory):
+    class Meta:
+        model = Test
+
+    name = factory.Sequence(lambda n: f"test_{n}")
+    testsuite = "testsuite"
+    flags_hash = "flags_hash"
+    id_ = factory.Sequence(lambda n: f"id_{n}")
+    repository = factory.SubFactory(RepositoryFactory)

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -402,14 +402,11 @@ def latest_test_instances_for_a_given_commit(db_session, commit_id):
 def should_write_flaky_detection(repoid: int, commit_yaml: UserYaml) -> bool:
     return (
         FLAKY_TEST_DETECTION.check_value(identifier=repoid, default=False)
-        and read_yaml_field(commit_yaml, ("test_analytics", "flake_detection"), False)
         or FLAKY_SHADOW_MODE.check_value(identifier=repoid, default=False)
-    )
+    ) and read_yaml_field(commit_yaml, ("test_analytics", "flake_detection"), True)
 
 
 def should_read_flaky_detection(repoid: int, commit_yaml: UserYaml) -> bool:
-    return (
-        FLAKY_TEST_DETECTION.check_value(identifier=repoid, default=False)
-        and read_yaml_field(commit_yaml, ("test_analytics", "flake_detection"), False)
-        or FLAKY_SHADOW_MODE.check_value(identifier=repoid, default=False)
-    )
+    return FLAKY_TEST_DETECTION.check_value(
+        identifier=repoid, default=False
+    ) and read_yaml_field(commit_yaml, ("test_analytics", "flake_detection"), True)

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -408,6 +408,8 @@ def should_write_flaky_detection(repoid: int, commit_yaml: UserYaml) -> bool:
 
 
 def should_read_flaky_detection(repoid: int, commit_yaml: UserYaml) -> bool:
-    return FLAKY_TEST_DETECTION.check_value(
-        identifier=repoid, default=False
-    ) and read_yaml_field(commit_yaml, ("test_analytics", "flake_detection"), False)
+    return (
+        FLAKY_TEST_DETECTION.check_value(identifier=repoid, default=False)
+        and read_yaml_field(commit_yaml, ("test_analytics", "flake_detection"), False)
+        or FLAKY_SHADOW_MODE.check_value(identifier=repoid, default=False)
+    )

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -17,7 +17,7 @@ from shared.yaml import UserYaml
 from shared.yaml.user_yaml import OwnerContext
 
 from app import celery_app
-from database.models import Commit, Pull, Repository
+from database.models import Commit, Pull, Repository, Test
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
 from helpers.metrics import metrics
@@ -377,9 +377,11 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                             synchronize_session=False,
                         )
                     )
-                self.trigger_process_flakes(
-                    repoid, pull.head, pull_dict["head"]["branch"], current_yaml
-                )
+
+                if db_session.query(Test).filter(Test.repoid == repoid).count() > 0:
+                    self.trigger_process_flakes(
+                        repoid, pull.head, pull_dict["head"]["branch"], current_yaml
+                    )
 
             # set the rest of the commits to deleted (do not show in the UI)
             deleted_count = (

--- a/tasks/tests/unit/test_sync_pull.py
+++ b/tasks/tests/unit/test_sync_pull.py
@@ -20,19 +20,21 @@ here = Path(__file__)
 
 class TestPullSyncTask(object):
     @pytest.mark.parametrize(
-        "flake_detection,flaky_shadow_mode,tests_exist,outcome",
+        "flake_detection_config, flake_detection,flaky_shadow_mode,tests_exist,outcome",
         [
-            (False, False, False, False),
-            (False, True, False, False),
-            (True, False, False, False),
-            (False, True, True, True),
-            (True, True, True, True),
+            (False, True, True, True, False),
+            (True, False, False, False, False),
+            (True, False, False, True, False),
+            (True, True, False, True, True),
+            (True, False, True, True, True),
+            (True, True, True, True, True),
         ],
     )
     def test_update_pull_commits_merged(
         self,
         dbsession,
         mocker,
+        flake_detection_config,
         flake_detection,
         flaky_shadow_mode,
         tests_exist,
@@ -108,7 +110,7 @@ class TestPullSyncTask(object):
         current_yaml = UserYaml.from_dict(
             {
                 "test_analytics": {
-                    "flake_detection": flake_detection,
+                    "flake_detection": flake_detection_config,
                 }
             }
         )


### PR DESCRIPTION
This PR does 2 things:
- makes it so the flaky shadow mode feature flag also enables the read path for flake detection, meaning when that feature flag resolves to true users will also get notified of any flaky tests that they fail on in their PRs
- change the behaviour of sync pulls to avoid calling the process flakes task when a repo isn't uploading test results