### PR TITLE
fix: WORKER-P8R

### DIFF
--- a/services/bundle_analysis/notify/contexts/commit_status.py
+++ b/services/bundle_analysis/notify/contexts/commit_status.py
@@ -170,6 +170,9 @@ class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
 
     @sentry_sdk.trace
     def evaluate_should_use_upgrade_message(self) -> Self:
+        if self._notification_context.pull is None:
+            self._notification_context.should_use_upgrade_comment = False
+            return self
         activate_seat_info = determine_seat_activation(self._notification_context.pull)
         match activate_seat_info.should_activate_seat:
             case ShouldActivateSeat.AUTO_ACTIVATE:

--- a/services/bundle_analysis/notify/contexts/tests/test_commit_status_context.py
+++ b/services/bundle_analysis/notify/contexts/tests/test_commit_status_context.py
@@ -289,6 +289,16 @@ class TestBundleAnalysisPRCommentNotificationContext:
         assert context.pull == other_context.pull
         assert other_context.bundle_analysis_comparison == fake_comparison
 
+    def test_evaluate_should_use_upgrade_message_no_pull(self, dbsession, mocker):
+        head_commit, _ = get_commit_pair(dbsession)
+        user_yaml = UserYaml.from_dict({})
+        builder = CommitStatusNotificationContextBuilder().initialize(
+            head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
+        )
+        builder._notification_context.pull = None
+        builder.evaluate_should_use_upgrade_message()
+        assert builder._notification_context.should_use_upgrade_comment is False
+
     @pytest.mark.parametrize(
         "activation_result, auto_activate_succeeds, expected",
         [


### PR DESCRIPTION
For the `commit_status` context it's possible that the `pull` is `None` (which is not the case for `comment`). I forgot to include that check.

This really shows that:
(1) the builders pattern is not very good, because of code duplication, and
(2) we need better tests

But for now this only fixes issue worker-p8r
