### PR TITLE
feat: collect extra shas for gitlab notif

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/42f83ec717e632c543cc6ceab8fc3cc39eccc5be.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/f54ab4f53ce09d47b9c8bfb2b7d1bf39ebee4f97.tar.gz#egg=shared
 https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz#egg=test-results-parser
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/f54ab4f53ce09d47b9c8bfb2b7d1bf39ebee4f97.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/cdf263f5173c16585030bcab40e639045c69e199.tar.gz#egg=shared
 https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz#egg=test-results-parser
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -357,7 +357,7 @@ sentry-sdk[celery]==2.13.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/f54ab4f53ce09d47b9c8bfb2b7d1bf39ebee4f97.tar.gz
+shared @ https://github.com/codecov/shared/archive/cdf263f5173c16585030bcab40e639045c69e199.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -357,7 +357,7 @@ sentry-sdk[celery]==2.13.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/42f83ec717e632c543cc6ceab8fc3cc39eccc5be.tar.gz
+shared @ https://github.com/codecov/shared/archive/f54ab4f53ce09d47b9c8bfb2b7d1bf39ebee4f97.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/comparison/__init__.py
+++ b/services/comparison/__init__.py
@@ -31,6 +31,11 @@ class ComparisonContext(object):
     test_results_error: TestResultsProcessingError | None = None
     gh_app_installation_name: str | None = None
     gh_is_using_codecov_commenter: bool = False
+    # GitLab has a "merge results pipeline" (see https://docs.gitlab.com/ee/ci/pipelines/merged_results_pipelines.html)
+    # This runs on an "internal" commit that is the merge from the PR HEAD and the target branch. This commit only exists in GitLab.
+    # We need to send commit statuses to this other commit, to guarantee that the check is not ignored.
+    # See https://docs.gitlab.com/ee/ci/pipelines/merged_results_pipelines.html#successful-merged-results-pipeline-overrides-a-failed-branch-pipeline
+    gitlab_extra_shas: set[str] | None = None
 
 
 class ComparisonProxy(object):

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -585,7 +585,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
     @sentry_sdk.trace
     async def get_gitlab_extra_shas_to_notify(
         self, commit: Commit, repository_service: TorngitBaseAdapter
-    ) -> set[str] | None:
+    ) -> set[str]:
         """ "
         Fetches extra commit SHAs we should send statuses too for GitLab.
 
@@ -598,6 +598,12 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
             extra=dict(commit=commit.commitid),
         )
         report = commit.commit_report(ReportType.COVERAGE)
+        if report is None:
+            log.info(
+                "No coverage report found. Skipping extra shas for GitLab",
+                extra=dict(commit=commit.commitid),
+            )
+            return set()
         project_id = commit.repository.service_id
         job_ids = [
             upload.job_code for upload in report.uploads if upload.job_code is not None

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Optional
 
@@ -378,6 +379,14 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                     "notifications": None,
                     "reason": "no_head_report",
                 }
+
+            if commit.repository.service == "gitlab":
+                gitlab_extra_shas_to_notify = async_to_sync(
+                    self.get_gitlab_extra_shas_to_notify
+                )(commit, repository_service)
+            else:
+                gitlab_extra_shas_to_notify = None
+
             log.info(
                 "We are going to be sending notifications",
                 extra=dict(
@@ -409,6 +418,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 gh_is_using_codecov_commenter=self.is_using_codecov_commenter(
                     repository_service
                 ),
+                gitlab_extra_shas_to_notify=gitlab_extra_shas_to_notify,
             )
             self.log_checkpoint(kwargs, UploadFlow.NOTIFIED)
             log.info(
@@ -529,6 +539,9 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
             return
         head_commit = comparison.head.commit
         db_session = head_commit.get_db_session()
+        if db_session is None:
+            log.warning("Failed to save patch_totals. dbsession is None")
+            return
         patch_coverage = async_to_sync(comparison.get_patch_totals)()
         if (
             comparison.project_coverage_base is not None
@@ -570,6 +583,35 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 compare_commit.patch_totals = minimal_totals(patch_coverage)
 
     @sentry_sdk.trace
+    async def get_gitlab_extra_shas_to_notify(
+        self, commit: Commit, repository_service: TorngitBaseAdapter
+    ) -> set[str] | None:
+        """ "
+        Fetches extra commit SHAs we should send statuses too for GitLab.
+
+        GitLab has a "merge results pipeline" (see https://docs.gitlab.com/ee/ci/pipelines/merged_results_pipelines.html)
+        This runs on an "internal" commit that is the merge from the PR HEAD and the target branch. This commit only exists in GitLab.
+        We need to send commit statuses to this other commit, to guarantee that the check is not ignored (see https://docs.gitlab.com/ee/ci/pipelines/merged_results_pipelines.html#successful-merged-results-pipeline-overrides-a-failed-branch-pipeline)
+        """
+        log.info(
+            "Checking if we need to send notification to more commits",
+            extra=dict(commit=commit.commitid),
+        )
+        report = commit.commit_report(ReportType.COVERAGE)
+        project_id = commit.repository.service_id
+        job_ids = [
+            upload.job_code for upload in report.uploads if upload.job_code is not None
+        ]
+        tasks = [
+            repository_service.get_pipeline_details(project_id, job_id)
+            for job_id in job_ids
+        ]
+        results = await asyncio.gather(*tasks)
+        return set(
+            filter(lambda sha: sha is not None and sha != commit.commitid, results)
+        )
+
+    @sentry_sdk.trace
     def submit_third_party_notifications(
         self,
         current_yaml: UserYaml,
@@ -585,6 +627,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
         test_results_error: bool = False,
         installation_name_to_use: str = GITHUB_APP_INSTALLATION_DEFAULT_NAME,
         gh_is_using_codecov_commenter: bool = False,
+        gitlab_extra_shas_to_notify: set[str] | None = None,
     ):
         # base_commit is an "adjusted" base commit; for project coverage, we
         # compare a PR head's report against its base's report, or if the base
@@ -618,6 +661,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 test_results_error=test_results_error,
                 gh_app_installation_name=installation_name_to_use,
                 gh_is_using_codecov_commenter=gh_is_using_codecov_commenter,
+                gitlab_extra_shas=gitlab_extra_shas_to_notify,
             ),
         )
 


### PR DESCRIPTION
depends on https://github.com/codecov/shared/pull/354

These changes collect extra SHAs that we need to (potentially) notify for GitLab users
that use "merge request result" pipelines and the "merge train" feature.

These changes only _collect_ the extra SHAs. The actual notification will happen later.
