### PR TITLE
Better detect corrupted Go report lines

### DIFF
--- a/services/report/languages/helpers.py
+++ b/services/report/languages/helpers.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from xml.etree.ElementTree import Element
 
 
@@ -17,3 +18,16 @@ def child_text(parent: Element, element: str) -> str:
     if child is None:
         return ""
     return child.text or ""
+
+
+@dataclass
+class SourceLocation:
+    line: int
+    column: int
+
+
+@dataclass
+class Region:
+    start: SourceLocation
+    end: SourceLocation
+    hits: int


### PR DESCRIPTION
It appears that Go coverage reports are very susceptible to mangled lines. This makes sure we encapsulate all of the parsing for a coverage line within a try/except block, or skip over other invalid lines, instead of raising unexpected errors.

fixes [WORKER-MB9](https://codecov.sentry.io/issues/5165160706/), fixes [WORKER-P4S](https://codecov.sentry.io/issues/5787850847/), fixes [WORKER-P8D](https://codecov.sentry.io/issues/5826394496/), fixes [WORKER-P7Z](https://codecov.sentry.io/issues/5821076186/), fixes [WORKER-PAJ](https://codecov.sentry.io/issues/5860678163/), fixes [WORKER-PAH](https://codecov.sentry.io/issues/5860453353/), fixes [WORKER-P56](https://codecov.sentry.io/issues/5792037589/), fixes [WORKER-P7W](https://codecov.sentry.io/issues/5820563536/), fixes [WORKER-PBC](https://codecov.sentry.io/issues/5868077255/)