### PR TITLE
feat: upgrade message in BA commit status

### DIFF
--- a/services/bundle_analysis/notify/contexts/comment.py
+++ b/services/bundle_analysis/notify/contexts/comment.py
@@ -49,7 +49,7 @@ class BundleAnalysisPRCommentNotificationContext(BaseBundleAnalysisNotificationC
     commit_status_level: CommitStatusLevel = NotificationContextField[
         CommitStatusLevel
     ]()
-    should_use_upgrade_comment: bool
+    should_use_upgrade_comment: bool = NotificationContextField[bool]()
 
 
 class BundleAnalysisPRCommentContextBuilder(NotificationContextBuilder):
@@ -59,6 +59,7 @@ class BundleAnalysisPRCommentContextBuilder(NotificationContextBuilder):
         "user_config",
         "pull",
         "bundle_analysis_comparison",
+        "should_use_upgrade_comment",
     )
 
     def initialize(

--- a/services/bundle_analysis/notify/contexts/commit_status.py
+++ b/services/bundle_analysis/notify/contexts/commit_status.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 import sentry_sdk
 from asgiref.sync import async_to_sync
 from shared.bundle_analysis import (
@@ -7,6 +9,7 @@ from shared.config import get_config
 from shared.yaml import UserYaml
 
 from database.models.core import Commit
+from services.activation import activate_user, schedule_new_user_activated_task
 from services.bundle_analysis.comparison import ComparisonLoader
 from services.bundle_analysis.exceptions import (
     MissingBaseCommit,
@@ -29,6 +32,7 @@ from services.repository import (
     EnrichedPull,
     fetch_and_update_pull_request_information_from_commit,
 )
+from services.seats import ShouldActivateSeat, determine_seat_activation
 from services.urls import get_bundle_analysis_pull_url, get_commit_url
 
 
@@ -44,6 +48,7 @@ class CommitStatusNotificationContext(BaseBundleAnalysisNotificationContext):
     ]()
     commit_status_url: str = NotificationContextField[str]()
     cache_ttl: int = NotificationContextField[int]()
+    should_use_upgrade_comment: bool = NotificationContextField[bool]()
 
     @property
     def base_commit(self) -> Commit:
@@ -59,11 +64,12 @@ class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
         "user_config",
         "pull",
         "bundle_analysis_comparison",
+        "should_use_upgrade_comment",
     )
 
     def initialize(
         self, commit: Commit, current_yaml: UserYaml, gh_app_installation_name: str
-    ) -> "CommitStatusNotificationContextBuilder":
+    ) -> Self:
         self.current_yaml = current_yaml
         self._notification_context = CommitStatusNotificationContext(
             commit=commit,
@@ -74,7 +80,7 @@ class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
     @sentry_sdk.trace
     async def load_optional_enriched_pull(
         self,
-    ) -> "CommitStatusNotificationContextBuilder":
+    ) -> Self:
         """Loads an optional EnrichedPull into the NotificationContext.
         EnrichedPull includes updated info from the git provider and info saved in the database.
         If the value is None it's because the commit is not in a Pull Request
@@ -94,7 +100,7 @@ class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
     @sentry_sdk.trace
     def load_bundle_comparison(
         self,
-    ) -> "CommitStatusNotificationContextBuilder":
+    ) -> Self:
         """Loads the BundleAnalysisComparison into the NotificationContext.
         BundleAnalysisComparison is the diff between 2 BundleAnalysisReports.
         IF pull is not None, comparison is pull's BASE vs HEAD
@@ -127,7 +133,7 @@ class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
                 "load_bundle_comparison", detail=exp.__class__.__name__
             )
 
-    def load_commit_status_level(self) -> "CommitStatusNotificationContextBuilder":
+    def load_commit_status_level(self) -> Self:
         bundle_analysis_comparison = (
             self._notification_context.bundle_analysis_comparison
         )
@@ -143,7 +149,7 @@ class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
             self._notification_context.commit_status_level = CommitStatusLevel.ERROR
         return self
 
-    def load_commit_status_url(self) -> "CommitStatusNotificationContextBuilder":
+    def load_commit_status_url(self) -> Self:
         if self._notification_context.pull:
             self._notification_context.commit_status_url = get_bundle_analysis_pull_url(
                 self._notification_context.pull.database_pull
@@ -154,7 +160,7 @@ class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
             )
         return self
 
-    def load_cache_ttl(self) -> "CommitStatusNotificationContextBuilder":
+    def load_cache_ttl(self) -> Self:
         self._notification_context.cache_ttl = int(
             # using `get_config` instead of `current_yaml` because
             # `current_yaml` does not include the install configuration
@@ -162,12 +168,37 @@ class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
         )  # 10 min default
         return self
 
