### PR TITLE
bundle analysis: remove unnecessary save measurements

### DIFF
--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -372,49 +372,49 @@ class BundleAnalysisReportService(BaseReportService):
 
             db_session = commit.get_db_session()
             bundle_report = bundle_analysis_report.bundle_report(bundle_name)
-
-            # For overall bundle size
-            if MeasurementName.bundle_analysis_report_size.value in dataset_names:
-                self._save_to_timeseries(
-                    db_session,
-                    commit,
-                    MeasurementName.bundle_analysis_report_size.value,
-                    bundle_report.name,
-                    bundle_report.total_size(),
-                )
-
-            # For individual javascript associated assets using UUID
-            if MeasurementName.bundle_analysis_asset_size.value in dataset_names:
-                for asset in bundle_report.asset_reports():
-                    if asset.asset_type == AssetType.JAVASCRIPT:
-                        self._save_to_timeseries(
-                            db_session,
-                            commit,
-                            MeasurementName.bundle_analysis_asset_size.value,
-                            asset.uuid,
-                            asset.size,
-                        )
-
-            # For asset types sizes
-            asset_type_map = {
-                MeasurementName.bundle_analysis_font_size: AssetType.FONT,
-                MeasurementName.bundle_analysis_image_size: AssetType.IMAGE,
-                MeasurementName.bundle_analysis_stylesheet_size: AssetType.STYLESHEET,
-                MeasurementName.bundle_analysis_javascript_size: AssetType.JAVASCRIPT,
-            }
-            for measurement_name, asset_type in asset_type_map.items():
-                if measurement_name.value in dataset_names:
-                    total_size = 0
-                    for asset in bundle_report.asset_reports():
-                        if asset.asset_type == asset_type:
-                            total_size += asset.size
+            if bundle_report:
+                # For overall bundle size
+                if MeasurementName.bundle_analysis_report_size.value in dataset_names:
                     self._save_to_timeseries(
                         db_session,
                         commit,
-                        measurement_name.value,
+                        MeasurementName.bundle_analysis_report_size.value,
                         bundle_report.name,
-                        total_size,
+                        bundle_report.total_size(),
                     )
