### PR TITLE
feat: add percentage change and warnings in bundle rows

### DIFF
--- a/services/bundle_analysis/notify/contexts/comment.py
+++ b/services/bundle_analysis/notify/contexts/comment.py
@@ -25,7 +25,7 @@ from services.bundle_analysis.notify.contexts import (
     NotificationContextField,
 )
 from services.bundle_analysis.notify.helpers import (
-    is_bundle_change_within_bundle_threshold,
+    is_bundle_comparison_change_within_configured_threshold,
 )
 from services.bundle_analysis.notify.types import NotificationType
 from services.repository import (
@@ -146,14 +146,14 @@ class BundleAnalysisPRCommentContextBuilder(NotificationContextBuilder):
         comparison = self._notification_context.bundle_analysis_comparison
         should_continue = {
             False: True,
-            True: not is_bundle_change_within_bundle_threshold(
+            True: not is_bundle_comparison_change_within_configured_threshold(
                 comparison,
                 required_changes_threshold,
                 compare_non_negative_numbers=True,
             ),
             "bundle_increase": (
                 comparison.total_size_delta > 0
-                and not is_bundle_change_within_bundle_threshold(
+                and not is_bundle_comparison_change_within_configured_threshold(
                     comparison,
                     required_changes_threshold,
                     compare_non_negative_numbers=True,
@@ -194,7 +194,7 @@ class BundleAnalysisPRCommentContextBuilder(NotificationContextBuilder):
         )
         user_config = self._notification_context.user_config
 
-        if is_bundle_change_within_bundle_threshold(
+        if is_bundle_comparison_change_within_configured_threshold(
             bundle_analysis_comparison, user_config.warning_threshold
         ):
             self._notification_context.commit_status_level = CommitStatusLevel.INFO

--- a/services/bundle_analysis/notify/contexts/commit_status.py
+++ b/services/bundle_analysis/notify/contexts/commit_status.py
@@ -25,7 +25,7 @@ from services.bundle_analysis.notify.contexts import (
     NotificationContextField,
 )
 from services.bundle_analysis.notify.helpers import (
-    is_bundle_change_within_bundle_threshold,
+    is_bundle_comparison_change_within_configured_threshold,
 )
 from services.bundle_analysis.notify.types import NotificationType
 from services.repository import (
@@ -139,7 +139,7 @@ class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
         )
         user_config = self._notification_context.user_config
 
-        if is_bundle_change_within_bundle_threshold(
+        if is_bundle_comparison_change_within_configured_threshold(
             bundle_analysis_comparison, user_config.warning_threshold
         ):
             self._notification_context.commit_status_level = CommitStatusLevel.INFO

--- a/services/bundle_analysis/notify/helpers.py
+++ b/services/bundle_analysis/notify/helpers.py
@@ -1,9 +1,7 @@
 import numbers
 from typing import Iterable, Literal
 
-from shared.bundle_analysis import (
-    BundleAnalysisComparison,
-)
+from shared.bundle_analysis import BundleAnalysisComparison, BundleChange
 from shared.django_apps.codecov_auth.models import Service
 from shared.torngit.base import TorngitBaseAdapter
 from shared.validation.types import BundleThreshold
@@ -89,7 +87,7 @@ def to_BundleThreshold(value: int | float | BundleThreshold) -> BundleThreshold:
     raise TypeError(f"Can't parse {value} into BundleThreshold")
 
 
-def is_bundle_change_within_bundle_threshold(
+def is_bundle_comparison_change_within_configured_threshold(
     comparison: BundleAnalysisComparison,
     threshold: BundleThreshold,
     compare_non_negative_numbers: bool = False,
@@ -103,3 +101,12 @@ def is_bundle_change_within_bundle_threshold(
         return total_size_delta <= threshold.threshold
     else:
         return comparison.percentage_delta <= threshold.threshold
+
+
+def is_bundle_change_within_configured_threshold(
+    bundle_change: BundleChange, threshold: BundleThreshold
+) -> bool:
+    if threshold.type == "absolute":
+        return bundle_change.size_delta <= threshold.threshold
+    else:
+        return bundle_change.percentage_delta <= threshold.threshold

--- a/services/bundle_analysis/notify/messages/templates/bundle_analysis_notify/bundle_table.md
+++ b/services/bundle_analysis/notify/messages/templates/bundle_analysis_notify/bundle_table.md
@@ -2,6 +2,6 @@
 
 {% endif %}| Bundle name | Size | Change |
 | ----------- | ---- | ------ |{% for bundle_row in bundle_rows %}
-| {{bundle_row.bundle_name}}{% if bundle_row.is_cached %}*{% endif %} | {{bundle_row.bundle_size}} | {{bundle_row.change_size_readable}} {{bundle_row.change_icon}} |{% endfor %}{% if status_level == "INFO" %}
+| {{bundle_row.bundle_name}}{% if bundle_row.is_cached %}*{% endif %} | {{bundle_row.bundle_size}} | {{bundle_row.change_size_readable}} ({{bundle_row.percentage_change_readable}}) {{bundle_row.change_icon}}{% if bundle_row.is_change_outside_threshold and status_level == "WARNING" %}:warning:{% elif bundle_row.is_change_outside_threshold and status_level == "ERROR"%}:x:{% endif %}{{bundle_row.}} |{% endfor %}{% if status_level == "INFO" %}
 
 </details>{% endif %}

--- a/services/bundle_analysis/notify/messages/tests/test_comment.py
+++ b/services/bundle_analysis/notify/messages/tests/test_comment.py
@@ -61,11 +61,11 @@ class TestCommentMesage:
 
                 | Bundle name | Size | Change |
                 | ----------- | ---- | ------ |
-                | @codecov/sveltekit-plugin-esm | 1.1kB | 188 bytes :arrow_up: |
-                | @codecov/rollup-plugin-esm | 1.32kB | 1.01kB :arrow_down: |
-                | @codecov/bundler-plugin-core-esm | 8.2kB | 30.02kB :arrow_down: |
-                | @codecov/bundler-plugin-core-cjs | 43.32kB | 611 bytes :arrow_up: |
-                | @codecov/example-next-app-server-cjs | (removed) | 342.32kB :arrow_down: |
+                | @codecov/sveltekit-plugin-esm | 1.1kB | 188 bytes (20.68%) :arrow_up: |
+                | @codecov/rollup-plugin-esm | 1.32kB | 1.01kB (-43.37%) :arrow_down: |
+                | @codecov/bundler-plugin-core-esm | 8.2kB | 30.02kB (-78.55%) :arrow_down: |
+                | @codecov/bundler-plugin-core-cjs | 43.32kB | 611 bytes (1.43%) :arrow_up: |
+                | @codecov/example-next-app-server-cjs | (removed) | 342.32kB (-100.0%) :arrow_down: |
 
                 </details>""").format(
             pullid=enriched_pull.database_pull.pullid,

--- a/services/bundle_analysis/notify/tests/test_helpers.py
+++ b/services/bundle_analysis/notify/tests/test_helpers.py
@@ -14,7 +14,7 @@ from services.bundle_analysis.notify.helpers import (
     bytes_readable,
     get_github_app_used,
     get_notification_types_configured,
-    is_bundle_change_within_bundle_threshold,
+    is_bundle_comparison_change_within_configured_threshold,
     to_BundleThreshold,
 )
 from services.bundle_analysis.notify.types import NotificationType
@@ -175,4 +175,7 @@ def test_is_bundle_change_within_bundle_threshold(threshold, expected):
         name="fake_comparison", total_size_delta=10000, percentage_delta=12.5
     )
     assert comparison.total_size_delta == 10000
-    assert is_bundle_change_within_bundle_threshold(comparison, threshold) == expected
+    assert (
+        is_bundle_comparison_change_within_configured_threshold(comparison, threshold)
+        == expected
+    )

--- a/services/bundle_analysis/tests/test_bundle_analysis.py
+++ b/services/bundle_analysis/tests/test_bundle_analysis.py
@@ -65,7 +65,7 @@ def hook_mock_pull(mocker, mock_pull):
                     "added-bundle",
                     BundleChange.ChangeType.ADDED,
                     size_delta=12345,
-                    percentage_delta=2.56,
+                    percentage_delta=5.56,
                 ),
                 BundleChange(
                     "changed-bundle",
@@ -94,9 +94,9 @@ def hook_mock_pull(mocker, mock_pull):
 
             | Bundle name | Size | Change |
             | ----------- | ---- | ------ |
-            | added-bundle | 123.46kB | 12.35kB :arrow_up: |
-            | changed-bundle | 123.46kB | 3.46kB :arrow_up: |
-            | removed-bundle | (removed) | 1.23kB :arrow_down: |"""),
+            | added-bundle | 123.46kB | 12.35kB (5.56%) :arrow_up::warning: |
+            | changed-bundle | 123.46kB | 3.46kB (0.35%) :arrow_up: |
+            | removed-bundle | (removed) | 1.23kB (-1.23%) :arrow_down: |"""),
             id="comment_increase_size_warning",
         ),
         pytest.param(
@@ -105,7 +105,7 @@ def hook_mock_pull(mocker, mock_pull):
                     "added-bundle",
                     BundleChange.ChangeType.ADDED,
                     size_delta=12345,
-                    percentage_delta=2.56,
+                    percentage_delta=5.56,
                 ),
                 BundleChange(
                     "changed-bundle",
@@ -117,7 +117,7 @@ def hook_mock_pull(mocker, mock_pull):
                     "removed-bundle",
                     BundleChange.ChangeType.REMOVED,
                     size_delta=-1234,
-                    percentage_delta=2.56,
+                    percentage_delta=-100.0,
                 ),
             ],
             5.56,
@@ -134,9 +134,9 @@ def hook_mock_pull(mocker, mock_pull):
 
             | Bundle name | Size | Change |
             | ----------- | ---- | ------ |
-            | added-bundle | 123.46kB | 12.35kB :arrow_up: |
-            | changed-bundle | 123.46kB | 3.46kB :arrow_up: |
-            | removed-bundle | (removed) | 1.23kB :arrow_down: |"""),
+            | added-bundle | 123.46kB | 12.35kB (5.56%) :arrow_up::x: |
+            | changed-bundle | 123.46kB | 3.46kB (2.56%) :arrow_up: |
+            | removed-bundle | (removed) | 1.23kB (-100.0%) :arrow_down: |"""),
             id="comment_increase_size_error",
         ),
         pytest.param(
@@ -176,9 +176,9 @@ def hook_mock_pull(mocker, mock_pull):
                    
             | Bundle name | Size | Change |
             | ----------- | ---- | ------ |
-            | added-bundle | 123.46kB | 12.35kB :arrow_up: |
-            | cached-bundle* | 123.46kB | 3.46kB :arrow_up: |
-            | removed-bundle | (removed) | 1.23kB :arrow_down: |
+            | added-bundle | 123.46kB | 12.35kB (2.56%) :arrow_up: |
+            | cached-bundle* | 123.46kB | 3.46kB (2.56%) :arrow_up: |
+            | removed-bundle | (removed) | 1.23kB (2.56%) :arrow_down: |
                    
             </details>
 
@@ -211,7 +211,7 @@ def hook_mock_pull(mocker, mock_pull):
             
             | Bundle name | Size | Change |
             | ----------- | ---- | ------ |
-            | test-bundle | 123.46kB | 3.46kB :arrow_down: |
+            | test-bundle | 123.46kB | 3.46kB (-2.56%) :arrow_down: |
             
             </details>"""),
             id="comment_decrease_size",


### PR DESCRIPTION
The designs for the bundle comment include percentage change and potentially warnings
in the rows of the bundles (PR comment).

These changes add those.
This fully matches the designs for now.
