### PR TITLE
Remove parallel session_id allocations in Redis

### DIFF
--- a/services/redis.py
+++ b/services/redis.py
@@ -7,23 +7,6 @@ from shared.config import get_config
 
 log = logging.getLogger(__name__)
 
-# The purpose of this key is to synchronize allocation of session IDs
-# when processing reports in parallel. If multiple uploads are processed
-# at a time, they all need to know what session id to use when generating
-# their chunks.txt. This is because in UploadFinisher, they will all be
-# combined together and need to all have unique session IDs.
-
-# This key is a counter that will hold an integer, representing the smallest
-# session ID that is available to be claimed. It can be claimed by incrementing
-# the key.
-PARALLEL_UPLOAD_PROCESSING_SESSION_COUNTER_REDIS_KEY = (
-    "parallel_session_counter:{repoid}:{commitid}"
-)
-
-PARALLEL_UPLOAD_PROCESSING_SESSION_COUNTER_TTL = (
-    10800  # 3 hours, chosen somewhat arbitrarily
-)
-
 
 def get_redis_url() -> str:
     url = get_config("services", "redis_url")
@@ -53,9 +36,3 @@ def download_archive_from_redis(
     if raw_uploaded_report is not None:
         return raw_uploaded_report.decode()
     return None
-
-
-def get_parallel_upload_processing_session_counter_redis_key(repoid, commitid):
-    return PARALLEL_UPLOAD_PROCESSING_SESSION_COUNTER_REDIS_KEY.format(
-        repoid=repoid, commitid=commitid
-    )

--- a/tasks/flush_repo.py
+++ b/tasks/flush_repo.py
@@ -30,11 +30,6 @@ from database.models import (
     uploadflagmembership,
 )
 from services.archive import ArchiveService
-from services.redis import (
-    PARALLEL_UPLOAD_PROCESSING_SESSION_COUNTER_TTL,
-    get_parallel_upload_processing_session_counter_redis_key,
-    get_redis_connection,
-)
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
@@ -156,25 +151,9 @@ class FlushRepoTask(BaseCodecovTask, name="app.tasks.flush_repo.FlushRepo"):
 
     @sentry_sdk.trace
     def _delete_commits(self, db_session: Session, repoid: int) -> int:
-        commits_to_delete = (
-            db_session.query(Commit.commitid).filter_by(repoid=repoid).all()
-        )
-        commit_ids_to_delete = [commit.commitid for commit in commits_to_delete]
-
-        pipeline = get_redis_connection().pipeline()
-        for id in commit_ids_to_delete:
-            pipeline.set(
-                get_parallel_upload_processing_session_counter_redis_key(
-                    repoid=repoid, commitid=id
-                ),
-                0,
-                ex=PARALLEL_UPLOAD_PROCESSING_SESSION_COUNTER_TTL,
-            )
-        pipeline.execute()
-
         delete_count = (
             db_session.query(Commit)
-            .filter(Commit.commitid.in_(commit_ids_to_delete))
+            .filter_by(repoid=repoid)
             .delete(synchronize_session=False)
         )
         db_session.commit()


### PR DESCRIPTION
It looks like this code was incomplete, as it was *writing* to redis, but never *reading* from it.