+
+                # For individual javascript associated assets using UUID
+                if MeasurementName.bundle_analysis_asset_size.value in dataset_names:
+                    for asset in bundle_report.asset_reports():
+                        if asset.asset_type == AssetType.JAVASCRIPT:
+                            self._save_to_timeseries(
+                                db_session,
+                                commit,
+                                MeasurementName.bundle_analysis_asset_size.value,
+                                asset.uuid,
+                                asset.size,
+                            )
+
+                # For asset types sizes
+                asset_type_map = {
+                    MeasurementName.bundle_analysis_font_size: AssetType.FONT,
+                    MeasurementName.bundle_analysis_image_size: AssetType.IMAGE,
+                    MeasurementName.bundle_analysis_stylesheet_size: AssetType.STYLESHEET,
+                    MeasurementName.bundle_analysis_javascript_size: AssetType.JAVASCRIPT,
+                }
+                for measurement_name, asset_type in asset_type_map.items():
+                    if measurement_name.value in dataset_names:
+                        total_size = 0
+                        for asset in bundle_report.asset_reports():
+                            if asset.asset_type == asset_type:
+                                total_size += asset.size
+                        self._save_to_timeseries(
+                            db_session,
+                            commit,
+                            measurement_name.value,
+                            bundle_report.name,
+                            total_size,
+                        )
 
             return ProcessingResult(
                 upload=upload,

--- a/services/bundle_analysis/tests/test_bundle_analysis.py
+++ b/services/bundle_analysis/tests/test_bundle_analysis.py
@@ -416,11 +416,8 @@ async def test_bundle_analysis_save_measurements_report_size(
             return self.size
 
     class MockBundleAnalysisReport:
-        def bundle_reports(self):
-            return [
-                MockBundleReport("BundleA", 1111),
-                MockBundleReport("BundleB", 2222),
-            ]
+        def bundle_report(self, bundle_name):
+            return MockBundleReport("BundleA", 1111)
 
     mocker.patch(
         "shared.bundle_analysis.BundleAnalysisReportLoader.load",
@@ -428,7 +425,9 @@ async def test_bundle_analysis_save_measurements_report_size(
     )
 
     report_service = BundleAnalysisReportService(UserYaml.from_dict({}))
-    result: ProcessingResult = report_service.save_measurements(commit, upload)
+    result: ProcessingResult = report_service.save_measurements(
+        commit, upload, "BundleA"
+    )
 
     assert result.error is None
 
@@ -457,8 +456,7 @@ async def test_bundle_analysis_save_measurements_report_size(
         .all()
     )
 
-    assert len(measurements) == 1
-    assert measurements[0].value == 2222
+    assert len(measurements) == 0
 
 
 @pytest.mark.asyncio
@@ -528,8 +526,8 @@ async def test_bundle_analysis_save_measurements_asset_size(
             ]
 
     class MockBundleAnalysisReport:
-        def bundle_reports(self):
-            return [MockBundleReport("BundleA", 1111)]
+        def bundle_report(self, bundle_name):
+            return MockBundleReport("BundleA", 1111)
 
     mocker.patch(
         "shared.bundle_analysis.BundleAnalysisReportLoader.load",
@@ -537,7 +535,9 @@ async def test_bundle_analysis_save_measurements_asset_size(
     )
 
     report_service = BundleAnalysisReportService(UserYaml.from_dict({}))
-    result: ProcessingResult = report_service.save_measurements(commit, upload)
+    result: ProcessingResult = report_service.save_measurements(
+        commit, upload, "BundleA"
+    )
 
     assert result.error is None
 
@@ -646,8 +646,8 @@ async def test_bundle_analysis_save_measurements_asset_type_sizes(
             ]
 
     class MockBundleAnalysisReport:
-        def bundle_reports(self):
-            return [MockBundleReport("BundleA", 1111)]
+        def bundle_report(self, bundle_name):
+            return MockBundleReport("BundleA", 1111)
 
     mocker.patch(
         "shared.bundle_analysis.BundleAnalysisReportLoader.load",
@@ -655,7 +655,9 @@ async def test_bundle_analysis_save_measurements_asset_type_sizes(
     )
 
     report_service = BundleAnalysisReportService(UserYaml.from_dict({}))
-    result: ProcessingResult = report_service.save_measurements(commit, upload)
+    result: ProcessingResult = report_service.save_measurements(
+        commit, upload, "BundleA"
+    )
 
     assert result.error is None
 
@@ -750,6 +752,8 @@ async def test_bundle_analysis_save_measurements_error(dbsession, mocker, mock_s
     )
 
     report_service = BundleAnalysisReportService(UserYaml.from_dict({}))
-    result: ProcessingResult = report_service.save_measurements(commit, upload)
+    result: ProcessingResult = report_service.save_measurements(
+        commit, upload, "BundleA"
+    )
 
     assert result.error is not None

--- a/tasks/bundle_analysis_save_measurements.py
+++ b/tasks/bundle_analysis_save_measurements.py
@@ -65,12 +65,16 @@ class BundleAnalysisSaveMeasurementsTask(
         if all((result["error"] is not None for result in previous_result)):
             save_measurements = False
 
+        bundle_name = None
+        for result in previous_result:
+            bundle_name = result.get("bundle_name")
+
         if save_measurements:
             report_service = BundleAnalysisReportService(
                 UserYaml.from_dict(commit_yaml)
             )
             result: ProcessingResult = report_service.save_measurements(
-                commit, upload, previous_result["bundle_name"]
+                commit, upload, bundle_name
             )
             save_measurements = result.error is None
 

--- a/tasks/bundle_analysis_save_measurements.py
+++ b/tasks/bundle_analysis_save_measurements.py
@@ -69,7 +69,9 @@ class BundleAnalysisSaveMeasurementsTask(
             report_service = BundleAnalysisReportService(
                 UserYaml.from_dict(commit_yaml)
             )
-            result: ProcessingResult = report_service.save_measurements(commit, upload)
+            result: ProcessingResult = report_service.save_measurements(
+                commit, upload, previous_result["bundle_name"]
+            )
             save_measurements = result.error is None
 
         log.info(

--- a/tasks/tests/unit/test_bundle_analysis_save_measurements_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_save_measurements_task.py
@@ -41,7 +41,14 @@ def test_bundle_analysis_save_measurements_task_success(
         commitid=commit.commitid,
         uploadid=upload.id_,
         commit_yaml={},
-        previous_result=[{"upload_id": upload.id_, "session_id": 28, "error": None}],
+        previous_result=[
+            {
+                "upload_id": upload.id_,
+                "session_id": 28,
+                "error": None,
+                "bundle_name": "BundleA",
+            }
+        ],
     )
     assert result == {"successful": True}
 


### PR DESCRIPTION

closes https://github.com/codecov/engineering-team/issues/1875

No need to save every bundle of a commit, just save the processed bundle instead, otherwise it is inserting duplicate measurements to timeseries

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.