### PR TITLE
fix: UI and status report diff patch numbers

### DIFF
--- a/helpers/comparison.py
+++ b/helpers/comparison.py
@@ -1,0 +1,21 @@
+from shared.reports.types import ReportTotals
+
+
+def minimal_totals(totals: ReportTotals | None) -> dict:
+    if totals is None:
+        return {
+            "hits": 0,
+            "misses": 0,
+            "partials": 0,
+            "coverage": None,
+        }
+    return {
+        "hits": totals.hits,
+        "misses": totals.misses,
+        "partials": totals.partials,
+        # ReportTotals has coverage as a string, we want float in the DB
+        # Also the coverage from ReportTotals is 0-100, while in the DB it's 0-1
+        "coverage": (
+            (float(totals.coverage) / 100) if totals.coverage is not None else None
+        ),
+    }

--- a/services/comparison/__init__.py
+++ b/services/comparison/__init__.py
@@ -59,6 +59,7 @@ class ComparisonProxy(object):
         self._repository_service = None
         self._adjusted_base_diff = None
         self._original_base_diff = None
+        self._patch_totals = None
         self._changes = None
         self._existing_statuses = None
         self._behind_by = None
@@ -209,9 +210,11 @@ class ComparisonProxy(object):
 
         Patch coverage refers to looking at the coverage in HEAD report filtered by the git diff HEAD..BASE.
         """
+        if self._patch_totals:
+            return self._patch_totals
         diff = await self.get_diff(use_original_base=True)
-        totals = self.head.report.apply_diff(diff)
-        return totals
+        self._patch_totals = self.head.report.apply_diff(diff)
+        return self._patch_totals
 
     async def get_behind_by(self):
         async with self._behind_by_lock:

--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -9,7 +9,9 @@ log = logging.getLogger(__name__)
 
 
 class StatusPatchMixin(object):
-    async def get_patch_status(self, comparison) -> Tuple[str, str]:
+    async def get_patch_status(
+        self, comparison: ComparisonProxy | FilteredComparison
+    ) -> Tuple[str, str]:
         threshold = self.notifier_yaml_settings.get("threshold", "0.0")
 
         # check if user has erroneously added a % to this input and fix
@@ -21,8 +23,7 @@ class StatusPatchMixin(object):
         except (InvalidOperation, TypeError):
             threshold = Decimal("0.0")
 
-        diff = await comparison.get_diff(use_original_base=True)
-        totals = comparison.head.report.apply_diff(diff)
+        totals = await comparison.get_patch_totals()
         if self.notifier_yaml_settings.get("target") not in ("auto", None):
             target_coverage = Decimal(
                 str(self.notifier_yaml_settings.get("target")).replace("%", "")

--- a/services/repository.py
+++ b/services/repository.py
@@ -541,6 +541,7 @@ async def _pick_best_base_comparedto_pair(
     return (candidates_to_base[0], None)
 
 
+@sentry_sdk.trace
 async def fetch_and_update_pull_request_information(
     repository_service, db_session, repoid, pullid, current_yaml
 ) -> EnrichedPull:

--- a/services/repository.py
+++ b/services/repository.py
@@ -471,6 +471,7 @@ class EnrichedPull(object):
     provider_pull: Optional[Mapping[str, Any]]
 
 
+@sentry_sdk.trace
 async def fetch_and_update_pull_request_information_from_commit(
     repository_service, commit, current_yaml
 ) -> Optional[EnrichedPull]:

--- a/tasks/tests/integration/cassetes/test_notify_task/TestNotifyTask/test_simple_call_only_status_notifiers.yaml
+++ b/tasks/tests/integration/cassetes/test_notify_task/TestNotifyTask/test_simple_call_only_status_notifiers.yaml
@@ -1,740 +1,67 @@
 interactions:
 - request:
-    body: null
+    body: ''
     headers:
-      Accept:
+      accept:
       - application/json
-      User-Agent:
-      - Default
-    method: GET
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/contents?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a
-  response:
-    content: '[{"name":".gitignore","path":".gitignore","sha":"e9428a03c7fc4ce77bba5997760efb3bb6ec42ee","size":1765,"url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/.gitignore?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/.gitignore","git_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/e9428a03c7fc4ce77bba5997760efb3bb6ec42ee","download_url":"https://raw.githubusercontent.com/ThiagoCodecov/example-python/649eaaf2924e92dc7fd8d370ddb857033231e67a/.gitignore","type":"file","_links":{"self":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/.gitignore?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","git":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/e9428a03c7fc4ce77bba5997760efb3bb6ec42ee","html":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/.gitignore"}},{"name":"Makefile","path":"Makefile","sha":"4cf0cf64e3274981f8185b80ea98a3b822785972","size":1010,"url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/Makefile?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/Makefile","git_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/4cf0cf64e3274981f8185b80ea98a3b822785972","download_url":"https://raw.githubusercontent.com/ThiagoCodecov/example-python/649eaaf2924e92dc7fd8d370ddb857033231e67a/Makefile","type":"file","_links":{"self":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/Makefile?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","git":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/4cf0cf64e3274981f8185b80ea98a3b822785972","html":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/Makefile"}},{"name":"README.md","path":"README.md","sha":"5314ac058c0057d99274bfa44ecb21fb04c117c3","size":226,"url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/README.md?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/README.md","git_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/5314ac058c0057d99274bfa44ecb21fb04c117c3","download_url":"https://raw.githubusercontent.com/ThiagoCodecov/example-python/649eaaf2924e92dc7fd8d370ddb857033231e67a/README.md","type":"file","_links":{"self":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/README.md?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","git":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/5314ac058c0057d99274bfa44ecb21fb04c117c3","html":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/README.md"}},{"name":"awesome","path":"awesome","sha":"3316b7f6d266fb0b94545680f5de19e57a82a2de","size":0,"url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/awesome?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/tree/649eaaf2924e92dc7fd8d370ddb857033231e67a/awesome","git_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/3316b7f6d266fb0b94545680f5de19e57a82a2de","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/awesome?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","git":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/3316b7f6d266fb0b94545680f5de19e57a82a2de","html":"https://github.com/ThiagoCodecov/example-python/tree/649eaaf2924e92dc7fd8d370ddb857033231e67a/awesome"}},{"name":"codecov.yaml","path":"codecov.yaml","sha":"e7bb8d289876a0b30be8fa103999f40dc3e0375e","size":354,"url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/codecov.yaml?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/codecov.yaml","git_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/e7bb8d289876a0b30be8fa103999f40dc3e0375e","download_url":"https://raw.githubusercontent.com/ThiagoCodecov/example-python/649eaaf2924e92dc7fd8d370ddb857033231e67a/codecov.yaml","type":"file","_links":{"self":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/codecov.yaml?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","git":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/e7bb8d289876a0b30be8fa103999f40dc3e0375e","html":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/codecov.yaml"}},{"name":"requirements.txt","path":"requirements.txt","sha":"ab0a8735f8dfaef9044d2092e6de622052069b1d","size":319,"url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/requirements.txt?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/requirements.txt","git_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/ab0a8735f8dfaef9044d2092e6de622052069b1d","download_url":"https://raw.githubusercontent.com/ThiagoCodecov/example-python/649eaaf2924e92dc7fd8d370ddb857033231e67a/requirements.txt","type":"file","_links":{"self":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/requirements.txt?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","git":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/ab0a8735f8dfaef9044d2092e6de622052069b1d","html":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/requirements.txt"}},{"name":"tests","path":"tests","sha":"deaaf0ea371584b29a7ad51161db63699532f4a0","size":0,"url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/tests?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/tree/649eaaf2924e92dc7fd8d370ddb857033231e67a/tests","git_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/deaaf0ea371584b29a7ad51161db63699532f4a0","download_url":null,"type":"dir","_links":{"self":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/tests?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","git":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/deaaf0ea371584b29a7ad51161db63699532f4a0","html":"https://github.com/ThiagoCodecov/example-python/tree/649eaaf2924e92dc7fd8d370ddb857033231e67a/tests"}}]'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - close
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 05 Dec 2019 13:44:01 GMT
-      Etag:
-      - W/"2e9aa67eafb7410ed9ecb73e5a60462452bfdd17"
-      Last-Modified:
-      - Sat, 05 Oct 2019 18:21:23 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      X-Accepted-Oauth-Scopes:
-      - ''
-      X-Consumed-Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3
-      X-Github-Request-Id:
-      - 383E:32B2:D25D2B:21A8CCD:5DE909A1
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4967'
-      X-Ratelimit-Reset:
-      - '1575556238'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-    status_code: 200
-    url: https://api.github.com/repos/ThiagoCodecov/example-python/contents?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Default
-    method: GET
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/contents/codecov.yaml?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a
-  response:
-    content: '{"name":"codecov.yaml","path":"codecov.yaml","sha":"e7bb8d289876a0b30be8fa103999f40dc3e0375e","size":354,"url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/codecov.yaml?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/codecov.yaml","git_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/e7bb8d289876a0b30be8fa103999f40dc3e0375e","download_url":"https://raw.githubusercontent.com/ThiagoCodecov/example-python/649eaaf2924e92dc7fd8d370ddb857033231e67a/codecov.yaml","type":"file","content":"Y29kZWNvdjoKICBub3RpZnk6CiAgICByZXF1aXJlX2NpX3RvX3Bhc3M6IHll\ncwoKY292ZXJhZ2U6CiAgcHJlY2lzaW9uOiAyCiAgcm91bmQ6IGRvd24KICBy\nYW5nZTogIjcwLi4uMTAwIgoKICBzdGF0dXM6CiAgICBwcm9qZWN0OiB5ZXMK\nICAgIHBhdGNoOiB5ZXMKICAgIGNoYW5nZXM6IG5vCgpwYXJzZXJzOgogIGdj\nb3Y6CiAgICBicmFuY2hfZGV0ZWN0aW9uOgogICAgICBjb25kaXRpb25hbDog\neWVzCiAgICAgIGxvb3A6IHllcwogICAgICBtZXRob2Q6IG5vCiAgICAgIG1h\nY3JvOiBubwoKY29tbWVudDoKICBsYXlvdXQ6ICJoZWFkZXIsIGRpZmYiCiAg\nYmVoYXZpb3I6IGRlZmF1bHQKICByZXF1aXJlX2NoYW5nZXM6IG5v\n","encoding":"base64","_links":{"self":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/codecov.yaml?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","git":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs/e7bb8d289876a0b30be8fa103999f40dc3e0375e","html":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/codecov.yaml"}}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - close
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 05 Dec 2019 13:44:01 GMT
-      Etag:
-      - W/"e7bb8d289876a0b30be8fa103999f40dc3e0375e"
-      Last-Modified:
-      - Tue, 26 Nov 2019 23:54:15 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      X-Accepted-Oauth-Scopes:
-      - ''
-      X-Consumed-Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3
-      X-Github-Request-Id:
-      - 383F:6844:44B785:A1B3CF:5DE909A1
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4966'
-      X-Ratelimit-Reset:
-      - '1575556238'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-    status_code: 200
-    url: https://api.github.com/repos/ThiagoCodecov/example-python/contents/codecov.yaml?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Default
-    method: GET
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/statuses?page=1&per_page=100
-  response:
-    content: '[{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","id":8296741626,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4Mjk2NzQxNjI2","state":"success","description":"85.00%
-      (+0.00%) compared to 17a71a9","target_url":"https://codecov.io/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/project","created_at":"2019-12-05T13:44:00Z","updated_at":"2019-12-05T13:44:00Z","creator":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false}},{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars1.githubusercontent.com/oa/166618?v=4","id":8231102724,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4MjMxMTAyNzI0","state":"success","description":"Coverage
-      not affected when comparing 17a71a9...649eaaf","target_url":"http://localhost/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/patch","created_at":"2019-11-27T00:01:14Z","updated_at":"2019-11-27T00:01:14Z","creator":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false}},{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars1.githubusercontent.com/oa/166618?v=4","id":8231102539,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4MjMxMTAyNTM5","state":"success","description":"85.29%
-      remains the same compared to 17a71a9","target_url":"http://localhost/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/project","created_at":"2019-11-27T00:01:13Z","updated_at":"2019-11-27T00:01:13Z","creator":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false}}]'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - close
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 05 Dec 2019 13:44:02 GMT
-      Etag:
-      - W/"9455b4560a3c620d81b2c308f88894f5"
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      X-Accepted-Oauth-Scopes:
-      - repo, repo:status
-      X-Consumed-Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3
-      X-Github-Request-Id:
-      - 3840:3175:1291CAC:2D9067A:5DE909A2
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4965'
-      X-Ratelimit-Reset:
-      - '1575556238'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-    status_code: 200
-    url: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/statuses?page=1&per_page=100
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Default
-    method: GET
-    uri: https://api.github.com/search/issues?q=649eaaf2924e92dc7fd8d370ddb857033231e67a+repo%3AThiagoCodecov%2Fexample-python+type%3Apr+state%3Aopen
-  response:
-    content: '{"total_count":1,"incomplete_results":false,"items":[{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11","repository_url":"https://api.github.com/repos/ThiagoCodecov/example-python","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11/labels{/name}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11/comments","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11/events","html_url":"https://github.com/ThiagoCodecov/example-python/pull/11","id":511786496,"node_id":"MDExOlB1bGxSZXF1ZXN0MzMxOTE4MTgx","number":11,"title":"Adding
-      requirements","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"labels":[],"state":"open","locked":false,"assignee":null,"assignees":[],"milestone":null,"comments":1,"created_at":"2019-10-24T08:23:32Z","updated_at":"2019-12-03T21:15:27Z","closed_at":null,"author_association":"OWNER","pull_request":{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11","html_url":"https://github.com/ThiagoCodecov/example-python/pull/11","diff_url":"https://github.com/ThiagoCodecov/example-python/pull/11.diff","patch_url":"https://github.com/ThiagoCodecov/example-python/pull/11.patch"},"body":"","score":100.0}]}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - no-cache
-      Connection:
-      - close
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 05 Dec 2019 13:44:03 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      X-Accepted-Oauth-Scopes:
-      - ''
-      X-Consumed-Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3
-      X-Github-Request-Id:
-      - 3849:2727:D45E61:2154C61:5DE909A2
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '30'
-      X-Ratelimit-Remaining:
-      - '28'
-      X-Ratelimit-Reset:
-      - '1575553497'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-    status_code: 200
-    url: https://api.github.com/search/issues?q=649eaaf2924e92dc7fd8d370ddb857033231e67a+repo%3AThiagoCodecov%2Fexample-python+type%3Apr+state%3Aopen
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Default
-    method: GET
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11
-  response:
-    content: '{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11","id":331918181,"node_id":"MDExOlB1bGxSZXF1ZXN0MzMxOTE4MTgx","html_url":"https://github.com/ThiagoCodecov/example-python/pull/11","diff_url":"https://github.com/ThiagoCodecov/example-python/pull/11.diff","patch_url":"https://github.com/ThiagoCodecov/example-python/pull/11.patch","issue_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11","number":11,"state":"open","locked":false,"title":"Adding
-      requirements","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"body":"","created_at":"2019-10-24T08:23:32Z","updated_at":"2019-12-03T21:15:27Z","closed_at":null,"merged_at":null,"merge_commit_sha":"ebebc454bc399c79fa5efbd7e2f1662a43bb4196","assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"labels":[],"milestone":null,"commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/commits","review_comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/comments","review_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/comments{/number}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11/comments","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/10063a8d1d721d8d6c1b731f5273754a3675962d","head":{"label":"ThiagoCodecov:test-branch-1","ref":"test-branch-1","sha":"10063a8d1d721d8d6c1b731f5273754a3675962d","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"repo":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python
-      coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments","created_at":"2018-11-07T22:40:20Z","updated_at":"2019-10-05T18:21:23Z","pushed_at":"2019-12-03T21:15:06Z","git_url":"git://github.com/ThiagoCodecov/example-python.git","ssh_url":"git@github.com:ThiagoCodecov/example-python.git","clone_url":"https://github.com/ThiagoCodecov/example-python.git","svn_url":"https://github.com/ThiagoCodecov/example-python","homepage":"https://codecov.io","size":119,"stargazers_count":0,"watchers_count":0,"language":"Python","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":7,"license":null,"forks":0,"open_issues":7,"watchers":0,"default_branch":"master"}},"base":{"label":"ThiagoCodecov:master","ref":"master","sha":"17a71a9a2f5335ed4d00496c7bbc6405f547a527","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"repo":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python
-      coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments","created_at":"2018-11-07T22:40:20Z","updated_at":"2019-10-05T18:21:23Z","pushed_at":"2019-12-03T21:15:06Z","git_url":"git://github.com/ThiagoCodecov/example-python.git","ssh_url":"git@github.com:ThiagoCodecov/example-python.git","clone_url":"https://github.com/ThiagoCodecov/example-python.git","svn_url":"https://github.com/ThiagoCodecov/example-python","homepage":"https://codecov.io","size":119,"stargazers_count":0,"watchers_count":0,"language":"Python","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":0,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":7,"license":null,"forks":0,"open_issues":7,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11"},"html":{"href":"https://github.com/ThiagoCodecov/example-python/pull/11"},"issue":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11"},"comments":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11/comments"},"review_comments":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/comments"},"review_comment":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/commits"},"statuses":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/10063a8d1d721d8d6c1b731f5273754a3675962d"}},"author_association":"OWNER","merged":false,"mergeable":true,"rebaseable":true,"mergeable_state":"clean","merged_by":null,"comments":1,"review_comments":0,"maintainer_can_modify":false,"commits":6,"additions":31,"deletions":6,"changed_files":3}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - close
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 05 Dec 2019 13:44:03 GMT
-      Etag:
-      - W/"df979824ea38e80a32607ac5f2bb3a69"
-      Last-Modified:
-      - Tue, 03 Dec 2019 21:15:27 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      X-Accepted-Oauth-Scopes:
-      - ''
-      X-Consumed-Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3
-      X-Github-Request-Id:
-      - 384C:32B3:12F797D:2EA44B1:5DE909A3
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4964'
-      X-Ratelimit-Reset:
-      - '1575556238'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-    status_code: 200
-    url: https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Default
-    method: GET
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/statuses?page=1&per_page=100
-  response:
-    content: '[{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","id":8296741626,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4Mjk2NzQxNjI2","state":"success","description":"85.00%
-      (+0.00%) compared to 17a71a9","target_url":"https://codecov.io/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/project","created_at":"2019-12-05T13:44:00Z","updated_at":"2019-12-05T13:44:00Z","creator":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false}},{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars1.githubusercontent.com/oa/166618?v=4","id":8231102724,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4MjMxMTAyNzI0","state":"success","description":"Coverage
-      not affected when comparing 17a71a9...649eaaf","target_url":"http://localhost/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/patch","created_at":"2019-11-27T00:01:14Z","updated_at":"2019-11-27T00:01:14Z","creator":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false}},{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars1.githubusercontent.com/oa/166618?v=4","id":8231102539,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4MjMxMTAyNTM5","state":"success","description":"85.29%
-      remains the same compared to 17a71a9","target_url":"http://localhost/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/project","created_at":"2019-11-27T00:01:13Z","updated_at":"2019-11-27T00:01:13Z","creator":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false}}]'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - close
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 05 Dec 2019 13:44:04 GMT
-      Etag:
-      - W/"9455b4560a3c620d81b2c308f88894f5"
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      X-Accepted-Oauth-Scopes:
-      - repo, repo:status
-      X-Consumed-Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3
-      X-Github-Request-Id:
-      - 384D:0EAB:D94507:22C96EF:5DE909A4
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4963'
-      X-Ratelimit-Reset:
-      - '1575556238'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-    status_code: 200
-    url: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/statuses?page=1&per_page=100
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Default
-    method: GET
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/commits
-  response:
-    content: '[{"sha":"ab89bd097cd5e1af391dc52daccaa4e6c6579039","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3OmFiODliZDA5N2NkNWUxYWYzOTFkYzUyZGFjY2FhNGU2YzY1NzkwMzk=","commit":{"author":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-10-24T08:21:45Z"},"committer":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-10-24T08:21:45Z"},"message":"Adding
-      requirements","tree":{"sha":"c8091d748268a03a5886b5959cb0ae5e25d0c9d8","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/c8091d748268a03a5886b5959cb0ae5e25d0c9d8"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/ab89bd097cd5e1af391dc52daccaa4e6c6579039","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/ab89bd097cd5e1af391dc52daccaa4e6c6579039","html_url":"https://github.com/ThiagoCodecov/example-python/commit/ab89bd097cd5e1af391dc52daccaa4e6c6579039","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/ab89bd097cd5e1af391dc52daccaa4e6c6579039/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"17a71a9a2f5335ed4d00496c7bbc6405f547a527","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/17a71a9a2f5335ed4d00496c7bbc6405f547a527","html_url":"https://github.com/ThiagoCodecov/example-python/commit/17a71a9a2f5335ed4d00496c7bbc6405f547a527"}]},{"sha":"649eaaf2924e92dc7fd8d370ddb857033231e67a","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3OjY0OWVhYWYyOTI0ZTkyZGM3ZmQ4ZDM3MGRkYjg1NzAzMzIzMWU2N2E=","commit":{"author":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-11-26T23:54:15Z"},"committer":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-11-26T23:54:15Z"},"message":"Trying
-      stuff","tree":{"sha":"2e9aa67eafb7410ed9ecb73e5a60462452bfdd17","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/2e9aa67eafb7410ed9ecb73e5a60462452bfdd17"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/commit/649eaaf2924e92dc7fd8d370ddb857033231e67a","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"ab89bd097cd5e1af391dc52daccaa4e6c6579039","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/ab89bd097cd5e1af391dc52daccaa4e6c6579039","html_url":"https://github.com/ThiagoCodecov/example-python/commit/ab89bd097cd5e1af391dc52daccaa4e6c6579039"}]},{"sha":"8b190323a5dc374b02892c07136c3bd8893b2a04","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3OjhiMTkwMzIzYTVkYzM3NGIwMjg5MmMwNzEzNmMzYmQ4ODkzYjJhMDQ=","commit":{"author":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-12-03T21:13:27Z"},"committer":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-12-03T21:13:27Z"},"message":"Doing
-      some tests","tree":{"sha":"78cc08e9be6359826ccf03fb72a4ce3fcb25d7a2","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/78cc08e9be6359826ccf03fb72a4ce3fcb25d7a2"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/8b190323a5dc374b02892c07136c3bd8893b2a04","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/8b190323a5dc374b02892c07136c3bd8893b2a04","html_url":"https://github.com/ThiagoCodecov/example-python/commit/8b190323a5dc374b02892c07136c3bd8893b2a04","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/8b190323a5dc374b02892c07136c3bd8893b2a04/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"649eaaf2924e92dc7fd8d370ddb857033231e67a","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/commit/649eaaf2924e92dc7fd8d370ddb857033231e67a"}]},{"sha":"fa3df832e28febb2611ab8e4aa550a178dc5d733","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3OmZhM2RmODMyZTI4ZmViYjI2MTFhYjhlNGFhNTUwYTE3OGRjNWQ3MzM=","commit":{"author":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-12-03T21:13:51Z"},"committer":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-12-03T21:13:51Z"},"message":"Doing
-      some tests 2","tree":{"sha":"c1f9c27a1e3c1c70ae53e7d68a0f8d9a0535eee3","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/c1f9c27a1e3c1c70ae53e7d68a0f8d9a0535eee3"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/fa3df832e28febb2611ab8e4aa550a178dc5d733","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/fa3df832e28febb2611ab8e4aa550a178dc5d733","html_url":"https://github.com/ThiagoCodecov/example-python/commit/fa3df832e28febb2611ab8e4aa550a178dc5d733","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/fa3df832e28febb2611ab8e4aa550a178dc5d733/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"8b190323a5dc374b02892c07136c3bd8893b2a04","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/8b190323a5dc374b02892c07136c3bd8893b2a04","html_url":"https://github.com/ThiagoCodecov/example-python/commit/8b190323a5dc374b02892c07136c3bd8893b2a04"}]},{"sha":"844f31d1edcb864aaaa1447e185dec294134241e","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3Ojg0NGYzMWQxZWRjYjg2NGFhYWExNDQ3ZTE4NWRlYzI5NDEzNDI0MWU=","commit":{"author":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-12-03T21:14:40Z"},"committer":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-12-03T21:14:40Z"},"message":"Doing
-      some tests 2","tree":{"sha":"c88eb829331ec8401da569fe2fc44c2cc32219f7","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/c88eb829331ec8401da569fe2fc44c2cc32219f7"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/844f31d1edcb864aaaa1447e185dec294134241e","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/844f31d1edcb864aaaa1447e185dec294134241e","html_url":"https://github.com/ThiagoCodecov/example-python/commit/844f31d1edcb864aaaa1447e185dec294134241e","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/844f31d1edcb864aaaa1447e185dec294134241e/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"fa3df832e28febb2611ab8e4aa550a178dc5d733","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/fa3df832e28febb2611ab8e4aa550a178dc5d733","html_url":"https://github.com/ThiagoCodecov/example-python/commit/fa3df832e28febb2611ab8e4aa550a178dc5d733"}]},{"sha":"10063a8d1d721d8d6c1b731f5273754a3675962d","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3OjEwMDYzYThkMWQ3MjFkOGQ2YzFiNzMxZjUyNzM3NTRhMzY3NTk2MmQ=","commit":{"author":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-12-03T21:14:57Z"},"committer":{"name":"Thiago
-      Ramos","email":"thiago@codecov.io","date":"2019-12-03T21:14:57Z"},"message":"Doing
-      some tests 3","tree":{"sha":"9ac5df663e620e8f966964865cca4507f62619a6","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/9ac5df663e620e8f966964865cca4507f62619a6"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/10063a8d1d721d8d6c1b731f5273754a3675962d","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/10063a8d1d721d8d6c1b731f5273754a3675962d","html_url":"https://github.com/ThiagoCodecov/example-python/commit/10063a8d1d721d8d6c1b731f5273754a3675962d","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/10063a8d1d721d8d6c1b731f5273754a3675962d/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"844f31d1edcb864aaaa1447e185dec294134241e","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/844f31d1edcb864aaaa1447e185dec294134241e","html_url":"https://github.com/ThiagoCodecov/example-python/commit/844f31d1edcb864aaaa1447e185dec294134241e"}]}]'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - close
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Fri, 10 Jan 2020 03:14:48 GMT
-      Etag:
-      - W/"05b6236c2d4f303962bb91ebdebff6e3"
-      Last-Modified:
-      - Thu, 09 Jan 2020 19:23:25 GMT
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding
-      X-Accepted-Oauth-Scopes:
-      - ''
-      X-Consumed-Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3
-      X-Github-Request-Id:
-      - 13ED:5E02:2C2BF4:3F3E49:5E17EC28
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4998'
-      X-Ratelimit-Reset:
-      - '1578629688'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-    status_code: 200
-    url: https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/commits
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.github.com
+      user-agent:
       - Default
     method: GET
     uri: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/status?page=1&per_page=100
   response:
-    content: '{"state":"success","statuses":[{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars1.githubusercontent.com/oa/166618?v=4","id":8231102724,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4MjMxMTAyNzI0","state":"success","description":"Coverage
-      not affected when comparing 17a71a9...649eaaf","target_url":"http://localhost/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/patch","created_at":"2019-11-27T00:01:14Z","updated_at":"2019-11-27T00:01:14Z"},{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","id":8296741626,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4Mjk2NzQxNjI2","state":"success","description":"85.00000%
-      (+0.00%) compared to 17a71a9","target_url":"https://codecov.io/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/project","created_at":"2019-12-05T13:44:00Z","updated_at":"2019-12-05T13:44:00Z"},{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","id":8459091358,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4NDU5MDkxMzU4","state":"success","description":"No
-      unexpected coverage changes found","target_url":"https://codecov.io/gh/ThiagoCodecov/example-python/commit/649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/changes","created_at":"2019-12-30T11:15:30Z","updated_at":"2019-12-30T11:15:30Z"}],"sha":"649eaaf2924e92dc7fd8d370ddb857033231e67a","total_count":3,"repository":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python
-      coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments"},"commit_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/status"}'
+    content: '{"state":"pending","statuses":[],"sha":"649eaaf2924e92dc7fd8d370ddb857033231e67a","total_count":0,"repository":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments"},"commit_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/status"}'
     headers:
       Access-Control-Allow-Origin:
       - '*'
       Access-Control-Expose-Headers:
       - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - close
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 09 Apr 2020 16:02:50 GMT
-      Etag:
-      - W/"bebc0296cfb273d3427ec5d041a76079"
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding, Accept, X-Requested-With
-      X-Accepted-Oauth-Scopes:
-      - repo, repo:status
-      X-Consumed-Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3
-      X-Github-Request-Id:
-      - EB79:4EFD:254A6F:3285CA:5E8F472A
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4998'
-      X-Ratelimit-Reset:
-      - '1586451770'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-    status_code: 200
-    url: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/status?page=1&per_page=100
-- request:
-    body: '{"state": "success", "target_url": "https://codecov.io/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a",
-      "context": "codecov/project", "description": "85.00% (+0.00%) compared to 17a71a9"}'
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Default
-    method: POST
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a
-  response:
-    content: '{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","id":9333173070,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ5MzMzMTczMDcw","state":"success","description":"85.00%
-      (+0.00%) compared to 17a71a9","target_url":"https://codecov.io/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/project","created_at":"2020-04-09T16:02:50Z","updated_at":"2020-04-09T16:02:50Z","creator":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false}}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - close
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
       Content-Length:
-      - '1558'
+      - '95'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 09 Apr 2020 16:02:50 GMT
-      Etag:
-      - '"a51475cd1c4e96da18ba6971f77e888d"'
-      Location:
-      - https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a
+      - Tue, 03 Sep 2024 13:17:10 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
-      - GitHub.com
-      Status:
-      - 201 Created
+      - github.com
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
       Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
       - Accept-Encoding, Accept, X-Requested-With
-      X-Accepted-Oauth-Scopes:
-      - ''
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
       - deny
-      X-Github-Media-Type:
+      X-GitHub-Media-Type:
       - github.v3
-      X-Github-Request-Id:
-      - EB7A:4EFC:6EE2C:9967B:5E8F472A
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4997'
-      X-Ratelimit-Reset:
-      - '1586451769'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 201
-      message: Created
-    status_code: 201
-    url: https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - Default
-    method: GET
-    uri: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/status?page=1&per_page=100
-  response:
-    content: '{"state":"success","statuses":[{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars1.githubusercontent.com/oa/166618?v=4","id":8231102724,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4MjMxMTAyNzI0","state":"success","description":"Coverage
-      not affected when comparing 17a71a9...649eaaf","target_url":"http://localhost/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/patch","created_at":"2019-11-27T00:01:14Z","updated_at":"2019-11-27T00:01:14Z"},{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","id":8459091358,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ4NDU5MDkxMzU4","state":"success","description":"No
-      unexpected coverage changes found","target_url":"https://codecov.io/gh/ThiagoCodecov/example-python/commit/649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/changes","created_at":"2019-12-30T11:15:30Z","updated_at":"2019-12-30T11:15:30Z"},{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","id":9333173070,"node_id":"MDEzOlN0YXR1c0NvbnRleHQ5MzMzMTczMDcw","state":"success","description":"85.00%
-      (+0.00%) compared to 17a71a9","target_url":"https://codecov.io/gh/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","context":"codecov/project","created_at":"2020-04-09T16:02:50Z","updated_at":"2020-04-09T16:02:50Z"}],"sha":"649eaaf2924e92dc7fd8d370ddb857033231e67a","total_count":3,"repository":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars3.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python
-      coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments"},"commit_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/status"}'
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      Access-Control-Expose-Headers:
-      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
-        X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval,
-        X-GitHub-Media-Type, Deprecation, Sunset
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Connection:
-      - close
-      Content-Security-Policy:
-      - default-src 'none'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 09 Apr 2020 16:04:05 GMT
-      Etag:
-      - W/"d8e0c19b4411db7e4beb5c73dabb3799"
-      Referrer-Policy:
-      - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - GitHub.com
-      Status:
-      - 200 OK
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
-      - Accept-Encoding, Accept, X-Requested-With
-      X-Accepted-Oauth-Scopes:
-      - repo, repo:status
-      X-Consumed-Content-Encoding:
-      - gzip
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - deny
-      X-Github-Media-Type:
-      - github.v3
-      X-Github-Request-Id:
-      - EB95:2F61:1ED4E5:2BE2E5:5E8F4775
-      X-Oauth-Scopes:
-      - admin:org, admin:public_key, admin:repo_hook, repo, user, write:discussion
-      X-Ratelimit-Limit:
-      - '5000'
-      X-Ratelimit-Remaining:
-      - '4985'
-      X-Ratelimit-Reset:
-      - '1586451769'
-      X-Xss-Protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
+      X-GitHub-Request-Id:
+      - E8CF:37895C:261D361:4949EA9:66D70C56
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '50'
+      X-RateLimit-Reset:
+      - '1725372143'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '10'
+      X-XSS-Protection:
+      - '0'
+    http_version: HTTP/1.1
     status_code: 200
-    url: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/status?page=1&per_page=100
 - request:
     body: ''
     headers:
@@ -751,10 +78,7 @@ interactions:
     method: GET
     uri: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/pulls
   response:
-    content: '[{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11","id":331918181,"node_id":"MDExOlB1bGxSZXF1ZXN0MzMxOTE4MTgx","html_url":"https://github.com/ThiagoCodecov/example-python/pull/11","diff_url":"https://github.com/ThiagoCodecov/example-python/pull/11.diff","patch_url":"https://github.com/ThiagoCodecov/example-python/pull/11.patch","issue_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11","number":11,"state":"closed","locked":false,"title":"Adding
-      requirements","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"body":"","created_at":"2019-10-24T08:23:32Z","updated_at":"2019-12-09T12:13:28Z","closed_at":"2019-12-06T15:46:04Z","merged_at":"2019-12-06T15:46:04Z","merge_commit_sha":"5936002ddf11f01a9fc1641a5bbb620691443239","assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"labels":[],"milestone":null,"draft":false,"commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/commits","review_comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/comments","review_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/comments{/number}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11/comments","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/10063a8d1d721d8d6c1b731f5273754a3675962d","head":{"label":"ThiagoCodecov:test-branch-1","ref":"test-branch-1","sha":"10063a8d1d721d8d6c1b731f5273754a3675962d","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"repo":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python
-      coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments","created_at":"2018-11-07T22:40:20Z","updated_at":"2020-12-04T04:21:29Z","pushed_at":"2020-12-04T04:21:26Z","git_url":"git://github.com/ThiagoCodecov/example-python.git","ssh_url":"git@github.com:ThiagoCodecov/example-python.git","clone_url":"https://github.com/ThiagoCodecov/example-python.git","svn_url":"https://github.com/ThiagoCodecov/example-python","homepage":"https://codecov.io","size":178,"stargazers_count":0,"watchers_count":0,"language":"Shell","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":2,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":null,"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"topics":[],"visibility":"public","forks":2,"open_issues":1,"watchers":0,"default_branch":"master"}},"base":{"label":"ThiagoCodecov:master","ref":"master","sha":"17a71a9a2f5335ed4d00496c7bbc6405f547a527","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"repo":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python
-      coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments","created_at":"2018-11-07T22:40:20Z","updated_at":"2020-12-04T04:21:29Z","pushed_at":"2020-12-04T04:21:26Z","git_url":"git://github.com/ThiagoCodecov/example-python.git","ssh_url":"git@github.com:ThiagoCodecov/example-python.git","clone_url":"https://github.com/ThiagoCodecov/example-python.git","svn_url":"https://github.com/ThiagoCodecov/example-python","homepage":"https://codecov.io","size":178,"stargazers_count":0,"watchers_count":0,"language":"Shell","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"forks_count":2,"mirror_url":null,"archived":false,"disabled":false,"open_issues_count":1,"license":null,"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"topics":[],"visibility":"public","forks":2,"open_issues":1,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11"},"html":{"href":"https://github.com/ThiagoCodecov/example-python/pull/11"},"issue":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11"},"comments":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11/comments"},"review_comments":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/comments"},"review_comment":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/commits"},"statuses":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/10063a8d1d721d8d6c1b731f5273754a3675962d"}},"author_association":"OWNER","auto_merge":null,"active_lock_reason":null}]'
+    content: '[{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11","id":331918181,"node_id":"MDExOlB1bGxSZXF1ZXN0MzMxOTE4MTgx","html_url":"https://github.com/ThiagoCodecov/example-python/pull/11","diff_url":"https://github.com/ThiagoCodecov/example-python/pull/11.diff","patch_url":"https://github.com/ThiagoCodecov/example-python/pull/11.patch","issue_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11","number":11,"state":"closed","locked":true,"title":"Adding requirements","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"body":"","created_at":"2019-10-24T08:23:32Z","updated_at":"2019-12-09T12:13:28Z","closed_at":"2019-12-06T15:46:04Z","merged_at":"2019-12-06T15:46:04Z","merge_commit_sha":"5936002ddf11f01a9fc1641a5bbb620691443239","assignee":null,"assignees":[],"requested_reviewers":[],"requested_teams":[],"labels":[],"milestone":null,"draft":false,"commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/commits","review_comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/comments","review_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/comments{/number}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11/comments","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/10063a8d1d721d8d6c1b731f5273754a3675962d","head":{"label":"ThiagoCodecov:test-branch-1","ref":"test-branch-1","sha":"10063a8d1d721d8d6c1b731f5273754a3675962d","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"repo":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments","created_at":"2018-11-07T22:40:20Z","updated_at":"2023-07-04T20:51:23Z","pushed_at":"2022-08-17T20:09:02Z","git_url":"git://github.com/ThiagoCodecov/example-python.git","ssh_url":"git@github.com:ThiagoCodecov/example-python.git","clone_url":"https://github.com/ThiagoCodecov/example-python.git","svn_url":"https://github.com/ThiagoCodecov/example-python","homepage":"https://codecov.io","size":178,"stargazers_count":0,"watchers_count":0,"language":"Shell","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"has_discussions":false,"forks_count":3,"mirror_url":null,"archived":true,"disabled":false,"open_issues_count":1,"license":null,"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"topics":[],"visibility":"public","forks":3,"open_issues":1,"watchers":0,"default_branch":"master"}},"base":{"label":"ThiagoCodecov:master","ref":"master","sha":"17a71a9a2f5335ed4d00496c7bbc6405f547a527","user":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"repo":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments","created_at":"2018-11-07T22:40:20Z","updated_at":"2023-07-04T20:51:23Z","pushed_at":"2022-08-17T20:09:02Z","git_url":"git://github.com/ThiagoCodecov/example-python.git","ssh_url":"git@github.com:ThiagoCodecov/example-python.git","clone_url":"https://github.com/ThiagoCodecov/example-python.git","svn_url":"https://github.com/ThiagoCodecov/example-python","homepage":"https://codecov.io","size":178,"stargazers_count":0,"watchers_count":0,"language":"Shell","has_issues":false,"has_projects":true,"has_downloads":true,"has_wiki":false,"has_pages":false,"has_discussions":false,"forks_count":3,"mirror_url":null,"archived":true,"disabled":false,"open_issues_count":1,"license":null,"allow_forking":true,"is_template":false,"web_commit_signoff_required":false,"topics":[],"visibility":"public","forks":3,"open_issues":1,"watchers":0,"default_branch":"master"}},"_links":{"self":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11"},"html":{"href":"https://github.com/ThiagoCodecov/example-python/pull/11"},"issue":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11"},"comments":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/11/comments"},"review_comments":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/comments"},"review_comment":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/comments{/number}"},"commits":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls/11/commits"},"statuses":{"href":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/10063a8d1d721d8d6c1b731f5273754a3675962d"}},"author_association":"OWNER","auto_merge":null,"active_lock_reason":null}]'
     headers:
       Access-Control-Allow-Origin:
       - '*'
@@ -763,31 +87,22 @@ interactions:
         X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
         X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
         X-GitHub-Request-Id, Deprecation, Sunset
-      Cache-Control:
-      - private, max-age=60, s-maxage=60
-      Content-Encoding:
-      - gzip
+      Content-Length:
+      - '95'
       Content-Security-Policy:
       - default-src 'none'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Wed, 17 Aug 2022 01:18:51 GMT
-      ETag:
-      - W/"876ae794efdbbd6cd22b6d72b188cbf4fb0026cb0f076bcfb912360db3c0f21f"
+      - Tue, 03 Sep 2024 13:17:10 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:
-      - GitHub.com
+      - github.com
       Strict-Transport-Security:
       - max-age=31536000; includeSubdomains; preload
-      Transfer-Encoding:
-      - chunked
       Vary:
-      - Accept, Authorization, Cookie, X-GitHub-OTP
       - Accept-Encoding, Accept, X-Requested-With
-      X-Accepted-OAuth-Scopes:
-      - ''
       X-Content-Type-Options:
       - nosniff
       X-Frame-Options:
@@ -795,23 +110,208 @@ interactions:
       X-GitHub-Media-Type:
       - github.v3
       X-GitHub-Request-Id:
-      - C5F3:074A:7A0986:823408:62FC41FB
-      X-OAuth-Scopes:
-      - repo
+      - E8CF:37895C:261D361:4949EA9:66D70C56
       X-RateLimit-Limit:
-      - '5000'
+      - '60'
       X-RateLimit-Remaining:
-      - '4988'
+      - '50'
       X-RateLimit-Reset:
-      - '1660701033'
+      - '1725372143'
       X-RateLimit-Resource:
       - core
       X-RateLimit-Used:
-      - '12'
+      - '10'
       X-XSS-Protection:
       - '0'
-      github-authentication-token-expiration:
-      - 2022-08-24 01:18:21 UTC
     http_version: HTTP/1.1
     status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.github.com
+      user-agent:
+      - Default
+    method: GET
+    uri: https://api.github.com/repos/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a
+  response:
+    content: '{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a","permalink_url":"https://github.com/ThiagoCodecov/example-python/compare/ThiagoCodecov:17a71a9...ThiagoCodecov:649eaaf","diff_url":"https://github.com/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a.diff","patch_url":"https://github.com/ThiagoCodecov/example-python/compare/17a71a9a2f5335ed4d00496c7bbc6405f547a527...649eaaf2924e92dc7fd8d370ddb857033231e67a.patch","base_commit":{"sha":"17a71a9a2f5335ed4d00496c7bbc6405f547a527","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3OjE3YTcxYTlhMmY1MzM1ZWQ0ZDAwNDk2YzdiYmM2NDA1ZjU0N2E1Mjc=","commit":{"author":{"name":"Thiago Ramos","email":"thiago@codecov.io","date":"2019-10-05T18:21:13Z"},"committer":{"name":"Thiago Ramos","email":"thiago@codecov.io","date":"2019-10-05T18:21:13Z"},"message":"Adding file 20191005-4f786e3e-a901-4816-890a-295fa4aca6f7","tree":{"sha":"c78a6415857cd33367f26e78c4be1fcf3ca4d05f","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/c78a6415857cd33367f26e78c4be1fcf3ca4d05f"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/17a71a9a2f5335ed4d00496c7bbc6405f547a527","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/17a71a9a2f5335ed4d00496c7bbc6405f547a527","html_url":"https://github.com/ThiagoCodecov/example-python/commit/17a71a9a2f5335ed4d00496c7bbc6405f547a527","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/17a71a9a2f5335ed4d00496c7bbc6405f547a527/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"ffcb4efe52c91dc1f29030d1fb1a07ff85b38dd9","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/ffcb4efe52c91dc1f29030d1fb1a07ff85b38dd9","html_url":"https://github.com/ThiagoCodecov/example-python/commit/ffcb4efe52c91dc1f29030d1fb1a07ff85b38dd9"}]},"merge_base_commit":{"sha":"17a71a9a2f5335ed4d00496c7bbc6405f547a527","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3OjE3YTcxYTlhMmY1MzM1ZWQ0ZDAwNDk2YzdiYmM2NDA1ZjU0N2E1Mjc=","commit":{"author":{"name":"Thiago Ramos","email":"thiago@codecov.io","date":"2019-10-05T18:21:13Z"},"committer":{"name":"Thiago Ramos","email":"thiago@codecov.io","date":"2019-10-05T18:21:13Z"},"message":"Adding file 20191005-4f786e3e-a901-4816-890a-295fa4aca6f7","tree":{"sha":"c78a6415857cd33367f26e78c4be1fcf3ca4d05f","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/c78a6415857cd33367f26e78c4be1fcf3ca4d05f"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/17a71a9a2f5335ed4d00496c7bbc6405f547a527","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/17a71a9a2f5335ed4d00496c7bbc6405f547a527","html_url":"https://github.com/ThiagoCodecov/example-python/commit/17a71a9a2f5335ed4d00496c7bbc6405f547a527","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/17a71a9a2f5335ed4d00496c7bbc6405f547a527/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"ffcb4efe52c91dc1f29030d1fb1a07ff85b38dd9","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/ffcb4efe52c91dc1f29030d1fb1a07ff85b38dd9","html_url":"https://github.com/ThiagoCodecov/example-python/commit/ffcb4efe52c91dc1f29030d1fb1a07ff85b38dd9"}]},"status":"ahead","ahead_by":2,"behind_by":0,"total_commits":2,"commits":[{"sha":"ab89bd097cd5e1af391dc52daccaa4e6c6579039","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3OmFiODliZDA5N2NkNWUxYWYzOTFkYzUyZGFjY2FhNGU2YzY1NzkwMzk=","commit":{"author":{"name":"Thiago Ramos","email":"thiago@codecov.io","date":"2019-10-24T08:21:45Z"},"committer":{"name":"Thiago Ramos","email":"thiago@codecov.io","date":"2019-10-24T08:21:45Z"},"message":"Adding requirements","tree":{"sha":"c8091d748268a03a5886b5959cb0ae5e25d0c9d8","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/c8091d748268a03a5886b5959cb0ae5e25d0c9d8"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/ab89bd097cd5e1af391dc52daccaa4e6c6579039","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/ab89bd097cd5e1af391dc52daccaa4e6c6579039","html_url":"https://github.com/ThiagoCodecov/example-python/commit/ab89bd097cd5e1af391dc52daccaa4e6c6579039","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/ab89bd097cd5e1af391dc52daccaa4e6c6579039/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"17a71a9a2f5335ed4d00496c7bbc6405f547a527","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/17a71a9a2f5335ed4d00496c7bbc6405f547a527","html_url":"https://github.com/ThiagoCodecov/example-python/commit/17a71a9a2f5335ed4d00496c7bbc6405f547a527"}]},{"sha":"649eaaf2924e92dc7fd8d370ddb857033231e67a","node_id":"MDY6Q29tbWl0MTU2NjE3Nzc3OjY0OWVhYWYyOTI0ZTkyZGM3ZmQ4ZDM3MGRkYjg1NzAzMzIzMWU2N2E=","commit":{"author":{"name":"Thiago Ramos","email":"thiago@codecov.io","date":"2019-11-26T23:54:15Z"},"committer":{"name":"Thiago Ramos","email":"thiago@codecov.io","date":"2019-11-26T23:54:15Z"},"message":"Trying stuff","tree":{"sha":"2e9aa67eafb7410ed9ecb73e5a60462452bfdd17","url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees/2e9aa67eafb7410ed9ecb73e5a60462452bfdd17"},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a","comment_count":0,"verification":{"verified":false,"reason":"unsigned","signature":null,"payload":null}},"url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a","html_url":"https://github.com/ThiagoCodecov/example-python/commit/649eaaf2924e92dc7fd8d370ddb857033231e67a","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/comments","author":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"committer":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"parents":[{"sha":"ab89bd097cd5e1af391dc52daccaa4e6c6579039","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/ab89bd097cd5e1af391dc52daccaa4e6c6579039","html_url":"https://github.com/ThiagoCodecov/example-python/commit/ab89bd097cd5e1af391dc52daccaa4e6c6579039"}]}],"files":[{"sha":"ab0a8735f8dfaef9044d2092e6de622052069b1d","filename":"requirements.txt","status":"added","additions":20,"deletions":0,"changes":20,"blob_url":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/requirements.txt","raw_url":"https://github.com/ThiagoCodecov/example-python/raw/649eaaf2924e92dc7fd8d370ddb857033231e67a/requirements.txt","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/requirements.txt?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","patch":"@@ -0,0 +1,20 @@\n+atomicwrites==1.3.0\n+attrs==19.3.0\n+certifi==2019.9.11\n+chardet==3.0.4\n+codecov==2.0.15\n+coverage==4.5.4\n+idna==2.8\n+importlib-metadata==0.23\n+more-itertools==7.2.0\n+packaging==19.2\n+pluggy==0.13.0\n+py==1.8.0\n+pyparsing==2.4.2\n+pytest==5.2.1\n+pytest-cov==2.8.1\n+requests==2.22.0\n+six==1.12.0\n+urllib3==1.25.6\n+wcwidth==0.1.7\n+zipp==0.6.0"},{"sha":"aaaabbbbf8dfaef9044d2092e6de622052069b1d","filename":"awesome/__init__.py","status":"added","additions":20,"deletions":0,"changes":20,"blob_url":"https://github.com/ThiagoCodecov/example-python/blob/649eaaf2924e92dc7fd8d370ddb857033231e67a/requirements.txt","raw_url":"https://github.com/ThiagoCodecov/example-python/raw/649eaaf2924e92dc7fd8d370ddb857033231e67a/requirements.txt","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/requirements.txt?ref=649eaaf2924e92dc7fd8d370ddb857033231e67a","patch":"diff --git a/awesome/__init__.py b/awesome/__init__.py\nindex bc9e176b..4cf0cf64 100644\n--- a/awesome/__init__.py\n+++ b/awesome/__init__.py\n@@ -4,3 +4,4 @@ test:\n some line\n-line modified (old)\n+line modified (new)\n+line added\n some line"}]}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Length:
+      - '95'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 03 Sep 2024 13:17:10 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - github.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - E8CF:37895C:261D361:4949EA9:66D70C56
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '50'
+      X-RateLimit-Reset:
+      - '1725372143'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '10'
+      X-XSS-Protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.github.com
+      user-agent:
+      - Default
+    method: GET
+    uri: https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/status?page=1&per_page=100
+  response:
+    content: '{"state":"pending","statuses":[],"sha":"649eaaf2924e92dc7fd8d370ddb857033231e67a","total_count":0,"repository":{"id":156617777,"node_id":"MDEwOlJlcG9zaXRvcnkxNTY2MTc3Nzc=","name":"example-python","full_name":"ThiagoCodecov/example-python","private":false,"owner":{"login":"ThiagoCodecov","id":44376991,"node_id":"MDQ6VXNlcjQ0Mzc2OTkx","avatar_url":"https://avatars.githubusercontent.com/u/44376991?v=4","gravatar_id":"","url":"https://api.github.com/users/ThiagoCodecov","html_url":"https://github.com/ThiagoCodecov","followers_url":"https://api.github.com/users/ThiagoCodecov/followers","following_url":"https://api.github.com/users/ThiagoCodecov/following{/other_user}","gists_url":"https://api.github.com/users/ThiagoCodecov/gists{/gist_id}","starred_url":"https://api.github.com/users/ThiagoCodecov/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/ThiagoCodecov/subscriptions","organizations_url":"https://api.github.com/users/ThiagoCodecov/orgs","repos_url":"https://api.github.com/users/ThiagoCodecov/repos","events_url":"https://api.github.com/users/ThiagoCodecov/events{/privacy}","received_events_url":"https://api.github.com/users/ThiagoCodecov/received_events","type":"User","site_admin":false},"html_url":"https://github.com/ThiagoCodecov/example-python","description":"Python coverage example","fork":true,"url":"https://api.github.com/repos/ThiagoCodecov/example-python","forks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/forks","keys_url":"https://api.github.com/repos/ThiagoCodecov/example-python/keys{/key_id}","collaborators_url":"https://api.github.com/repos/ThiagoCodecov/example-python/collaborators{/collaborator}","teams_url":"https://api.github.com/repos/ThiagoCodecov/example-python/teams","hooks_url":"https://api.github.com/repos/ThiagoCodecov/example-python/hooks","issue_events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/events{/number}","events_url":"https://api.github.com/repos/ThiagoCodecov/example-python/events","assignees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/assignees{/user}","branches_url":"https://api.github.com/repos/ThiagoCodecov/example-python/branches{/branch}","tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/tags","blobs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/blobs{/sha}","git_tags_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/tags{/sha}","git_refs_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/refs{/sha}","trees_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/trees{/sha}","statuses_url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/{sha}","languages_url":"https://api.github.com/repos/ThiagoCodecov/example-python/languages","stargazers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/stargazers","contributors_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contributors","subscribers_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscribers","subscription_url":"https://api.github.com/repos/ThiagoCodecov/example-python/subscription","commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits{/sha}","git_commits_url":"https://api.github.com/repos/ThiagoCodecov/example-python/git/commits{/sha}","comments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/comments{/number}","issue_comment_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues/comments{/number}","contents_url":"https://api.github.com/repos/ThiagoCodecov/example-python/contents/{+path}","compare_url":"https://api.github.com/repos/ThiagoCodecov/example-python/compare/{base}...{head}","merges_url":"https://api.github.com/repos/ThiagoCodecov/example-python/merges","archive_url":"https://api.github.com/repos/ThiagoCodecov/example-python/{archive_format}{/ref}","downloads_url":"https://api.github.com/repos/ThiagoCodecov/example-python/downloads","issues_url":"https://api.github.com/repos/ThiagoCodecov/example-python/issues{/number}","pulls_url":"https://api.github.com/repos/ThiagoCodecov/example-python/pulls{/number}","milestones_url":"https://api.github.com/repos/ThiagoCodecov/example-python/milestones{/number}","notifications_url":"https://api.github.com/repos/ThiagoCodecov/example-python/notifications{?since,all,participating}","labels_url":"https://api.github.com/repos/ThiagoCodecov/example-python/labels{/name}","releases_url":"https://api.github.com/repos/ThiagoCodecov/example-python/releases{/id}","deployments_url":"https://api.github.com/repos/ThiagoCodecov/example-python/deployments"},"commit_url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a","url":"https://api.github.com/repos/ThiagoCodecov/example-python/commits/649eaaf2924e92dc7fd8d370ddb857033231e67a/status"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Length:
+      - '95'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 03 Sep 2024 13:17:10 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - github.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - E8CF:37895C:261D361:4949EA9:66D70C56
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '50'
+      X-RateLimit-Reset:
+      - '1725372143'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '10'
+      X-XSS-Protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - api.github.com
+      user-agent:
+      - Default
+    method: POST
+    uri: https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a
+  response:
+    content: '{"url":"https://api.github.com/repos/ThiagoCodecov/example-python/statuses/649eaaf2924e92dc7fd8d370ddb857033231e67a","avatar_url":"https://github.com/images/error/hubot_happy.gif","id":1,"node_id":"MDY6U3RhdHVzMQ==","state":"success","description":"Build has completed successfully","target_url":"https://ci.example.com/1000/output","context":"continuous-integration/jenkins","created_at":"2012-07-20T01:19:13Z","updated_at":"2012-07-20T01:19:13Z","creator":{"login":"octocat","id":1,"node_id":"MDQ6VXNlcjE=","avatar_url":"https://github.com/images/error/octocat_happy.gif","gravatar_id":"","url":"https://api.github.com/users/octocat","html_url":"https://github.com/octocat","followers_url":"https://api.github.com/users/octocat/followers","following_url":"https://api.github.com/users/octocat/following{/other_user}","gists_url":"https://api.github.com/users/octocat/gists{/gist_id}","starred_url":"https://api.github.com/users/octocat/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/octocat/subscriptions","organizations_url":"https://api.github.com/users/octocat/orgs","repos_url":"https://api.github.com/users/octocat/repos","events_url":"https://api.github.com/users/octocat/events{/privacy}","received_events_url":"https://api.github.com/users/octocat/received_events","type":"User","site_admin":false}}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Access-Control-Expose-Headers:
+      - ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining,
+        X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes,
+        X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO,
+        X-GitHub-Request-Id, Deprecation, Sunset
+      Content-Length:
+      - '95'
+      Content-Security-Policy:
+      - default-src 'none'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 03 Sep 2024 13:17:10 GMT
+      Referrer-Policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      Server:
+      - github.com
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubdomains; preload
+      Vary:
+      - Accept-Encoding, Accept, X-Requested-With
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-GitHub-Media-Type:
+      - github.v3
+      X-GitHub-Request-Id:
+      - E8CF:37895C:261D361:4949EA9:66D70C56
+      X-RateLimit-Limit:
+      - '60'
+      X-RateLimit-Remaining:
+      - '50'
+      X-RateLimit-Reset:
+      - '1725372143'
+      X-RateLimit-Resource:
+      - core
+      X-RateLimit-Used:
+      - '10'
+      X-XSS-Protection:
+      - '0'
+    http_version: HTTP/1.1
+    status_code: 201
 version: 1

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -508,6 +508,7 @@ class TestNotifyTask(object):
             "https://codecov.io"
         )
         mocker.patch.object(NotifyTask, "app")
+        mocker.patch.object(NotifyTask, "save_patch_totals")
         mocker.patch.object(NotifyTask, "should_send_notifications", return_value=True)
         fetch_and_update_whether_ci_passed_result = {}
         mocker.patch.object(
@@ -938,6 +939,7 @@ class TestNotifyTask(object):
             "get_notifiers_instances",
             return_value=[bad_notifier, good_notifier, disabled_notifier],
         )
+        mocker.patch.object(NotifyTask, "save_patch_totals")
         task = NotifyTask()
         expected_result = [
             {"notifier": "bad_name", "title": "bad_notifier", "result": None},
@@ -1108,6 +1110,7 @@ class TestNotifyTask(object):
             "https://codecov.io"
         )
         mocker.patch.object(NotifyTask, "app")
+        mocker.patch.object(NotifyTask, "save_patch_totals")
         mocker.patch.object(NotifyTask, "should_send_notifications", return_value=True)
         fetch_and_update_whether_ci_passed_result = {}
         mocker.patch.object(


### PR DESCRIPTION
related: https://github.com/codecov/internal-issues/issues/721
related: https://github.com/codecov/engineering-team/issues/2387

We have a problem that the UI and the statuses are reporting different numbers for patch.
Part of this issue is that the `NotifyTask` (calculates patch for status) has access to the `Pull` while the `ComputeComparison` (calculates for the UI) doesn't.

This is a problem because the base for patch coverage might be different, so numbers would be different (see [here](https://github.com/codecov/worker/blob/9078de24b4dbed1bb64250b2b3864336954f310c/tasks/compute_comparison.py#L334) that we assume no action is needed cause there's nothing we can do).

So the 1st change here is to have the `NotifyTask` calculate and save patch coverage.
The second change is to cache the patch calculation so we don't compute it more than once.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.