### PR TITLE
fix: deduplicate component measurements

### DIFF
--- a/services/tests/test_timeseries.py
+++ b/services/tests/test_timeseries.py
@@ -422,6 +422,12 @@ class TestTimeseriesService(object):
                         "flag_regexes": [],
                         "paths": [r"folder/*"],
                     },
+                    {  # testing duplicate component on purpose this was causing crashes
+                        "component_id": "all_settings",
+                        "name": "all settings",
+                        "flag_regexes": [],
+                        "paths": [r"folder/*"],
+                    },
                     {
                         "component_id": "path_not_found",
                         "name": "no expected covarage",


### PR DESCRIPTION
we were getting measurements with duplicate "index_elements" values in the measurements list which was causing errors because that's not allowed, so we have to deduplicate them. I added logs for when we get duplicates.

Fixes: https://github.com/codecov/internal-issues/issues/717