### PR TITLE
Add server_default value to avoid null tokens

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -147,6 +147,7 @@ class Repository(CodecovBaseModel):
     webhook_secret = Column(types.Text)
     activated = Column(types.Boolean, default=False)
     bundle_analysis_enabled = Column(types.Boolean, default=False)
+    upload_token = Column(postgresql.UUID, server_default=FetchedValue())
 
     # DEPRECATED - prefer GithubAppInstallation.is_repo_covered_by_integration
     using_integration = Column(types.Boolean)

--- a/database/tests/unit/test_events.py
+++ b/database/tests/unit/test_events.py
@@ -37,6 +37,11 @@ def test_shelter_repo_sync(dbsession, mock_configuration, mocker):
     repo.name = "testing"
     dbsession.commit()
 
+    # this wouldn't trigger the publish via SQLAlchemy events (after_update) since it's an unimportant attribute
+    repo.activated = True
+    dbsession.commit()
+
+    # this is from the first trigger
     publish.assert_called_once_with(
         "projects/test-project-id/topics/test-topic-id",
         b'{"type": "repo", "sync": "one", "id": 91728376}',


### PR DESCRIPTION
The revert of this PR, https://github.com/codecov/worker/pull/678. Additional change includes adding a server_default=FetchedValue() to prevent upload_tokens having a null value

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.