### PR TITLE
Revert "Make `session.id == upload.id` (#713)"

### DIFF
--- a/helpers/parallel_upload_processing.py
+++ b/helpers/parallel_upload_processing.py
@@ -1,4 +1,68 @@
+import copy
+
 import sentry_sdk
+from shared.utils.sessions import SessionType
+
+from database.models.reports import Upload
+
+
+# Copied from shared/reports/resources.py Report.next_session_number()
+def next_session_number(session_dict):
+    start_number = len(session_dict)
+    while start_number in session_dict or str(start_number) in session_dict:
+        start_number += 1
+    return start_number
+
+
+# Copied and cut down from worker/services/report/raw_upload_processor.py
+# this version stripped out all the ATS label stuff
+def _adjust_sessions(
+    original_sessions: dict,
+    to_merge_flags,
+    current_yaml,
+):
+    session_ids_to_fully_delete = []
+    flags_under_carryforward_rules = [
+        f for f in to_merge_flags if current_yaml.flag_has_carryfoward(f)
+    ]
+    if flags_under_carryforward_rules:
+        for sess_id, curr_sess in original_sessions.items():
+            if curr_sess.session_type == SessionType.carriedforward:
+                if curr_sess.flags:
+                    if any(
+                        f in flags_under_carryforward_rules for f in curr_sess.flags
+                    ):
+                        session_ids_to_fully_delete.append(sess_id)
+    if session_ids_to_fully_delete:
+        # delete sessions from dict
+        for id in session_ids_to_fully_delete:
+            original_sessions.pop(id, None)
+    return
+
+
+def get_parallel_session_ids(
+    sessions, argument_list, db_session, report_service, commit_yaml
+):
+    num_sessions = len(argument_list)
+
+    mock_sessions = copy.deepcopy(sessions)  # the sessions already in the report
+    get_parallel_session_ids = []
+
+    # iterate over all uploads, get the next session id, and adjust sessions (remove CFF logic)
+    for i in range(num_sessions):
+        next_session_id = next_session_number(mock_sessions)
+
+        upload_pk = argument_list[i]["upload_pk"]
+        upload = db_session.query(Upload).filter_by(id_=upload_pk).first()
+        to_merge_session = report_service.build_session(upload)
+        flags = upload.flag_names
+
+        mock_sessions[next_session_id] = to_merge_session
+        _adjust_sessions(mock_sessions, flags, commit_yaml)
+
+        get_parallel_session_ids.append(next_session_id)
+
+    return get_parallel_session_ids
 
 
 @sentry_sdk.trace

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -202,7 +202,7 @@ class ReportService(BaseReportService):
 
     @sentry_sdk.trace
     def initialize_and_save_report(
-        self, commit: Commit, report_code: str | None = None
+        self, commit: Commit, report_code: str = None
     ) -> CommitReport:
         """
             Initializes the commit report
@@ -412,7 +412,7 @@ class ReportService(BaseReportService):
         Does not include CF sessions if there is also an upload session with the same
         flag name.
         """
-        sessions: dict[int, Session] = {}
+        sessions = {}
 
         carryforward_sessions = {}
         uploaded_flags = set()
@@ -873,6 +873,7 @@ class ReportService(BaseReportService):
         report: Report,
         raw_report_info: RawReportInfo,
         upload: Upload,
