### PR TITLE
add shared-change-checker CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,12 @@ jobs:
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
 
+  shared-change-checker:
+    name: See if shared changed
+    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@main
+    with:
+      dep: 'shared'
+
   build-self-hosted:
     name: Build Self Hosted Worker
     needs: [build, test]


### PR DESCRIPTION
should automatically post/update a comment on PRs that change the hash of our `shared` dependency for reviewers to take a quick glance at

example comment (which was updated automatically as its PR switched to different hashes for `shared`):
<img width="687" alt="Screenshot 2024-09-04 at 5 01 02 PM" src="https://github.com/user-attachments/assets/d347c0aa-52b0-4604-b279-fd37af8cb4f6">