### PR TITLE
Add metric for uploads per scheduled tasks

### DIFF
--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -4,10 +4,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 import sentry_sdk
-from shared.bundle_analysis import (
-    BundleAnalysisReport,
-    BundleAnalysisReportLoader,
-)
+from shared.bundle_analysis import BundleAnalysisReport, BundleAnalysisReportLoader
 from shared.bundle_analysis.models import AssetType, MetadataKey
 from shared.bundle_analysis.storage import get_bucket_name
 from shared.django_apps.bundle_analysis.models import CacheConfig
@@ -99,7 +96,7 @@ class ProcessingResult:
 
 class BundleAnalysisReportService(BaseReportService):
     def initialize_and_save_report(
-        self, commit: Commit, report_code: str = None
+        self, commit: Commit, report_code: str | None = None
     ) -> CommitReport:
         db_session = commit.get_db_session()
 

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -109,7 +109,7 @@ class BaseReportService:
         self.current_yaml = current_yaml
 
     def initialize_and_save_report(
-        self, commit: Commit, report_code: str = None
+        self, commit: Commit, report_code: str | None = None
     ) -> CommitReport:
         raise NotImplementedError()
 
@@ -150,6 +150,7 @@ class BaseReportService:
             Upload
         """
         db_session = commit_report.get_db_session()
+        name = normalized_arguments.get("name")
         upload = Upload(
             external_id=normalized_arguments.get("reportid"),
             build_code=normalized_arguments.get("build"),
@@ -157,11 +158,7 @@ class BaseReportService:
             env=None,
             report_id=commit_report.id_,
             job_code=normalized_arguments.get("job"),
-            name=(
-                normalized_arguments.get("name")[:100]
-                if normalized_arguments.get("name")
-                else None
-            ),
+            name=(name[:100] if name else None),
             provider=normalized_arguments.get("service"),
             state="started",
             storage_path=normalized_arguments.get("url"),
@@ -295,8 +292,7 @@ class ReportService(BaseReportService):
         self, normalized_arguments: Mapping[str, str], commit_report: CommitReport
     ) -> Upload:
         upload = super().create_report_upload(normalized_arguments, commit_report)
-        flags = normalized_arguments.get("flags")
-        flags = flags.split(",") if flags else []
+        flags = normalized_arguments.get("flags", "").split(",")
         self._attach_flags_to_upload(upload, flags)
 
         # Insert entry in user measurements table only

--- a/services/report/report_processor.py
+++ b/services/report/report_processor.py
@@ -81,6 +81,7 @@ RAW_REPORT_PROCESSOR_COUNTER = Counter(
 )
 
 
+@sentry_sdk.trace
 def report_type_matching(
     report: ParsedUploadedReportFile, first_line: str
 ) -> (
@@ -200,10 +201,6 @@ def process_report(
             continue
         processor_name = type(processor).__name__
 
-        sentry_sdk.metrics.incr(
-            "services.report.report_processor.parser",
-            tags={"type": processor_name},
-        )
         RAW_REPORT_SIZE.labels(processor=processor_name).observe(report.size)
         with RAW_REPORT_PROCESSOR_RUNTIME_SECONDS.labels(
             processor=processor_name

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -7,20 +7,12 @@ from shared.yaml import UserYaml
 from sqlalchemy import desc
 
 from database.enums import ReportType
-from database.models import (
-    Commit,
-    CommitReport,
-    RepositoryFlag,
-    TestInstance,
-    Upload,
-)
+from database.models import Commit, CommitReport, RepositoryFlag, TestInstance, Upload
 from helpers.notifier import BaseNotifier
 from rollouts import FLAKY_SHADOW_MODE, FLAKY_TEST_DETECTION
 from services.license import requires_license
 from services.report import BaseReportService
-from services.repository import (
-    get_repo_provider_service,
-)
+from services.repository import get_repo_provider_service
 from services.urls import get_members_url, get_test_analytics_url
 from services.yaml import read_yaml_field
 
@@ -33,7 +25,7 @@ class TestResultsReportService(BaseReportService):
         self.flag_dict = None
 
     def initialize_and_save_report(
-        self, commit: Commit, report_code: str = None
+        self, commit: Commit, report_code: str | None = None
     ) -> CommitReport:
         db_session = commit.get_db_session()
         current_report_row = (
@@ -63,8 +55,7 @@ class TestResultsReportService(BaseReportService):
         self, normalized_arguments: Mapping[str, str], commit_report: CommitReport
     ) -> Upload:
         upload = super().create_report_upload(normalized_arguments, commit_report)
-        flags = normalized_arguments.get("flags")
-        flags = flags or []
+        flags = normalized_arguments.get("flags", "").split(",")
         self._attach_flags_to_upload(upload, flags)
         return upload
 


### PR DESCRIPTION
The `Upload` task schedules multiple `UploadProcessor` tasks and another `UploadFinisher`.

This batching is rather accidental because of locking rather than intentional. It might be good to know how uploads are being grouped into a single processor/finisher chain.

Also includes a bunch of cleanups and driveby typing fixes.