+        parallel_idx=None,
     ) -> ProcessingResult:
         """
         Processes an upload on top of an existing report `master` and returns
@@ -892,7 +893,6 @@ class ReportService(BaseReportService):
         reportid = upload.external_id
 
         session = Session(
-            id=upload.id,
             provider=service,
             build=build,
             job=job,
@@ -919,6 +919,7 @@ class ReportService(BaseReportService):
                     reportid=reportid,
                     commit_yaml=self.current_yaml.to_dict(),
                     archive_url=archive_url,
+                    in_parallel=parallel_idx is not None,
                 ),
             )
             result.error = ProcessingError(
@@ -954,11 +955,13 @@ class ReportService(BaseReportService):
                     raw_report,
                     flags,
                     session,
-                    upload,
+                    upload=upload,
+                    parallel_idx=parallel_idx,
                 )
                 result.report = process_result.report
             log.info(
-                "Successfully processed report",
+                "Successfully processed report"
+                + (" (in parallel)" if parallel_idx is not None else ""),
                 extra=dict(
                     session=session.id,
                     ci=f"{session.provider}:{session.build}:{session.job}",

--- a/services/report/tests/unit/test_process.py
+++ b/services/report/tests/unit/test_process.py
@@ -76,7 +76,7 @@ class TestProcessRawUpload(BaseTestCase):
             report=master,
             raw_reports=parsed_report,
             flags=[],
-            session=Session(id=3 if "M" in keys else 0),
+            session=Session(),
         )
         master = result.report
 
@@ -203,7 +203,7 @@ class TestProcessRawUpload(BaseTestCase):
                 raw_reports=LegacyReportParser().parse_raw_report_from_bytes(
                     "\n".join(report_data).encode()
                 ),
-                session=Session(id=1, flags=["fruits"]),
+                session=Session(flags=["fruits"]),
                 flags=[],
             )
         assert len(original_report.sessions) == 1
@@ -282,7 +282,7 @@ class TestProcessRawUpload(BaseTestCase):
                 Report(),
                 LegacyReportParser().parse_raw_report_from_bytes(b""),
                 [],
-                Session(id=0),
+                Session(),
             )
 
 
@@ -307,7 +307,7 @@ class TestProcessRawUploadFixed(BaseTestCase):
                 reports.encode()
             ),
             flags=[],
-            session=Session(id=0),
+            session=Session(),
         )
         report = result.report
         assert 2 not in report["file.go"], "2 never existed"
@@ -347,7 +347,7 @@ class TestProcessRawUploadNotJoined(BaseTestCase):
                         b"a<<<<<< EOF"
                     ),
                     flags=[flag],
-                    session=Session(id=1),
+                    session=Session(),
                 )
             merge.assert_called_with(mocker.ANY, joined=joined)
             call_args, call_kwargs = merge.call_args
@@ -363,7 +363,7 @@ class TestProcessRawUploadFlags(BaseTestCase):
         result = process.process_raw_upload(
             commit_yaml=UserYaml({"flags": {"docker": flag}}),
             report=Report(),
-            session=Session(id=0),
+            session=Session(),
             raw_reports=LegacyReportParser().parse_raw_report_from_bytes(
                 b'{"coverage": {"tests/test.py": [null, 0], "folder/file.py": [null, 1]}}'
             ),
@@ -380,7 +380,7 @@ class TestProcessSessions(BaseTestCase):
         process.process_raw_upload(
             commit_yaml={},
             report=report,
-            session=Session(id=0),
+            session=Session(),
             raw_reports=LegacyReportParser().parse_raw_report_from_bytes(
                 b'{"coverage": {"tests/test.py": [null, 0], "folder/file.py": [null, 1]}}'
             ),
@@ -389,7 +389,7 @@ class TestProcessSessions(BaseTestCase):
         process.process_raw_upload(
             commit_yaml={},
             report=report,
-            session=Session(id=1),
+            session=Session(),
             raw_reports=LegacyReportParser().parse_raw_report_from_bytes(
                 b'{"coverage": {"tests/test.py": [null, 0], "folder/file.py": [null, 1]}}'
             ),
@@ -914,7 +914,7 @@ class TestProcessReport(BaseTestCase):
                 third_raw_report_result,
             ],
         )
-        session = Session(id=1)
+        session = Session()
         result = process.process_raw_upload(
             UserYaml({}),
             original_report,
@@ -1092,7 +1092,7 @@ class TestProcessRawUploadCarryforwardFlags(BaseTestCase):
                 ),
             ],
         )
-        session = Session(id=2, flags=upload_flags)
+        session = Session(flags=upload_flags)
         result = process.process_raw_upload(
             UserYaml(
                 {

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -20,7 +20,11 @@ from helpers.exceptions import (
 )
 from rollouts import USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID
 from services.archive import ArchiveService
-from services.report import ProcessingError, RawReportInfo, ReportService
+from services.report import (
+    ProcessingError,
+    RawReportInfo,
+    ReportService,
+)
 from services.report.parser.legacy import LegacyReportParser
 from services.report.raw_upload_processor import (
     SessionAdjustmentResult,
@@ -129,7 +133,7 @@ class TestUploadProcessorTask(object):
                 ],
             },
             "sessions": {
-                str(upload.id_): {
+                "0": {
                     "N": None,
                     "a": url,
                     "c": None,
@@ -140,12 +144,16 @@ class TestUploadProcessorTask(object):
                     "p": None,
                     "t": [3, 24, 19, 5, 0, "79.16667", 0, 0, 0, 0, 0, 0, 0],
                     "u": None,
-                    "d": commit.report_json["sessions"][str(upload.id_)]["d"],
+                    "d": commit.report_json["sessions"]["0"]["d"],
                     "st": "uploaded",
                     "se": {},
                 }
             },
         }
+        assert (
+            commit.report_json["sessions"]["0"]
+            == expected_generated_report["sessions"]["0"]
+        )
         assert commit.report_json == expected_generated_report
         mocked_1.assert_called_with(commit.commitid, None)
         # mocked_3.send_task.assert_called_with(
@@ -257,7 +265,7 @@ class TestUploadProcessorTask(object):
                 ],
             },
             "sessions": {
-                str(upload.id_): {
+                "0": {
                     "N": None,
                     "a": url,
                     "c": None,
@@ -268,12 +276,16 @@ class TestUploadProcessorTask(object):
                     "p": None,
                     "t": [3, 24, 19, 5, 0, "79.16667", 0, 0, 0, 0, 0, 0, 0],
                     "u": None,
-                    "d": commit.report_json["sessions"][str(upload.id_)]["d"],
+                    "d": commit.report_json["sessions"]["0"]["d"],
                     "st": "uploaded",
                     "se": {},
                 }
             },
         }
+        assert (
+            commit.report_json["sessions"]["0"]
+            == expected_generated_report["sessions"]["0"]
+        )
         assert commit.report_json == expected_generated_report
         mocked_1.assert_called_with(commit.commitid, None)
         # mocked_3.send_task.assert_called_with(
@@ -373,7 +385,7 @@ class TestUploadProcessorTask(object):
                 ],
             },
             "sessions": {
-                str(upload.id_): {
+                "0": {
                     "N": None,
                     "a": url,
                     "c": None,
@@ -384,12 +396,18 @@ class TestUploadProcessorTask(object):
                     "p": None,
                     "t": [3, 24, 19, 5, 0, "79.16667", 0, 0, 0, 0, 0, 0, 0],
                     "u": None,
-                    "d": commit.report_json["sessions"][str(upload.id_)]["d"],
+                    "d": commit.report_json["sessions"]["0"]["d"],
                     "st": "uploaded",
                     "se": {},
                 }
             },
         }
+        assert (
+            commit.report_json["files"]["awesome/__init__.py"]
+            == expected_generated_report["files"]["awesome/__init__.py"]
+        )
+        assert commit.report_json["files"] == expected_generated_report["files"]
+        assert commit.report_json["sessions"] == expected_generated_report["sessions"]
         assert commit.report_json == expected_generated_report
         mocked_1.assert_called_with(commit.commitid, None)
 

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -13,6 +13,7 @@ from shared.torngit import GitlabEnterprise
 from shared.torngit.exceptions import TorngitClientError, TorngitRepoNotFoundError
 from shared.torngit.gitlab import Gitlab
 from shared.utils.sessions import SessionType
+from shared.yaml import UserYaml
 
 from database.enums import ReportType
 from database.models import Upload
@@ -800,7 +801,7 @@ class TestUploadTaskIntegration(object):
         mocked_1.assert_called_with(
             mocker.ANY,
             commit,
-            {"codecov": {"max_report_age": "764y ago"}},
+            UserYaml({"codecov": {"max_report_age": "764y ago"}}),
             [
                 {"build": "part1", "url": "url1", "upload_pk": mocker.ANY},
                 {"build": "part2", "url": "url2", "upload_pk": mocker.ANY},
@@ -856,7 +857,7 @@ class TestUploadTaskIntegration(object):
         mocked_1.assert_called_with(
             mocker.ANY,
             commit,
-            {"codecov": {"max_report_age": "764y ago"}},
+            UserYaml({"codecov": {"max_report_age": "764y ago"}}),
             [
                 {"build": "part1", "url": "url1", "upload_pk": mocker.ANY},
                 {"build": "part2", "url": "url2", "upload_pk": mocker.ANY},
@@ -933,7 +934,7 @@ class TestUploadTaskIntegration(object):
         mocked_schedule_task.assert_called_with(
             mocker.ANY,
             commit,
-            {"codecov": {"max_report_age": "764y ago"}},
+            UserYaml({"codecov": {"max_report_age": "764y ago"}}),
             [
                 {"build": "part1", "url": "url1", "upload_pk": first_session.id},
                 {"build": "part2", "url": "url2", "upload_pk": second_session.id},
@@ -1024,7 +1025,7 @@ class TestUploadTaskIntegration(object):
         mocked_schedule_task.assert_called_with(
             mocker.ANY,
             commit,
-            {"codecov": {"max_report_age": "764y ago"}},
+            UserYaml({"codecov": {"max_report_age": "764y ago"}}),
             [
                 {
                     "build": "part1",
@@ -1144,7 +1145,7 @@ class TestUploadTaskUnit(object):
     def test_schedule_task_with_one_task(self, dbsession, mocker):
         mocked_chain = mocker.patch("tasks.upload.chain")
         commit = CommitFactory.create()
-        commit_yaml = {"codecov": {"max_report_age": "100y ago"}}
+        commit_yaml = UserYaml({"codecov": {"max_report_age": "100y ago"}})
         argument_dict = {"argument_dict": 1}
         argument_list = [argument_dict]
         dbsession.add(commit)
@@ -1169,7 +1170,7 @@ class TestUploadTaskUnit(object):
             {},
             repoid=commit.repoid,
             commitid=commit.commitid,
-            commit_yaml=commit_yaml,
+            commit_yaml=commit_yaml.to_dict(),
             arguments_list=argument_list,
             report_code=None,
             in_parallel=False,
@@ -1179,7 +1180,7 @@ class TestUploadTaskUnit(object):
             kwargs={
                 "repoid": commit.repoid,
                 "commitid": commit.commitid,
-                "commit_yaml": commit_yaml,
+                "commit_yaml": commit_yaml.to_dict(),
                 "report_code": None,
                 "in_parallel": False,
                 _kwargs_key(UploadFlow): mocker.ANY,

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -31,6 +31,7 @@ from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import TestResultsFlow, UploadFlow
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
+from helpers.parallel_upload_processing import get_parallel_session_ids
 from helpers.reports import delete_archive_setting
 from helpers.save_commit_error import save_commit_error
 from rollouts import PARALLEL_UPLOAD_PROCESSING_BY_REPO
@@ -505,7 +506,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             scheduled_tasks = self.schedule_task(
                 db_session,
                 commit,
-                commit_yaml.to_dict(),
+                commit_yaml,
                 argument_list,
                 commit_report,
                 upload_context,
@@ -535,12 +536,14 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         self,
         db_session: Session,
         commit: Commit,
-        commit_yaml: dict,
+        commit_yaml: UserYaml,
         argument_list: list[dict],
         commit_report: CommitReport,
         upload_context: UploadContext,
         checkpoints: CheckpointLogger | None,
     ):
+        commit_yaml = commit_yaml.to_dict()
+
         # Carryforward the parent BA report for the current commit's BA report when handling uploads
         # that's not bundle analysis type.
         self.possibly_carryforward_bundle_report(
@@ -626,6 +629,26 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         if not do_parallel_processing:
             return serial_tasks.apply_async()
 
+        report_service = ReportService(commit_yaml)
+        sessions = report_service.build_sessions(commit=commit)
+
+        original_session_ids = list(sessions.keys())
+        parallel_session_ids = get_parallel_session_ids(
+            sessions,
+            argument_list,
+            db_session,
+            report_service,
+            UserYaml(commit_yaml),
+        )
+
+        log.info(
+            "Allocated the following session ids for parallel upload processing: "
+            + " ".join(str(id) for id in parallel_session_ids),
+            extra=upload_context.log_extra(
+                original_session_ids=original_session_ids,
+            ),
+        )
+
         parallel_processing_tasks = [
             upload_processor_task.s(
                 repoid=commit.repoid,
@@ -633,11 +656,13 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 commit_yaml=commit_yaml,
                 arguments_list=[arguments],
                 report_code=commit_report.code,
-                parallel_idx=arguments["upload_pk"],
+                parallel_idx=parallel_session_id,
                 in_parallel=True,
                 is_final=False,
             )
-            for arguments in argument_list
+            for arguments, parallel_session_id in zip(
+                argument_list, parallel_session_ids
+            )
         ]
 
         finish_parallel_sig = upload_finisher_task.signature(
@@ -721,7 +746,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         self,
         commit: Commit,
         commit_report: CommitReport,
-        commit_yaml: dict,
+        commit_yaml: UserYaml,
         argument_list: List[Dict],
     ):
         """


### PR DESCRIPTION
This reverts commit b110b7f8a37968786b30be6356217ef4e92096ec.

This has caused https://codecov.sentry.io/issues/5867617053/ which is reported as **integer out of range**.
Possibly the `order_number` is not wide enough to take the same values as the session_id. :-(