-    def build_context(self) -> "CommitStatusNotificationContextBuilder":
+    @sentry_sdk.trace
+    def evaluate_should_use_upgrade_message(self) -> Self:
+        activate_seat_info = determine_seat_activation(self._notification_context.pull)
+        match activate_seat_info.should_activate_seat:
+            case ShouldActivateSeat.AUTO_ACTIVATE:
+                successful_activation = activate_user(
+                    db_session=self._notification_context.commit.get_db_session(),
+                    org_ownerid=activate_seat_info.owner_id,
+                    user_ownerid=activate_seat_info.author_id,
+                )
+                if successful_activation:
+                    schedule_new_user_activated_task(
+                        activate_seat_info.owner_id,
+                        activate_seat_info.author_id,
+                    )
+                    self._notification_context.should_use_upgrade_comment = False
+                else:
+                    self._notification_context.should_use_upgrade_comment = True
+            case ShouldActivateSeat.MANUAL_ACTIVATE:
+                self._notification_context.should_use_upgrade_comment = True
+            case ShouldActivateSeat.NO_ACTIVATE:
+                self._notification_context.should_use_upgrade_comment = False
+        return self
+
+    def build_context(self) -> Self:
         super().build_context()
         async_to_sync(self.load_optional_enriched_pull)()
         return (
             self.load_bundle_comparison()
             .load_commit_status_level()
+            .evaluate_should_use_upgrade_message()
             .load_commit_status_url()
             .load_cache_ttl()
         )

--- a/services/bundle_analysis/notify/contexts/tests/test_commit_status_context.py
+++ b/services/bundle_analysis/notify/contexts/tests/test_commit_status_context.py
@@ -22,6 +22,7 @@ from services.bundle_analysis.notify.contexts.commit_status import (
     CommitStatusNotificationContextBuilder,
 )
 from services.bundle_analysis.notify.types import NotificationUserConfig
+from services.seats import SeatActivationInfo, ShouldActivateSeat
 
 
 class TestBundleAnalysisPRCommentNotificationContext:
@@ -287,3 +288,46 @@ class TestBundleAnalysisPRCommentNotificationContext:
         assert context.bundle_analysis_report == other_context.bundle_analysis_report
         assert context.pull == other_context.pull
         assert other_context.bundle_analysis_comparison == fake_comparison
+
+    @pytest.mark.parametrize(
+        "activation_result, auto_activate_succeeds, expected",
+        [
+            (ShouldActivateSeat.AUTO_ACTIVATE, True, False),
+            (ShouldActivateSeat.AUTO_ACTIVATE, False, True),
+            (ShouldActivateSeat.MANUAL_ACTIVATE, False, True),
+            (ShouldActivateSeat.NO_ACTIVATE, False, False),
+        ],
+    )
+    def test_evaluate_should_use_upgrade_message(
+        self, activation_result, dbsession, auto_activate_succeeds, expected, mocker
+    ):
+        activation_result = SeatActivationInfo(
+            should_activate_seat=activation_result,
+            owner_id=1,
+            author_id=10,
+            reason="mocked",
+        )
+        mocker.patch(
+            "services.bundle_analysis.notify.contexts.commit_status.determine_seat_activation",
+            return_value=activation_result,
+        )
+        mocker.patch(
+            "services.bundle_analysis.notify.contexts.commit_status.activate_user",
+            return_value=auto_activate_succeeds,
+        )
+        mocker.patch(
+            "services.bundle_analysis.notify.contexts.commit_status.schedule_new_user_activated_task",
+            return_value=auto_activate_succeeds,
+        )
+        head_commit, _ = get_commit_pair(dbsession)
+        user_yaml = UserYaml.from_dict({})
+        builder = CommitStatusNotificationContextBuilder().initialize(
+            head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
+        )
+        mock_pull = MagicMock(
+            name="fake_pull",
+            database_pull=MagicMock(bundle_analysis_commentid=12345, id=12),
+        )
+        builder._notification_context.pull = mock_pull
+        builder.evaluate_should_use_upgrade_message()
+        assert builder._notification_context.should_use_upgrade_comment == expected


### PR DESCRIPTION
We want the bundle analysis - no longer in beta - to be similar to coverage
in terms of seat count.

After some code review I stumbled upon https://github.com/codecov/worker/blob/ab427f8311ee1d9306f692f531c67e3897786faf/services/notification/notifiers/status/base.py#L47

This was not yet ported to bundle analysis. So these changes do just that.
