### PR TITLE
feat: customize comment based on status

### DIFF
--- a/services/bundle_analysis/notify/contexts/__init__.py
+++ b/services/bundle_analysis/notify/contexts/__init__.py
@@ -1,3 +1,4 @@
+from enum import Enum, auto
 from functools import cached_property
 from typing import Generic, Literal, Self, TypeVar
 
@@ -29,6 +30,17 @@ T = TypeVar("T")
 
 class ContextNotLoadedError(Exception):
     pass
+
+
+class CommitStatusLevel(Enum):
+    INFO = auto()
+    WARNING = auto()
+    ERROR = auto()
+
+    def to_str(self) -> Literal["success"] | Literal["failure"]:
+        if self.value == "ERROR":
+            return "failure"
+        return "success"
 
 
 class NotificationContextField(Generic[T]):

--- a/services/bundle_analysis/notify/contexts/comment.py
+++ b/services/bundle_analysis/notify/contexts/comment.py
@@ -19,6 +19,7 @@ from services.bundle_analysis.exceptions import (
 )
 from services.bundle_analysis.notify.contexts import (
     BaseBundleAnalysisNotificationContext,
+    CommitStatusLevel,
     NotificationContextBuilder,
     NotificationContextBuildError,
     NotificationContextField,
@@ -44,6 +45,9 @@ class BundleAnalysisPRCommentNotificationContext(BaseBundleAnalysisNotificationC
     pull: EnrichedPull = NotificationContextField[EnrichedPull]()
     bundle_analysis_comparison: BundleAnalysisComparison = NotificationContextField[
         BundleAnalysisComparison
+    ]()
+    commit_status_level: CommitStatusLevel = NotificationContextField[
+        CommitStatusLevel
     ]()
     should_use_upgrade_comment: bool
 
@@ -183,6 +187,22 @@ class BundleAnalysisPRCommentContextBuilder(NotificationContextBuilder):
                 self._notification_context.should_use_upgrade_comment = False
         return self
 
+    def load_commit_status_level(self) -> Self:
+        bundle_analysis_comparison = (
+            self._notification_context.bundle_analysis_comparison
+        )
+        user_config = self._notification_context.user_config
+
+        if is_bundle_change_within_bundle_threshold(
+            bundle_analysis_comparison, user_config.warning_threshold
+        ):
+            self._notification_context.commit_status_level = CommitStatusLevel.INFO
+        elif user_config.status_level == "informational":
+            self._notification_context.commit_status_level = CommitStatusLevel.WARNING
+        else:
+            self._notification_context.commit_status_level = CommitStatusLevel.ERROR
+        return self
+
     def build_context(self) -> Self:
         super().build_context()
         async_to_sync(self.load_enriched_pull)()
@@ -190,6 +210,7 @@ class BundleAnalysisPRCommentContextBuilder(NotificationContextBuilder):
             self.load_bundle_comparison()
             .evaluate_has_enough_changes()
             .evaluate_should_use_upgrade_message()
+            .load_commit_status_level()
         )
 
     def get_result(self) -> BundleAnalysisPRCommentNotificationContext:

--- a/services/bundle_analysis/notify/contexts/commit_status.py
+++ b/services/bundle_analysis/notify/contexts/commit_status.py
@@ -1,6 +1,3 @@
-from enum import Enum, auto
-from typing import Literal
-
 import sentry_sdk
 from asgiref.sync import async_to_sync
 from shared.bundle_analysis import (
@@ -19,6 +16,7 @@ from services.bundle_analysis.exceptions import (
 )
 from services.bundle_analysis.notify.contexts import (
     BaseBundleAnalysisNotificationContext,
+    CommitStatusLevel,
     NotificationContextBuilder,
     NotificationContextBuildError,
     NotificationContextField,
@@ -32,17 +30,6 @@ from services.repository import (
     fetch_and_update_pull_request_information_from_commit,
 )
 from services.urls import get_bundle_analysis_pull_url, get_commit_url
-
-
-class CommitStatusLevel(Enum):
-    INFO = auto()
-    WARNING = auto()
-    ERROR = auto()
-
-    def to_str(self) -> Literal["success"] | Literal["failure"]:
-        if self.value == "ERROR":
-            return "failure"
-        return "success"
 
 
 class CommitStatusNotificationContext(BaseBundleAnalysisNotificationContext):

--- a/services/bundle_analysis/notify/contexts/tests/test_comment_context.py
+++ b/services/bundle_analysis/notify/contexts/tests/test_comment_context.py
@@ -325,7 +325,7 @@ class TestBundleAnalysisPRCommentNotificationContext:
         with pytest.raises(ContextNotLoadedError):
             other_context.bundle_analysis_comparison
 
-        fake_comparison = MagicMock(name="fake_comparison")
+        fake_comparison = MagicMock(name="fake_comparison", percentage_delta=10.0)
         mocker.patch.object(
             ComparisonLoader, "get_comparison", return_value=fake_comparison
         )

--- a/services/bundle_analysis/notify/messages/templates/bundle_analysis_notify/bundle_comment.md
+++ b/services/bundle_analysis/notify/messages/templates/bundle_analysis_notify/bundle_comment.md
@@ -1,11 +1,10 @@
 ## [Bundle]({{pull_url}}) Report
 {% if total_size_delta == 0 %}
 Bundle size has no change :white_check_mark:
-{% elif total_size_delta > 0 %}
-Changes will increase total bundle size by {{total_size_readable}} :arrow_up:
 {% else %}
-Changes will decrease total bundle size by {{total_size_readable}} :arrow_down:
+{% if status_level == "ERROR" %}:x: Check failed: c{% else %}C{% endif %}hanges will {% if total_size_delta > 0 %}increase{% else %}decrease{% endif %} total bundle size by {{total_size_readable}} ({{total_percentage}}) {% if total_size_delta > 0 %}:arrow_up:{% else %}:arrow_down:{% endif %}{% if status_level == "WARNING" %}:warning:, exceeding the [configured](https://docs.codecov.com/docs/javascript-bundle-analysis#main-features) threshold of {{warning_threshold_readable}}.{% elif status_level == "ERROR" %}, **exceeding** the [configured](https://docs.codecov.com/docs/javascript-bundle-analysis#main-features) threshold of {{warning_threshold_readable}}.{% else %}. This is within the [configured](https://docs.codecov.com/docs/javascript-bundle-analysis#main-features) threshold :white_check_mark:{% endif %}
 {% endif %}
 {% if bundle_rows %}{% include "bundle_analysis_notify/bundle_table.md" %}{% if has_cached %}
+
 ℹ️ *Bundle size includes cached data from a previous commit
 {%endif%}{% endif %}

--- a/services/bundle_analysis/notify/messages/templates/bundle_analysis_notify/bundle_table.md
+++ b/services/bundle_analysis/notify/messages/templates/bundle_analysis_notify/bundle_table.md
@@ -1,3 +1,7 @@
-| Bundle name | Size | Change |
+{% if status_level == "INFO" %}<details><summary>Detailed changes</summary>
+
+{% endif %}| Bundle name | Size | Change |
 | ----------- | ---- | ------ |{% for bundle_row in bundle_rows %}
-| {{bundle_row.bundle_name}}{% if bundle_row.is_cached %}*{% endif %} | {{bundle_row.bundle_size}} | {{bundle_row.change_size_readable}} {{bundle_row.change_icon}} |{% endfor %}
+| {{bundle_row.bundle_name}}{% if bundle_row.is_cached %}*{% endif %} | {{bundle_row.bundle_size}} | {{bundle_row.change_size_readable}} {{bundle_row.change_icon}} |{% endfor %}{% if status_level == "INFO" %}
+
+</details>{% endif %}


### PR DESCRIPTION
Customizes the bundle analysis PR comment based on the commit status outcome. matches designs in https://github.com/codecov/engineering-team/issues/1491 except for the table warnings (we can't get a per-bundle percentage yet)

Removing some unit tests in favor of larger scoped ones in `test_bundle_analysis.py`
