### PR TITLE
Fix commit parent selection when there are multiple parents

### DIFF
--- a/services/repository.py
+++ b/services/repository.py
@@ -168,8 +168,7 @@ async def fetch_appropriate_parent_for_commit(
         else:
             possible_commit = possible_commit_query.filter(
                 Commit.branch == commit.branch,
-            )
-            possible_commit = possible_commit_query.first()
+            ).first()
         if possible_commit:
             return possible_commit.commitid
     ancestors_tree = await repository_service.get_ancestors_tree(commitid)

--- a/services/repository.py
+++ b/services/repository.py
@@ -32,6 +32,7 @@ from shared.yaml import UserYaml
 from shared.yaml.user_yaml import OwnerContext
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Query
 
 from database.enums import CommitErrorTypes
 from database.models import Commit, Owner, Pull, Repository
@@ -163,12 +164,7 @@ async def fetch_appropriate_parent_for_commit(
             ~Commit.message.is_(None),
             ~Commit.deleted.is_(True),
         )
-        if possible_commit_query.count() <= 1:
-            possible_commit = possible_commit_query.first()
-        else:
-            possible_commit = possible_commit_query.filter(
-                Commit.branch == commit.branch,
-            ).first()
+        possible_commit = possibly_filter_out_branch(commit, possible_commit_query)
         if possible_commit:
             return possible_commit.commitid
     ancestors_tree = await repository_service.get_ancestors_tree(commitid)
@@ -182,12 +178,7 @@ async def fetch_appropriate_parent_for_commit(
             ~Commit.message.is_(None),
             ~Commit.deleted.is_(True),
         )
-        if closest_parent_query.count() <= 1:
-            closest_parent = closest_parent_query.first()
-        else:
-            closest_parent = closest_parent_query.filter(
-                Commit.branch == commit.branch,
-            ).first()
+        closest_parent = possibly_filter_out_branch(commit, closest_parent_query)
         if closest_parent:
             return closest_parent.commitid
         if closest_parent_without_message is None:
@@ -196,12 +187,7 @@ async def fetch_appropriate_parent_for_commit(
                 Commit.repoid == commit.repoid,
                 ~Commit.deleted.is_(True),
             )
-            if res.count() <= 1:
-                res = res.first()
-            else:
-                res = res.filter(
-                    Commit.branch == commit.branch,
-                ).first()
+            res = possibly_filter_out_branch(commit, res)
             if res:
                 closest_parent_without_message = res[0]
         elements = parents
@@ -210,6 +196,16 @@ async def fetch_appropriate_parent_for_commit(
         extra=dict(commit=commit.commitid, repoid=commit.repoid),
     )
     return closest_parent_without_message
+
+
+def possibly_filter_out_branch(commit: Commit, query: Query) -> Commit | None:
+    if query.count() <= 1:
+        query = query.first()
+    else:
+        query = query.filter(
+            Commit.branch == commit.branch,
+        ).first()
+    return query
 
 
 async def possibly_update_commit_from_provider_info(commit, repository_service):

--- a/services/tests/test_repository_service.py
+++ b/services/tests/test_repository_service.py
@@ -635,17 +635,17 @@ class TestRepositoryServiceTestCase(object):
         first_parent_commit_id = "8aa5be054aeb21cf5a664ecd504a1af6f5ceafba"
         second_parent_commit_id = "a" * 32
         repository = RepositoryFactory.create()
-        first_parent_commit = CommitFactory.create(
-            commitid=first_parent_commit_id, repository=repository, branch="1stBranch"
-        )
         second_parent_commit = CommitFactory.create(
             commitid=second_parent_commit_id, repository=repository, branch="2ndBranch"
+        )
+        first_parent_commit = CommitFactory.create(
+            commitid=first_parent_commit_id, repository=repository, branch="1stBranch"
         )
         commit = CommitFactory.create(
             parent_commit_id=None, repository=repository, branch="1stBranch"
         )
-        dbsession.add(first_parent_commit)
         dbsession.add(second_parent_commit)
+        dbsession.add(first_parent_commit)
         dbsession.add(commit)
         dbsession.flush()
         git_commit = {"parents": [first_parent_commit_id, second_parent_commit_id]}


### PR DESCRIPTION
We were not actually performing the branch filter on the git parents. This fixes it and also refactors the code a bit to avoid duplication.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.