### PR TITLE
use main instead of pr32 for shared dep change check

### DIFF
--- a/.github/workflows/pr_detect_shared_changes.yml
+++ b/.github/workflows/pr_detect_shared_changes.yml
@@ -9,6 +9,6 @@ permissions:
 jobs:
   shared-change-checker:
     name: See if shared changed
-    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@pr32
+    uses: codecov/gha-workflows/.github/workflows/diff-dep.yml@main
     with:
       dep: 'shared'


### PR DESCRIPTION
apparently i added https://github.com/codecov/worker/pull/690 to the merge queue. i meant to change the version of the workflow it used back to `main` before merging.