### PR TITLE
move shared change check to separate workflow with correct permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,6 @@ jobs:
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
 
-  shared-change-checker:
-    name: See if shared changed
-    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@main
-    with:
-      dep: 'shared'
-
   build-self-hosted:
     name: Build Self Hosted Worker
     needs: [build, test]

--- a/.github/workflows/pr_detect_shared_changes.yml
+++ b/.github/workflows/pr_detect_shared_changes.yml
@@ -1,0 +1,14 @@
+name: Detect dep version changes
+
+on:
+  pull_request:
+
+permissions:
+  pull-requests: "write"
+
+jobs:
+  shared-change-checker:
+    name: See if shared changed
+    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@pr32
+    with:
+      dep: 'shared'

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/172f45a027fc3663523208856dbbdc267cc25e96.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/42f83ec717e632c543cc6ceab8fc3cc39eccc5be.tar.gz#egg=shared
 https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz#egg=test-results-parser
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -357,7 +357,7 @@ sentry-sdk[celery]==2.13.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/172f45a027fc3663523208856dbbdc267cc25e96.tar.gz
+shared @ https://github.com/codecov/shared/archive/42f83ec717e632c543cc6ceab8fc3cc39eccc5be.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
https://github.com/codecov/gha-workflows/pull/32 will change this to use `main` before merging

- [run that skips posting a comment because shared was not changed](https://github.com/codecov/worker/actions/runs/10726314483/job/29746076253?pr=690)
- [run that posts a comment to this PR](https://github.com/codecov/worker/actions/runs/10726340835/job/29746157639?pr=690)

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.