### PR TITLE
Avoid copying raw upload for parallel verification

### DIFF
--- a/helpers/reports.py
+++ b/helpers/reports.py
@@ -1,7 +1,20 @@
 from collections import namedtuple
 
+from shared.config import get_config
+from shared.yaml import UserYaml
+
+from services.yaml.reader import read_yaml_field
+
 null = namedtuple("_", ["totals"])(None)
 
 
 def get_totals_from_file_in_reports(report, path):
     return report.get(path, null).totals
+
+
+def delete_archive_setting(commit_yaml: UserYaml | dict) -> bool:
+    if get_config("services", "minio", "expire_raw_after_n_days"):
+        return True
+    return not read_yaml_field(
+        commit_yaml, ("codecov", "archive", "uploads"), _else=True
+    )

--- a/services/yaml/reader.py
+++ b/services/yaml/reader.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 """
 
 
-def read_yaml_field(yaml_dict: UserYaml, keys, _else=None) -> Any:
+def read_yaml_field(yaml_dict: UserYaml | Mapping[str, Any], keys, _else=None) -> Any:
     log.debug("Field %s requested", keys)
     try:
         for key in keys:

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -545,7 +545,7 @@ class TestUploadProcessorTask(object):
         assert upload.state_id == UploadState.ERROR.db_id
         assert upload.state == "error"
         assert not mocked_3.called
-        mocked_4.assert_called_with(commit.repository, upload, is_parallel=False)
+        mocked_4.assert_called_with(commit.repository, upload)
         mocked_5.assert_called()
 
     @pytest.mark.django_db(databases={"default"})

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -179,7 +179,7 @@ class TestUploadTaskIntegration(object):
             ],
             report_code=None,
             in_parallel=False,
-            is_final=True,
+            is_final=False,
         )
         kwargs = dict(
             repoid=commit.repoid,
@@ -659,7 +659,7 @@ class TestUploadTaskIntegration(object):
             ],
             report_code=None,
             in_parallel=False,
-            is_final=True,
+            is_final=False,
         )
         kwargs = dict(
             repoid=commit.repoid,
@@ -1164,7 +1164,7 @@ class TestUploadTaskUnit(object):
             arguments_list=argument_list,
             report_code=None,
             in_parallel=False,
-            is_final=True,
+            is_final=False,
         )
         t2 = upload_finisher_task.signature(
             kwargs={

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -596,6 +596,10 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
     ):
         checkpoints.log(UploadFlow.INITIAL_PROCESSING_COMPLETE)
 
+        do_parallel_processing = PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
+            identifier=commit.repository.repoid
+        ) and not delete_archive_setting(commit_yaml)
+
         processing_tasks = [
             upload_processor_task.s(
                 repoid=commit.repoid,
@@ -609,7 +613,8 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             for chunk in itertools.batched(argument_list, CHUNK_SIZE)
         ]
         processing_tasks[0].args = ({},)  # this is the first `previous_results`
-        processing_tasks[-1].kwargs.update(is_final=True)
+        if do_parallel_processing:
+            processing_tasks[-1].kwargs.update(is_final=True)
 
         processing_tasks.append(
             upload_finisher_task.signature(
@@ -625,10 +630,6 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         )
 
         serial_tasks = chain(processing_tasks)
-
-        do_parallel_processing = PARALLEL_UPLOAD_PROCESSING_BY_REPO.check_value(
-            identifier=commit.repository.repoid
-        ) and not delete_archive_setting(commit_yaml)
 
         if not do_parallel_processing:
             return serial_tasks.apply_async()


### PR DESCRIPTION
Instead of creating a copy of a raw upload for consumption in the parallel verification task, this will only schedule parallel verification in case the uploads are not being deleted after processing.

That way, the uploads are guaranteed to still be there for verification, so no copy is needed.