### PR TITLE
Run django db migrations for tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -39,7 +39,7 @@ def pytest_itemcollected(item):
 
 
 @pytest.fixture(scope="session")
-def engine(request, sqlalchemy_connect_url, app_config):
+def engine(request, sqlalchemy_db, sqlalchemy_connect_url, app_config):
     """Engine configuration.
     See http://docs.sqlalchemy.org/en/latest/core/engines.html
     for more details.
@@ -66,22 +66,11 @@ def engine(request, sqlalchemy_connect_url, app_config):
         engine.url.database = "{}_{}".format(engine.url.database, xdist_suffix)
         engine = create_engine(engine.url)  # override engine
 
-    def fin():
-        print("Disposing engine")
-        engine.dispose()
-
-    request.addfinalizer(fin)
-    return engine
-
-
-@pytest.fixture(scope="session")
-def db(engine, sqlalchemy_connect_url, django_db_setup):
-    # Bootstrap the DB by running the Django bootstrap version.
+    # Check that the DB exist and migrate the unmigrated SQLALchemy models as a stop-gap
     database_url = sqlalchemy_connect_url
     if not database_exists(database_url):
         raise RuntimeError(f"SQLAlchemy cannot connect to DB at {database_url}")
 
-    # Create the unmigrated models as a stopgap
     Base.metadata.tables["profiling_profilingcommit"].create(bind=engine)
     Base.metadata.tables["profiling_profilingupload"].create(bind=engine)
     Base.metadata.tables["timeseries_measurement"].create(bind=engine)
@@ -104,9 +93,59 @@ def db(engine, sqlalchemy_connect_url, django_db_setup):
         bind=engine
     )
 
+    yield engine
+
+    print("Disposing engine")
+    engine.dispose()
+
+
+@pytest.fixture(scope="session")
+def sqlalchemy_db(request: pytest.FixtureRequest, django_db_blocker, django_db_setup):
+    # Bootstrap the DB by running the Django bootstrap version.
+    from django.conf import settings
+    from django.db import connections
+    from django.test.utils import setup_databases, teardown_databases
+
+    with django_db_blocker.unblock():
+        # Temporarily reset the database to the SQLAlchemy DBs to run the migrations.
+        original_test_name = settings.DATABASES["default"]["TEST"]["NAME"]
+        settings.DATABASES["default"]["TEST"]["NAME"] = "test_postgres_sqlalchemy"
+        db_cfg = setup_databases(
+            verbosity=request.config.option.verbose,
+            interactive=False,
+        )
+        settings.DATABASES["default"]["TEST"]["NAME"] = original_test_name
+
+        # Hack to get the default connection for the test database to _actually_ be the
+        # Django database that the django_db should actually use. It was set to the SQLAlchemy database,
+        # but this makes sure that the default Django DB connection goes to the Django database.
+        # Since the database was already created and migrated in the django_db_setup fixture,
+        # we set keepdb=True to avoid recreating the database and rerunning the migrations.
+        connections.configure_settings(settings.DATABASES)
+        connections["default"].creation.create_test_db(
+            verbosity=request.config.option.verbose,
+            autoclobber=True,
+            keepdb=True,
+        )
+
+    yield
+
+    # Cleanup with Django version as well
+    try:
+        with django_db_blocker.unblock():
+            settings.DATABASES["default"]["TEST"]["NAME"] = "test_postgres_sqlalchemy"
+            teardown_databases(db_cfg, verbosity=request.config.option.verbose)
+            settings.DATABASES["default"]["TEST"]["NAME"] = original_test_name
+    except Exception as exc:  # noqa: BLE001
+        request.node.warn(
+            pytest.PytestWarning(
+                f"Error when trying to teardown test databases: {exc!r}"
+            )
+        )
+
 
 @pytest.fixture
-def dbsession(db, engine):
+def dbsession(sqlalchemy_db, engine):
     """Sets up the SQLAlchemy dbsession."""
     connection = engine.connect()
 

--- a/database/tests/factories/core.py
+++ b/database/tests/factories/core.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from hashlib import sha1
 from uuid import uuid4
 
@@ -71,9 +71,11 @@ class RepositoryFactory(Factory):
 
     owner = factory.SubFactory(OwnerFactory)
     bot = None
-    updatestamp = factory.LazyAttribute(lambda o: datetime.now())
+    updatestamp = factory.LazyAttribute(lambda o: datetime.now(tz=timezone.utc))
     languages = []
-    languages_last_updated = factory.LazyAttribute(lambda o: datetime.now())
+    languages_last_updated = factory.LazyAttribute(
+        lambda o: datetime.now(tz=timezone.utc)
+    )
     bundle_analysis_enabled = False
 
 
@@ -113,7 +115,7 @@ class CommitFactory(Factory):
     )
     ci_passed = True
     pullid = None
-    timestamp = datetime(2019, 2, 1, 17, 59, 47)
+    timestamp = datetime(2019, 2, 1, 17, 59, 47, tzinfo=timezone.utc)
     author = factory.SubFactory(OwnerFactory)
     repository = factory.SubFactory(RepositoryFactory)
     totals = factory.LazyFunction(

--- a/database/tests/unit/test_model_utils.py
+++ b/database/tests/unit/test_model_utils.py
@@ -56,14 +56,14 @@ class TestArchiveField(object):
             self.ClassWithArchiveFieldMissingMethods, ArchiveFieldInterface
         )
 
-    def test_archive_getter_db_field_set(self, db):
+    def test_archive_getter_db_field_set(self, sqlalchemy_db):
         commit = CommitFactory()
         test_class = self.ClassWithArchiveField(commit, "db_value", "gcs_path")
         assert test_class._archive_field == "db_value"
         assert test_class._archive_field_storage_path == "gcs_path"
         assert test_class.archive_field == "db_value"
 
-    def test_archive_getter_archive_field_set(self, db, mocker):
+    def test_archive_getter_archive_field_set(self, sqlalchemy_db, mocker):
         some_json = {"some": "data"}
         mock_read_file = mocker.MagicMock(return_value=json.dumps(some_json))
         mock_archive_service = mocker.patch("database.utils.ArchiveService")
@@ -81,7 +81,7 @@ class TestArchiveField(object):
         assert test_class.archive_field == some_json
         assert mock_read_file.call_count == 1
 
-    def test_archive_getter_file_not_in_storage(self, db, mocker):
+    def test_archive_getter_file_not_in_storage(self, sqlalchemy_db, mocker):
         mocker.patch(
             "database.utils.ArchiveField.read_timeout",
             new_callable=PropertyMock,
@@ -99,7 +99,7 @@ class TestArchiveField(object):
         mock_read_file.assert_called_with("gcs_path")
         mock_archive_service.assert_called_with(repository=commit.repository)
 
-    def test_archive_setter_db_field(self, db, mocker):
+    def test_archive_setter_db_field(self, sqlalchemy_db, mocker):
         commit = CommitFactory()
         test_class = self.ClassWithArchiveField(commit, "db_value", "gcs_path", False)
         assert test_class._archive_field == "db_value"
@@ -111,7 +111,7 @@ class TestArchiveField(object):
         assert test_class._archive_field == "batata frita"
         assert test_class.archive_field == "batata frita"
 
-    def test_archive_setter_archive_field(self, db, mocker):
+    def test_archive_setter_archive_field(self, sqlalchemy_db, mocker):
         commit = CommitFactory()
         test_class = self.ClassWithArchiveField(commit, "db_value", None, True)
         some_json = {"some": "data"}

--- a/django_scaffold/tests_settings.py
+++ b/django_scaffold/tests_settings.py
@@ -22,3 +22,5 @@ TEMPLATES = [
         },
     }
 ]
+
+DATABASES["default"]["TEST"] = {"NAME": "test_postgres_django"}

--- a/helpers/tests/unit/test_github_installation.py
+++ b/helpers/tests/unit/test_github_installation.py
@@ -18,7 +18,7 @@ def test_get_installation_name_for_owner_for_task(dbsession: Session):
         installation_name="my_installation",
         task_name=task_name,
     )
-    dbsession.add_all([owner, installation_task_config])
+    dbsession.add_all([owner, other_owner, installation_task_config])
     dbsession.flush()
     assert (
         get_installation_name_for_owner_for_task(task_name, owner) == "my_installation"

--- a/one_off_scripts/tests/test_backfill_daily_test_rollups.py
+++ b/one_off_scripts/tests/test_backfill_daily_test_rollups.py
@@ -1,85 +1,17 @@
 import datetime as dt
 
 import pytest
-import time_machine
-from shared.django_apps.core.tests.factories import RepositoryFactory
 from shared.django_apps.reports.models import DailyTestRollup
-from shared.django_apps.reports.tests.factories import (
-    DailyTestRollupFactory,
-    FlakeFactory,
-    TestFactory,
-    TestInstanceFactory,
-)
 
 from one_off_scripts.backfill_daily_test_rollups import backfill_test_rollups
-
-
-@pytest.fixture
-def setup_tests(transactional_db):
-    repo_1 = RepositoryFactory(test_analytics_enabled=True)
-
-    test_1 = TestFactory(repository=repo_1)
-
-    _ = FlakeFactory(
-        test=test_1,
-        repository=repo_1,
-        start_date=dt.datetime.fromisoformat("1970-01-02T00:00:00Z"),
-        end_date=dt.datetime.fromisoformat("1970-01-04T00:00:00Z"),
-    )
-
-    _ = FlakeFactory(
-        test=test_1,
-        repository=repo_1,
-        start_date=dt.datetime.fromisoformat("1970-01-04T12:00:00Z"),
-        end_date=None,
-    )
-
-    traveller = time_machine.travel("1970-01-01T00:00:00Z", tick=False)
-    traveller.start()
-    ti = TestInstanceFactory(test=test_1, duration_seconds=10.0)
-    traveller.stop()
-
-    traveller = time_machine.travel("1970-01-03T00:00:00Z", tick=False)
-    traveller.start()
-    ti = TestInstanceFactory(test=test_1, duration_seconds=10.0)
-    traveller.stop()
-
-    traveller = time_machine.travel("1970-01-05T00:00:00Z", tick=False)
-    traveller.start()
-    ti = TestInstanceFactory(
-        test=test_1,
-        duration_seconds=10000.0,
-    )
-    traveller.stop()
-
-    _ = DailyTestRollupFactory(
-        test=test_1,
-        date=dt.date.fromisoformat("1970-01-03"),
-        fail_count=10,
-        pass_count=5,
-        last_duration_seconds=10.0,
-        avg_duration_seconds=1.0,
-        latest_run=dt.datetime.fromisoformat("1970-01-01T00:00:00Z"),
-    )
-
-    _ = DailyTestRollupFactory(
-        test=test_1,
-        date=dt.date.fromisoformat("1970-01-05"),
-        fail_count=10,
-        pass_count=5,
-        last_duration_seconds=10.0,
-        avg_duration_seconds=1.0,
-        latest_run=dt.datetime.fromisoformat("1970-01-01T00:00:00Z"),
-    )
-
-    _ = RepositoryFactory(test_analytics_enabled=False)
-
-    return repo_1
+from one_off_scripts.tests.utils import setup_one_off_tests
 
 
 @pytest.mark.django_db(transaction=True)
-def test_backfill_test_rollups(setup_tests):
-    rollups = DailyTestRollup.objects.all()
+def test_backfill_test_rollups():
+    setup_one_off_tests()
+
+    rollups = DailyTestRollup.objects.all().order_by("date")
     assert [
         {
             "date": r.date,
@@ -123,7 +55,7 @@ def test_backfill_test_rollups(setup_tests):
         end_date="1970-01-04",
     )
 
-    rollups = DailyTestRollup.objects.all()
+    rollups = DailyTestRollup.objects.all().order_by("date")
 
     assert [
         {
@@ -139,16 +71,6 @@ def test_backfill_test_rollups(setup_tests):
         for r in rollups
     ] == [
         {
-            "avg_duration_seconds": 1.0,
-            "date": dt.date(1970, 1, 5),
-            "fail_count": 10,
-            "flaky_fail_count": 0,
-            "last_duration_seconds": 10.0,
-            "latest_run": dt.datetime.fromisoformat("1970-01-01T00:00:00Z"),
-            "pass_count": 5,
-            "skip_count": 0,
-        },
-        {
             "avg_duration_seconds": 10.0,
             "date": dt.date(1970, 1, 3),
             "fail_count": 1,
@@ -158,16 +80,26 @@ def test_backfill_test_rollups(setup_tests):
             "pass_count": 0,
             "skip_count": 0,
         },
+        {
+            "avg_duration_seconds": 1.0,
+            "date": dt.date(1970, 1, 5),
+            "fail_count": 10,
+            "flaky_fail_count": 0,
+            "last_duration_seconds": 10.0,
+            "latest_run": dt.datetime.fromisoformat("1970-01-01T00:00:00Z"),
+            "pass_count": 5,
+            "skip_count": 0,
+        },
     ]
 
-    assert len(rollups[1].commits_where_fail) == 1
+    assert len(rollups[0].commits_where_fail) == 1
 
     backfill_test_rollups(
         start_date="1970-01-02",
         end_date="1970-01-05",
     )
 
-    rollups = DailyTestRollup.objects.all()
+    rollups = DailyTestRollup.objects.all().order_by("date")
 
     assert [
         {
@@ -203,6 +135,5 @@ def test_backfill_test_rollups(setup_tests):
             "skip_count": 0,
         },
     ]
-
     for r in rollups:
         assert len(r.commits_where_fail) == 1

--- a/one_off_scripts/tests/test_backfill_test_flag_bridges.py
+++ b/one_off_scripts/tests/test_backfill_test_flag_bridges.py
@@ -9,10 +9,12 @@ from shared.django_apps.reports.tests.factories import (
 )
 
 from one_off_scripts.backfill_test_flag_bridges import backfill_test_flag_bridges
+from one_off_scripts.tests.utils import setup_one_off_tests
 
 
-@pytest.mark.django_db
-def test_it_backfills_test_flag_bridges(setup_tests):
+@pytest.mark.django_db(transaction=True)
+def test_it_backfills_test_flag_bridges():
+    setup_one_off_tests()
     repo = RepositoryFactory(test_analytics_enabled=True)
 
     flag_1 = RepositoryFlagFactory(repository=repo, flag_name="first")

--- a/one_off_scripts/tests/test_backfill_test_flag_bridges.py
+++ b/one_off_scripts/tests/test_backfill_test_flag_bridges.py
@@ -11,8 +11,8 @@ from shared.django_apps.reports.tests.factories import (
 from one_off_scripts.backfill_test_flag_bridges import backfill_test_flag_bridges
 
 
-@pytest.fixture
-def setup_tests(transactional_db):
+@pytest.mark.django_db
+def test_it_backfills_test_flag_bridges(setup_tests):
     repo = RepositoryFactory(test_analytics_enabled=True)
 
     flag_1 = RepositoryFlagFactory(repository=repo, flag_name="first")
@@ -31,9 +31,6 @@ def setup_tests(transactional_db):
 
     test_3 = TestFactory(repository_id=repo.repoid)
 
-
-@pytest.mark.django_db(transaction=True)
-def test_it_backfills_test_flag_bridges(setup_tests):
     bridges = TestFlagBridge.objects.all()
     assert len(bridges) == 0
 
@@ -44,15 +41,15 @@ def test_it_backfills_test_flag_bridges(setup_tests):
 
     assert [(b.test.name, b.flag.flag_name) for b in bridges] == [
         (
-            "test_1",
+            test_1.name,
             "first",
         ),
         (
-            "test_1",
+            test_1.name,
             "second",
         ),
         (
-            "test_2",
+            test_2.name,
             "third",
         ),
     ]

--- a/one_off_scripts/tests/utils.py
+++ b/one_off_scripts/tests/utils.py
@@ -1,0 +1,74 @@
+import datetime as dt
+
+import time_machine
+from shared.django_apps.core.tests.factories import (
+    RepositoryFactory,
+)
+from shared.django_apps.reports.tests.factories import (
+    DailyTestRollupFactory,
+    FlakeFactory,
+    TestFactory,
+    TestInstanceFactory,
+)
+
+
+def setup_one_off_tests():
+    repo_1 = RepositoryFactory(test_analytics_enabled=True)
+
+    test_1 = TestFactory(repository=repo_1)
+
+    _ = FlakeFactory(
+        test=test_1,
+        repository=repo_1,
+        start_date=dt.datetime.fromisoformat("1970-01-02T00:00:00Z"),
+        end_date=dt.datetime.fromisoformat("1970-01-04T00:00:00Z"),
+    )
+
+    _ = FlakeFactory(
+        test=test_1,
+        repository=repo_1,
+        start_date=dt.datetime.fromisoformat("1970-01-04T12:00:00Z"),
+        end_date=None,
+    )
+
+    traveller = time_machine.travel("1970-01-01T00:00:00Z", tick=False)
+    traveller.start()
+    ti = TestInstanceFactory(test=test_1, duration_seconds=10.0)
+    traveller.stop()
+
+    traveller = time_machine.travel("1970-01-03T00:00:00Z", tick=False)
+    traveller.start()
+    ti = TestInstanceFactory(test=test_1, duration_seconds=10.0)
+    traveller.stop()
+
+    traveller = time_machine.travel("1970-01-05T00:00:00Z", tick=False)
+    traveller.start()
+    ti = TestInstanceFactory(
+        test=test_1,
+        duration_seconds=10000.0,
+    )
+    traveller.stop()
+
+    _ = DailyTestRollupFactory(
+        test=test_1,
+        date=dt.date.fromisoformat("1970-01-03"),
+        fail_count=10,
+        pass_count=5,
+        last_duration_seconds=10.0,
+        avg_duration_seconds=1.0,
+        latest_run=dt.datetime.fromisoformat("1970-01-01T00:00:00Z"),
+    )
+
+    _ = DailyTestRollupFactory(
+        test=test_1,
+        date=dt.date.fromisoformat("1970-01-05"),
+        fail_count=10,
+        pass_count=5,
+        last_duration_seconds=10.0,
+        avg_duration_seconds=1.0,
+        latest_run=dt.datetime.fromisoformat("1970-01-01T00:00:00Z"),
+    )
+
+    _ = RepositoryFactory(test_analytics_enabled=False)
+
+    return repo_1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = django_scaffold.tests_settings
-addopts = --sqlalchemy-connect-url="postgresql://postgres@postgres:5432/background_test" --ignore-glob=**/test_results*
+addopts = --sqlalchemy-connect-url="postgresql://postgres@postgres:5432/test_postgres" --ignore-glob=**/test_results*
 markers=
     integration: integration tests (includes tests with vcrs)
     real_checkpoint_logger: prevents use of stubbed CheckpointLogger

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = django_scaffold.tests_settings
-addopts = --sqlalchemy-connect-url="postgresql://postgres@postgres:5432/test_postgres" --ignore-glob=**/test_results*
+addopts = --sqlalchemy-connect-url="postgresql://postgres@postgres:5432/test_postgres_sqlalchemy" --ignore-glob=**/test_results*
 markers=
     integration: integration tests (includes tests with vcrs)
     real_checkpoint_logger: prevents use of stubbed CheckpointLogger

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/6e68957eb90e234cbec237ede814e1d36b170291.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/83b3376fef128a8c8f4191212d89b97f3b507d15.tar.gz#egg=shared
 https://github.com/codecov/test-results-parser/archive/ef39a0888acd62d02a316a852a15d755c74e78c6.tar.gz#egg=test-results-parser
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -362,7 +362,7 @@ sentry-sdk[celery]==2.13.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/6e68957eb90e234cbec237ede814e1d36b170291.tar.gz
+shared @ https://github.com/codecov/shared/archive/83b3376fef128a8c8f4191212d89b97f3b507d15.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/bundle_analysis/notify/tests/test_helpers.py
+++ b/services/bundle_analysis/notify/tests/test_helpers.py
@@ -53,6 +53,7 @@ def github_owner_with_apps(dbsession) -> Owner:
         ownerid=owner.ownerid,
         owner=owner,
         name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+        installation_id=1234,
     )
     dbsession.add_all([owner, ghapp])
     dbsession.commit()

--- a/services/notification/notifiers/tests/conftest.py
+++ b/services/notification/notifiers/tests/conftest.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pytest
 from shared.reports.readonly import ReadOnlyReport
 from shared.reports.resources import Report, ReportFile, ReportLine
@@ -312,6 +314,8 @@ def sample_comparison(dbsession, request, sample_report, mocker):
         owner__username=request.node.name,
         owner__service="github",
         owner__integration_id="10000",
+        # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+        owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         using_integration=True,
     )
     dbsession.add(repository)
@@ -330,7 +334,6 @@ def sample_comparison(dbsession, request, sample_report, mocker):
     dbsession.add(head_commit)
     dbsession.add(pull)
     dbsession.flush()
-    repository = base_commit.repository
     base_full_commit = FullCommit(
         commit=base_commit, report=ReadOnlyReport.create_from_report(get_small_report())
     )

--- a/services/notification/notifiers/tests/integration/cassetes/test_comment/TestCommentNotifierIntegration/test_notify_gitlab.yaml
+++ b/services/notification/notifiers/tests/integration/cassetes/test_comment/TestCommentNotifierIntegration/test_notify_gitlab.yaml
@@ -195,7 +195,7 @@ interactions:
       user-agent:
       - Default
     method: POST
-    uri: https://gitlab.com/api/v4/projects/47404140/merge_requests/1/notes
+    uri: https://gitlab.com/api/v4/projects/47404140/merge_requests/5/notes
   response:
     content: "{\"id\":1457135397,\"type\":null,\"body\":\"## [Codecov](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1?src=pr\\\
       u0026el=h1\\u0026utm_medium=referral\\u0026utm_source=gitlab\\u0026utm_content=comment\\\

--- a/services/notification/notifiers/tests/integration/cassetes/test_comment/TestCommentNotifierIntegration/test_notify_upgrade.yaml
+++ b/services/notification/notifiers/tests/integration/cassetes/test_comment/TestCommentNotifierIntegration/test_notify_upgrade.yaml
@@ -21,7 +21,7 @@ interactions:
       user-agent:
       - Default
     method: POST
-    uri: https://api.github.com/repos/codecove2e/example-python/issues/4/comments
+    uri: https://api.github.com/repos/codecove2e/example-python/issues/2/comments
   response:
     content: '{"url":"https://api.github.com/repos/codecove2e/example-python/issues/comments/1361234119","html_url":"https://github.com/codecove2e/example-python/pull/4#issuecomment-1361234119","issue_url":"https://api.github.com/repos/codecove2e/example-python/issues/4","id":1361234119,"node_id":"IC_kwDOHrbKcs5RIsjH","user":{"login":"codecove2e","id":93560619,"node_id":"U_kgDOBZOfKw","avatar_url":"https://avatars.githubusercontent.com/u/93560619?v=4","gravatar_id":"","url":"https://api.github.com/users/codecove2e","html_url":"https://github.com/codecove2e","followers_url":"https://api.github.com/users/codecove2e/followers","following_url":"https://api.github.com/users/codecove2e/following{/other_user}","gists_url":"https://api.github.com/users/codecove2e/gists{/gist_id}","starred_url":"https://api.github.com/users/codecove2e/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/codecove2e/subscriptions","organizations_url":"https://api.github.com/users/codecove2e/orgs","repos_url":"https://api.github.com/users/codecove2e/repos","events_url":"https://api.github.com/users/codecove2e/events{/privacy}","received_events_url":"https://api.github.com/users/codecove2e/received_events","type":"User","site_admin":false},"created_at":"2022-12-21T12:07:36Z","updated_at":"2022-12-21T12:07:36Z","author_association":"OWNER","body":"The
       author of this PR, codecove2e, is not an activated member of this organization

--- a/services/notification/notifiers/tests/integration/cassetes/test_comment/TestCommentNotifierIntegration/test_notify_upload_limited.yaml
+++ b/services/notification/notifiers/tests/integration/cassetes/test_comment/TestCommentNotifierIntegration/test_notify_upload_limited.yaml
@@ -22,7 +22,7 @@ interactions:
       user-agent:
       - Default
     method: POST
-    uri: https://api.github.com/repos/test-acc9/priv_example/issues/1/comments
+    uri: https://api.github.com/repos/test-acc9/priv_example/issues/3/comments
   response:
     content: '{"url":"https://api.github.com/repos/test-acc9/priv_example/issues/comments/1111984446","html_url":"https://github.com/test-acc9/priv_example/pull/1#issuecomment-1111984446","issue_url":"https://api.github.com/repos/test-acc9/priv_example/issues/1","id":1111984446,"node_id":"IC_kwDOHP_eEc5CR4k-","user":{"login":"test-acc9","id":104562106,"node_id":"U_kgDOBjt9ug","avatar_url":"https://avatars.githubusercontent.com/u/104562106?v=4","gravatar_id":"","url":"https://api.github.com/users/test-acc9","html_url":"https://github.com/test-acc9","followers_url":"https://api.github.com/users/test-acc9/followers","following_url":"https://api.github.com/users/test-acc9/following{/other_user}","gists_url":"https://api.github.com/users/test-acc9/gists{/gist_id}","starred_url":"https://api.github.com/users/test-acc9/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/test-acc9/subscriptions","organizations_url":"https://api.github.com/users/test-acc9/orgs","repos_url":"https://api.github.com/users/test-acc9/repos","events_url":"https://api.github.com/users/test-acc9/events{/privacy}","received_events_url":"https://api.github.com/users/test-acc9/received_events","type":"User","site_admin":false},"created_at":"2022-04-28T09:42:44Z","updated_at":"2022-04-28T09:42:44Z","author_association":"OWNER","body":"#
       [Codecov](None/account/gh/test-acc9/billing) upload limit reached :warning:\nThis

--- a/services/notification/notifiers/tests/integration/test_comment.py
+++ b/services/notification/notifiers/tests/integration/test_comment.py
@@ -170,7 +170,7 @@ def sample_comparison_gitlab(dbsession, request, sample_report, small_report):
         repository=repository,
         base=base_commit.commitid,
         head=head_commit.commitid,
-        pullid=1,
+        pullid=5,
     )
     dbsession.add(base_commit)
     dbsession.add(head_commit)
@@ -233,7 +233,7 @@ def sample_comparison_for_upgrade(dbsession, request, sample_report, small_repor
         repository=repository,
         base=base_commit.commitid,
         head=head_commit.commitid,
-        pullid=4,
+        pullid=2,
     )
     dbsession.add(base_commit)
     dbsession.add(head_commit)
@@ -298,7 +298,7 @@ def sample_comparison_for_limited_upload(
         repository=repository,
         base=base_commit.commitid,
         head=head_commit.commitid,
-        pullid=1,
+        pullid=3,
     )
     dbsession.add(base_commit)
     dbsession.add(head_commit)
@@ -513,7 +513,7 @@ class TestCommentNotifierIntegration(object):
         assert result.data_sent == {
             "commentid": None,
             "message": expected_message,
-            "pullid": 4,
+            "pullid": 2,
         }
         assert result.data_received == {"id": 1361234119}
 
@@ -556,7 +556,7 @@ class TestCommentNotifierIntegration(object):
         assert result.data_sent == {
             "commentid": None,
             "message": expected_message,
-            "pullid": 1,
+            "pullid": 3,
         }
         assert result.data_received == {"id": 1111984446}
 
@@ -581,15 +581,15 @@ class TestCommentNotifierIntegration(object):
         assert result.notification_successful
         assert result.explanation is None
         message = [
-            "## [Codecov](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1?dropdown=coverage&src=pr&el=h1) Report",
+            "## [Codecov](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5?dropdown=coverage&src=pr&el=h1) Report",
             "All modified and coverable lines are covered by tests :white_check_mark:",
             "> Project coverage is 60.00%. Comparing base [(`0fc784a`)](https://app.codecov.io/gl/joseph-sentry/example-python/commit/0fc784af11c401449e56b24a174bae7b9af86c98?dropdown=coverage&el=desc) to head [(`0b6a213`)](https://app.codecov.io/gl/joseph-sentry/example-python/commit/0b6a213fc300cd328c0625f38f30432ee6e066e5?dropdown=coverage&el=desc).",
             "",
-            "[![Impacted file tree graph](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1/graphs/tree.svg?width=650&height=150&src=pr&token=abcdefghij)](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1?src=pr&el=tree)",
+            "[![Impacted file tree graph](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5/graphs/tree.svg?width=650&height=150&src=pr&token=abcdefghij)](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5?src=pr&el=tree)",
             "",
             "```diff",
             "@@              Coverage Diff              @@",
-            "##               main       #1       +/-   ##",
+            "##               main       #5       +/-   ##",
             "=============================================",
             "+ Coverage     50.00%   60.00%   +10.00%     ",
             "+ Complexity       11       10        -1     ",
@@ -603,27 +603,27 @@ class TestCommentNotifierIntegration(object):
             "- Partials          0        1        +1     ",
             "```",
             "",
-            "| [Flag](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1/flags?src=pr&el=flags) | Coverage Δ | Complexity Δ | |",
+            "| [Flag](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5/flags?src=pr&el=flags) | Coverage Δ | Complexity Δ | |",
             "|---|---|---|---|",
-            "| [integration](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1/flags?src=pr&el=flag) | `?` | `?` | |",
-            "| [unit](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1/flags?src=pr&el=flag) | `100.00% <ø> (?)` | `0.00 <ø> (?)` | |",
+            "| [integration](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5/flags?src=pr&el=flag) | `?` | `?` | |",
+            "| [unit](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5/flags?src=pr&el=flag) | `100.00% <ø> (?)` | `0.00 <ø> (?)` | |",
             "",
             "Flags with carried forward coverage won't be shown. [Click here](https://docs.codecov.io/docs/carryforward-flags#carryforward-flags-in-the-pull-request-comment) to find out more.",
             "",
-            "[see 2 files with indirect coverage changes](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1/indirect-changes?src=pr&el=tree-more)",
+            "[see 2 files with indirect coverage changes](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5/indirect-changes?src=pr&el=tree-more)",
             "",
             "------",
             "",
-            "[Continue to review full report in Codecov by Sentry](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1?dropdown=coverage&src=pr&el=continue).",
+            "[Continue to review full report in Codecov by Sentry](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5?dropdown=coverage&src=pr&el=continue).",
             "> **Legend** - [Click here to learn more](https://docs.codecov.io/docs/codecov-delta)",
             "> `Δ = absolute <relative> (impact)`, `ø = not affected`, `? = missing data`",
-            "> Powered by [Codecov](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1?dropdown=coverage&src=pr&el=footer). Last update [0fc784a...0b6a213](https://app.codecov.io/gl/joseph-sentry/example-python/pull/1?dropdown=coverage&src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
+            "> Powered by [Codecov](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5?dropdown=coverage&src=pr&el=footer). Last update [0fc784a...0b6a213](https://app.codecov.io/gl/joseph-sentry/example-python/pull/5?dropdown=coverage&src=pr&el=lastupdated). Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             "",
         ]
         for exp, res in zip(result.data_sent["message"], message):
             assert exp == res
         assert result.data_sent["message"] == message
-        assert result.data_sent == {"commentid": None, "message": message, "pullid": 1}
+        assert result.data_sent == {"commentid": None, "message": message, "pullid": 5}
         assert result.data_received == {"id": 1457135397}
 
     def test_notify_new_layout(

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -5106,6 +5106,8 @@ class TestCommentNotifierWelcome:
 
         owner = OwnerFactory.create(
             service="github",
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         repository = RepositoryFactory.create(owner=owner)
         branch = "new_branch"

--- a/services/notification/notifiers/tests/unit/test_webhook.py
+++ b/services/notification/notifiers/tests/unit/test_webhook.py
@@ -45,7 +45,7 @@ class TestWebhookNotifier(object):
                 "name": head_commit.author.name,
             },
             "url": f"test.example.br/gh/{repository.slug}/commit/{head_commit.commitid}",
-            "timestamp": "2019-02-01T17:59:47",
+            "timestamp": "2019-02-01T17:59:47+00:00",
             "totals": {
                 "files": 2,
                 "lines": 10,
@@ -108,7 +108,7 @@ class TestWebhookNotifier(object):
                 "name": head_commit.author.name,
             },
             "url": f"codecov.io/gl/{username_in_db}/{repository.name}/commit/{head_commit.commitid}",
-            "timestamp": "2019-02-01T17:59:47",
+            "timestamp": "2019-02-01T17:59:47+00:00",
             "totals": {
                 "files": 2,
                 "lines": 10,
@@ -159,7 +159,7 @@ class TestWebhookNotifier(object):
         expected_result = {
             "author": None,
             "url": f"test.example.br/gh/{repository.slug}/commit/{head_commit.commitid}",
-            "timestamp": "2019-02-01T17:59:47",
+            "timestamp": "2019-02-01T17:59:47+00:00",
             "totals": {
                 "files": 2,
                 "lines": 10,
@@ -225,7 +225,7 @@ class TestWebhookNotifier(object):
                     "name": head_commit.author.name,
                 },
                 "url": f"test.example.br/gh/{repository.slug}/commit/{head_commit.commitid}",
-                "timestamp": "2019-02-01T17:59:47",
+                "timestamp": "2019-02-01T17:59:47+00:00",
                 "totals": {
                     "files": 2,
                     "lines": 10,
@@ -255,7 +255,7 @@ class TestWebhookNotifier(object):
                     "name": base_commit.author.name,
                 },
                 "url": f"test.example.br/gh/{repository.slug}/commit/{base_commit.commitid}",
-                "timestamp": "2019-02-01T17:59:47",
+                "timestamp": "2019-02-01T17:59:47+00:00",
                 "totals": {
                     "files": 2,
                     "lines": 6,
@@ -351,7 +351,7 @@ class TestWebhookNotifier(object):
                     "name": head_commit.author.name,
                 },
                 "url": f"test.example.br/gh/{repository.slug}/commit/{head_commit.commitid}",
-                "timestamp": "2019-02-01T17:59:47",
+                "timestamp": "2019-02-01T17:59:47+00:00",
                 "totals": {
                     "files": 2,
                     "lines": 10,
@@ -381,7 +381,7 @@ class TestWebhookNotifier(object):
                     "name": base_commit.author.name,
                 },
                 "url": f"test.example.br/gh/{repository.slug}/commit/{base_commit.commitid}",
-                "timestamp": "2019-02-01T17:59:47",
+                "timestamp": "2019-02-01T17:59:47+00:00",
                 "totals": {
                     "files": 2,
                     "lines": 6,
@@ -468,7 +468,7 @@ class TestWebhookNotifier(object):
                     "name": head_commit.author.name,
                 },
                 "url": f"test.example.br/gh/{repository.slug}/commit/{head_commit.commitid}",
-                "timestamp": "2019-02-01T17:59:47",
+                "timestamp": "2019-02-01T17:59:47+00:00",
                 "totals": {
                     "files": 2,
                     "lines": 10,
@@ -498,7 +498,7 @@ class TestWebhookNotifier(object):
                     "name": base_commit.author.name,
                 },
                 "url": f"test.example.br/gh/{repository.slug}/commit/{base_commit.commitid}",
-                "timestamp": "2019-02-01T17:59:47",
+                "timestamp": "2019-02-01T17:59:47+00:00",
                 "totals": {
                     "files": 2,
                     "lines": 6,
@@ -581,7 +581,7 @@ class TestWebhookNotifier(object):
                     "name": head_commit.author.name,
                 },
                 "url": f"test.example.br/gh/{repository.slug}/commit/{head_commit.commitid}",
-                "timestamp": "2019-02-01T17:59:47",
+                "timestamp": "2019-02-01T17:59:47+00:00",
                 "totals": {
                     "files": 2,
                     "lines": 10,
@@ -611,7 +611,7 @@ class TestWebhookNotifier(object):
                     "name": base_commit.author.name,
                 },
                 "url": f"test.example.br/gh/{repository.slug}/commit/{base_commit.commitid}",
-                "timestamp": "2019-02-01T17:59:47",
+                "timestamp": "2019-02-01T17:59:47+00:00",
                 "totals": None,
                 "commitid": base_commit.commitid,
                 "service_url": f"https://github.com/{repository.slug}/commit/{base_commit.commitid}",
@@ -686,7 +686,7 @@ class TestWebhookNotifier(object):
                     "name": head_commit.author.name,
                 },
                 "url": f"test.example.br/gh/{repository.slug}/commit/{head_commit.commitid}",
-                "timestamp": "2019-02-01T17:59:47",
+                "timestamp": "2019-02-01T17:59:47+00:00",
                 "totals": {
                     "files": 2,
                     "lines": 10,

--- a/services/notification/tests/unit/test_commit_notifications.py
+++ b/services/notification/tests/unit/test_commit_notifications.py
@@ -86,7 +86,7 @@ class TestCommitNotificationsServiceTestCase(object):
     ):
         comparison.enriched_pull = None
         commit = comparison.head.commit
-        app = GithubAppInstallation(owner=commit.repository.owner)
+        app = GithubAppInstallation(owner=commit.repository.owner, installation_id=1234)
         dbsession.add(app)
         dbsession.flush()
         notifier = CommentNotifier(

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from database.tests.factories import OwnerFactory
-from services.billing import is_pr_billing_plan
+from services.billing import BillingPlan, is_pr_billing_plan
 
 
 class TestBillingServiceTestCase(object):
@@ -34,7 +34,9 @@ class TestBillingServiceTestCase(object):
     def test_plan_not_pr_author(
         self, request, dbsession, mocker, mock_configuration, with_sql_functions
     ):
-        owner = OwnerFactory.create(service="github")
+        owner = OwnerFactory.create(
+            service="github", plan=BillingPlan.users_monthly.value
+        )
         dbsession.add(owner)
         dbsession.flush()
 

--- a/services/yaml/tests/test_yaml.py
+++ b/services/yaml/tests/test_yaml.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timezone
 
 import mock
 import pytest
@@ -264,6 +265,8 @@ class TestYamlService(BaseTestCase):
             get_source=mock.AsyncMock(return_value=contents_result_future),
         )
         commit = CommitFactory.create(
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
             repository__yaml={
                 "coverage": {
                     "precision": 2,
@@ -271,7 +274,7 @@ class TestYamlService(BaseTestCase):
                     "range": [70.0, 100.0],
                     "status": {"project": True, "patch": True, "changes": False},
                 }
-            }
+            },
         )
 
         dbsession.add(commit)
@@ -319,6 +322,8 @@ class TestYamlService(BaseTestCase):
             )
         )
         commit = CommitFactory.create(
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
             repository__yaml={
                 "coverage": {
                     "precision": 2,
@@ -326,7 +331,7 @@ class TestYamlService(BaseTestCase):
                     "range": [70.0, 100.0],
                     "status": {"project": True, "patch": True, "changes": False},
                 }
-            }
+            },
         )
         dbsession.add(commit)
         res = await get_current_yaml(commit, valid_handler)
@@ -369,6 +374,8 @@ class TestYamlService(BaseTestCase):
             )
         )
         commit = CommitFactory.create(
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
             repository__yaml={
                 "coverage": {
                     "precision": 2,
@@ -376,7 +383,7 @@ class TestYamlService(BaseTestCase):
                     "range": [70.0, 100.0],
                     "status": {"project": True, "patch": True, "changes": False},
                 }
-            }
+            },
         )
         dbsession.add(commit)
         res = await get_current_yaml(commit, valid_handler)

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -826,6 +826,9 @@ class TestNotifyTask(object):
         )
         dbsession.add(repository)
         dbsession.flush()
+        repository.owner.plan_activated_users = [repository.owner.ownerid]
+        dbsession.add(repository)
+        dbsession.flush()
         head_commitid = "5601846871b8142ab0df1e0b8774756c658bcc7d"
         master_sha = "5b174c2b40d501a70c479e91025d5109b1ad5c1b"
         master_commit = CommitFactory.create(

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -110,7 +110,7 @@ class TestNotifyTask(object):
                                     "branch": "test-branch-1",
                                     "message": "",
                                     "author": "christina84",
-                                    "timestamp": "2019-02-01T17:59:47",
+                                    "timestamp": "2019-02-01T17:59:47+00:00",
                                     "ci_passed": True,
                                     "totals": {
                                         "C": 0,
@@ -252,7 +252,7 @@ class TestNotifyTask(object):
                                     "branch": "test-branch-1",
                                     "message": "",
                                     "author": "bateslouis",
-                                    "timestamp": "2019-02-01T17:59:47",
+                                    "timestamp": "2019-02-01T17:59:47+00:00",
                                     "ci_passed": True,
                                     "totals": {
                                         "C": 0,
@@ -290,7 +290,7 @@ class TestNotifyTask(object):
                                     "branch": "master",
                                     "message": "",
                                     "author": "bateslouis",
-                                    "timestamp": "2019-02-01T17:59:47",
+                                    "timestamp": "2019-02-01T17:59:47+00:00",
                                     "ci_passed": True,
                                     "totals": {
                                         "C": 0,
@@ -490,7 +490,7 @@ class TestNotifyTask(object):
                                     "branch": "test-branch-1",
                                     "message": "",
                                     "author": "rolabuhasna",
-                                    "timestamp": "2019-02-01T17:59:47",
+                                    "timestamp": "2019-02-01T17:59:47+00:00",
                                     "ci_passed": True,
                                     "totals": {
                                         "C": 0,
@@ -528,7 +528,7 @@ class TestNotifyTask(object):
                                     "branch": "master",
                                     "message": "",
                                     "author": "bateslouis",
-                                    "timestamp": "2019-02-01T17:59:47",
+                                    "timestamp": "2019-02-01T17:59:47+00:00",
                                     "ci_passed": True,
                                     "totals": {
                                         "C": 0,
@@ -717,7 +717,7 @@ class TestNotifyTask(object):
                                     "branch": "thiago/base-no-base",
                                     "message": "",
                                     "author": "rolabuhasna",
-                                    "timestamp": "2019-02-01T17:59:47",
+                                    "timestamp": "2019-02-01T17:59:47+00:00",
                                     "ci_passed": True,
                                     "totals": {
                                         "C": 0,
@@ -755,7 +755,7 @@ class TestNotifyTask(object):
                                     "branch": "master",
                                     "message": "",
                                     "author": "bateslouis",
-                                    "timestamp": "2019-02-01T17:59:47",
+                                    "timestamp": "2019-02-01T17:59:47+00:00",
                                     "ci_passed": True,
                                     "totals": {
                                         "C": 0,
@@ -799,6 +799,7 @@ class TestNotifyTask(object):
         assert result == expected_result
 
     @patch("requests.post")
+    @pytest.mark.django_db
     def test_simple_call_status_and_notifiers(
         self,
         mock_post_request,
@@ -917,7 +918,7 @@ class TestNotifyTask(object):
                             "head": {
                                 "author": expected_author_dict,
                                 "url": "https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/commit/5601846871b8142ab0df1e0b8774756c658bcc7d",
-                                "timestamp": "2019-02-01T17:59:47",
+                                "timestamp": "2019-02-01T17:59:47+00:00",
                                 "totals": {
                                     "files": 3,
                                     "lines": 20,
@@ -955,7 +956,7 @@ class TestNotifyTask(object):
                             "base": {
                                 "author": expected_author_dict,
                                 "url": "https://myexamplewebsite.io/gh/joseph-sentry/codecov-demo/commit/5b174c2b40d501a70c479e91025d5109b1ad5c1b",
-                                "timestamp": "2019-02-01T17:59:47",
+                                "timestamp": "2019-02-01T17:59:47+00:00",
                                 "totals": {
                                     "files": 3,
                                     "lines": 20,
@@ -1100,7 +1101,7 @@ class TestNotifyTask(object):
                                     "branch": "test",
                                     "message": "",
                                     "author": "joseph-sentry",
-                                    "timestamp": "2019-02-01T17:59:47",
+                                    "timestamp": "2019-02-01T17:59:47+00:00",
                                     "ci_passed": True,
                                     "totals": {
                                         "C": 0,
@@ -1138,7 +1139,7 @@ class TestNotifyTask(object):
                                     "branch": "main",
                                     "message": "",
                                     "author": "joseph-sentry",
-                                    "timestamp": "2019-02-01T17:59:47",
+                                    "timestamp": "2019-02-01T17:59:47+00:00",
                                     "ci_passed": True,
                                     "totals": {
                                         "C": 0,
@@ -1358,14 +1359,13 @@ class TestNotifyTask(object):
         dbsession.add(commit)
         dbsession.add(master_commit)
         dbsession.flush()
-        pull = PullFactory.create(
-            repository=repository,
-            pullid=1234,
-            head=commit.commitid,
-            base=master_commit.commitid,
-        )
+        pull = dbsession.query(Pull).filter_by(pullid=1234).first()
+        pull.repository = repository
+        pull.head = commit.commitid
+        pull.base = master_commit.commitid
         dbsession.add(pull)
         dbsession.flush()
+
         task = NotifyTask()
         with open("tasks/tests/samples/sample_chunks_1.txt") as f:
             content = f.read().encode()

--- a/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -452,7 +452,7 @@ def test_bundle_analysis_process_associate_no_parent_commit_id(
         },
     )
 
-    parent_commit = CommitFactory.create(state="completed")
+    parent_commit = CommitFactory.create(state="complete")
     dbsession.add(parent_commit)
     dbsession.flush()
 
@@ -505,7 +505,7 @@ def test_bundle_analysis_process_associate_no_parent_commit_object(
         },
     )
 
-    parent_commit = CommitFactory.create(state="completed")
+    parent_commit = CommitFactory.create(state="complete")
 
     commit = CommitFactory.create(
         state="pending", parent_commit_id=parent_commit.commitid
@@ -558,7 +558,7 @@ def test_bundle_analysis_process_associate_no_parent_commit_report_object(
         },
     )
 
-    parent_commit = CommitFactory.create(state="completed")
+    parent_commit = CommitFactory.create(state="complete")
     dbsession.add(parent_commit)
     dbsession.flush()
 
@@ -615,7 +615,7 @@ def test_bundle_analysis_process_associate_called(
         },
     )
 
-    parent_commit = CommitFactory.create(state="completed")
+    parent_commit = CommitFactory.create(state="complete")
     dbsession.add(parent_commit)
     dbsession.flush()
 
@@ -679,7 +679,7 @@ def test_bundle_analysis_process_associate_called_two(
         },
     )
 
-    parent_commit = CommitFactory.create(state="completed")
+    parent_commit = CommitFactory.create(state="complete")
     dbsession.add(parent_commit)
     dbsession.flush()
 
@@ -754,7 +754,7 @@ def test_bundle_analysis_processor_associate_custom_compare_sha(
         },
     )
 
-    parent_commit = CommitFactory.create(state="completed")
+    parent_commit = CommitFactory.create(state="complete")
     dbsession.add(parent_commit)
     dbsession.flush()
 

--- a/tasks/tests/unit/test_delete_owner.py
+++ b/tasks/tests/unit/test_delete_owner.py
@@ -147,10 +147,10 @@ class TestDeleteOwnerTaskUnit(object):
     def test_delete_owner_from_orgs_removes_ownerid_from_organizations_of_related_owners(
         self, mocker, mock_configuration, mock_storage, dbsession
     ):
-        org_ownerid = 123
-
-        org = OwnerFactory.create(ownerid=org_ownerid, service_id="9000")
+        org = OwnerFactory.create(service_id="9000")
         dbsession.add(org)
+        dbsession.flush()
+        org_ownerid = org.ownerid
 
         user_1 = OwnerFactory.create(
             ownerid=1001, service_id="9001", organizations=[org_ownerid]
@@ -201,9 +201,7 @@ class TestDeleteOwnerTaskUnit(object):
     def test_delete_owner_timeout(
         self, mocker, mock_configuration, mock_storage, dbsession
     ):
-        org_ownerid = 123
-
-        org = OwnerFactory.create(ownerid=org_ownerid, service_id="9000")
+        org = OwnerFactory.create(service_id="9000")
         dbsession.add(org)
 
         dbsession.flush()
@@ -211,4 +209,4 @@ class TestDeleteOwnerTaskUnit(object):
             DeleteOwnerTask, "delete_repo_archives", side_effect=SoftTimeLimitExceeded()
         )
         with pytest.raises(Retry):
-            DeleteOwnerTask().run_impl(dbsession, org_ownerid)
+            DeleteOwnerTask().run_impl(dbsession, org.ownerid)

--- a/tasks/tests/unit/test_ghm_sync_plans.py
+++ b/tasks/tests/unit/test_ghm_sync_plans.py
@@ -30,8 +30,6 @@ class TestGHMarketplaceSyncPlansTaskUnit(object):
         assert owner.plan == BillingPlan.users_basic.value
         assert owner.plan_user_count == 1
         assert owner.plan_activated_users is None
-        # Owner was already created, we don't update this value
-        assert owner.createstamp is None
 
         dbsession.commit()
         # their repos should also be deactivated
@@ -69,12 +67,12 @@ class TestGHMarketplaceSyncPlansTaskUnit(object):
         assert owner.username == username
         assert owner.name == name
         assert owner.email == email
-        assert owner.createstamp.isoformat() == "2024-03-28T00:00:00"
+        assert owner.createstamp.isoformat() == "2024-03-28T00:00:00+00:00"
 
     def test_create_or_update_plan_known_user_with_plan(self, dbsession, mocker):
         owner = OwnerFactory.create(
             service="github",
-            plan="some-plan",
+            plan="users-basic",
             plan_user_count=10,
             plan_activated_users=[34123, 231, 2314212],
             stripe_customer_id="cus_123",

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, call
 
@@ -272,8 +273,12 @@ class TestNotifyTaskHelpers(object):
         self, cached_id, app_to_save, mocker, dbsession
     ):
         commit = CommitFactory(repository__owner__service="github")
-        app = GithubAppInstallation(id_=12, owner=commit.repository.owner)
-        other_app = GithubAppInstallation(id_=24, owner=commit.repository.owner)
+        app = GithubAppInstallation(
+            id_=12, owner=commit.repository.owner, installation_id=123
+        )
+        other_app = GithubAppInstallation(
+            id_=24, owner=commit.repository.owner, installation_id=123
+        )
         commit_notifications = [
             CommitNotification(
                 commit=commit,
@@ -453,6 +458,8 @@ class TestNotifyTask(object):
             pullid=None,
             branch="test-branch-1",
             commitid="649eaaf2924e92dc7fd8d370ddb857033231e67a",
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         mocked_fetch_yaml = mocker.patch(
             "services.yaml.fetch_commit_yaml_from_provider"

--- a/tasks/tests/unit/test_process_flakes.py
+++ b/tasks/tests/unit/test_process_flakes.py
@@ -65,7 +65,7 @@ class RepoSimulator:
                 "flaky_fail_count": 0,
                 "avg_duration_seconds": 0.0,
                 "last_duration_seconds": 0.0,
-                "latest_run": dt.datetime.now(),
+                "latest_run": dt.datetime.now(tz=dt.timezone.utc),
                 "commits_where_fail": [],
             },
         )
@@ -270,7 +270,7 @@ def test_it_creates_flakes_from_orig_branch(transactional_db):
     assert len(Flake.objects.all()) == 1
     assert Flake.objects.first().count == 1
     assert Flake.objects.first().fail_count == 1
-    assert Flake.objects.first().start_date == dt.datetime.now(dt.UTC)
+    assert Flake.objects.first().start_date == dt.datetime.now(tz=dt.UTC)
 
 
 @time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
@@ -471,7 +471,7 @@ def test_it_creates_rollups(transactional_db):
             branch=rs.repo.branch,
         )
 
-        rollups = DailyTestRollup.objects.all()
+        rollups = DailyTestRollup.objects.all().order_by("date")
 
         assert len(rollups) == 4
 

--- a/tasks/tests/unit/test_sync_repos_task.py
+++ b/tasks/tests/unit/test_sync_repos_task.py
@@ -70,7 +70,7 @@ class TestSyncReposTaskUnit(object):
         )
         assert new_entry is not None
         assert new_entry.username == username
-        assert new_entry.createstamp.isoformat() == "2024-03-28T00:00:00"
+        assert new_entry.createstamp.isoformat() == "2024-03-28T00:00:00+00:00"
 
     def test_upsert_owner_update_existing(self, dbsession):
         ownerid = 1

--- a/tasks/tests/unit/test_sync_teams_task.py
+++ b/tasks/tests/unit/test_sync_teams_task.py
@@ -133,6 +133,6 @@ class TestSyncTeamsTaskUnit(object):
             expected_data = expected_groups.get(service_id, {})
             assert g.username == expected_data.get("username")
             assert g.name == expected_data["name"]
-            assert g.createstamp.isoformat() == "2024-03-28T00:00:00"
+            assert g.createstamp.isoformat() == "2024-03-28T00:00:00+00:00"
             if expected_data["parent_service_id"]:
                 assert g.parent_service_id == expected_data["parent_service_id"]

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -694,10 +694,10 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             ]
 
             assert [r.latest_run for r in rollups] == [
-                datetime(1970, 1, 1, 0, 0),
-                datetime(1970, 1, 1, 0, 0),
-                datetime(1970, 1, 2, 0, 0),
-                datetime(1970, 1, 2, 0, 0),
+                datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
+                datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
+                datetime(1970, 1, 2, 0, 0, tzinfo=timezone.utc),
+                datetime(1970, 1, 2, 0, 0, tzinfo=timezone.utc),
             ]
             assert [r.avg_duration_seconds for r in rollups] == [
                 7.2,

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta, timezone
+from itertools import chain
 from pathlib import Path
 
 import pytest
@@ -663,54 +664,61 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
                 }
             ]
 
-            rollups: list[DailyTestRollup] = dbsession.query(DailyTestRollup).all()
-
             assert result == expected_result
 
-            assert [r.branch for r in rollups] == [
-                "first_branch",
-                "first_branch",
-                "second_branch",
-                "second_branch",
-            ]
+            rollups_first_branch: list[DailyTestRollup] = (
+                dbsession.query(DailyTestRollup).filter_by(branch="first_branch").all()
+            )
 
-            assert [r.date for r in rollups] == [
-                date.today() - timedelta(days=1),
-                date.today() - timedelta(days=1),
-                date.today(),
-                date.today(),
-            ]
-
-            assert [r.fail_count for r in rollups] == [0, 1, 1, 0]
-            assert [r.pass_count for r in rollups] == [1, 1, 0, 2]
-            assert [r.skip_count for r in rollups] == [0, 0, 0, 0]
-            assert [r.flaky_fail_count for r in rollups] == [0, 0, 1, 0]
-
-            assert [r.commits_where_fail for r in rollups] == [
-                [],
-                ["cd76b0821854a780b60012aed85af0a8263004ad"],
-                ["bd76b0821854a780b60012aed85af0a8263004ad"],
-                [],
-            ]
-
-            assert [r.latest_run for r in rollups] == [
-                datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
-                datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc),
-                datetime(1970, 1, 2, 0, 0, tzinfo=timezone.utc),
-                datetime(1970, 1, 2, 0, 0, tzinfo=timezone.utc),
-            ]
-            assert [r.avg_duration_seconds for r in rollups] == [
+            assert set(r.date for r in rollups_first_branch) == {
+                date.today() - timedelta(days=1)
+            }
+            assert set(r.fail_count for r in rollups_first_branch) == {0, 1}
+            assert set(r.pass_count for r in rollups_first_branch) == {1}
+            assert set(r.skip_count for r in rollups_first_branch) == {0}
+            assert set(r.flaky_fail_count for r in rollups_first_branch) == {0}
+            assert set(
+                chain.from_iterable(r.commits_where_fail for r in rollups_first_branch)
+            ) == {
+                "cd76b0821854a780b60012aed85af0a8263004ad",
+            }
+            assert set(r.latest_run for r in rollups_first_branch) == {
+                datetime(1970, 1, 1, 0, 0, tzinfo=timezone.utc)
+            }
+            assert set(r.avg_duration_seconds for r in rollups_first_branch) == {
                 7.2,
                 0.001,
-                3.6,
-                0.002,
-            ]
-            assert [r.last_duration_seconds for r in rollups] == [
+            }
+            assert set(r.last_duration_seconds for r in rollups_first_branch) == {
                 7.2,
                 0.001,
+            }
+
+            rollups_second_branch: list[DailyTestRollup] = (
+                dbsession.query(DailyTestRollup).filter_by(branch="second_branch").all()
+            )
+
+            assert set(r.date for r in rollups_second_branch) == {date.today()}
+            assert set(r.fail_count for r in rollups_second_branch) == {0, 1}
+            assert set(r.pass_count for r in rollups_second_branch) == {0, 2}
+            assert set(r.skip_count for r in rollups_second_branch) == {0}
+            assert set(r.flaky_fail_count for r in rollups_second_branch) == {0, 1}
+            assert set(
+                chain.from_iterable(r.commits_where_fail for r in rollups_second_branch)
+            ) == {
+                "bd76b0821854a780b60012aed85af0a8263004ad",
+            }
+            assert set(r.latest_run for r in rollups_second_branch) == {
+                datetime(1970, 1, 2, 0, 0, tzinfo=timezone.utc)
+            }
+            assert set(r.avg_duration_seconds for r in rollups_second_branch) == {
                 3.6,
                 0.002,
-            ]
+            }
+            assert set(r.last_duration_seconds for r in rollups_second_branch) == {
+                3.6,
+                0.002,
+            }
 
     @pytest.mark.integration
     @pytest.mark.parametrize(

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -1,6 +1,6 @@
 import json
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -143,6 +143,8 @@ class TestUploadTaskIntegration(object):
             repository__yaml={"codecov": {"max_report_age": "1y ago"}},
             repository__name="example-python",
             pullid=1,
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -195,7 +197,6 @@ class TestUploadTaskIntegration(object):
         kwargs[_kwargs_key(UploadFlow)] = mocker.ANY
         finisher = upload_finisher_task.signature(kwargs=kwargs)
         mocked_chord.assert_called_with([processor], finisher)
-
         calls = [
             mock.call(
                 "time_before_processing",
@@ -237,6 +238,8 @@ class TestUploadTaskIntegration(object):
             repository__yaml={"codecov": {"max_report_age": "1y ago"}},
             repository__name="example-python",
             pullid=1,
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -301,6 +304,8 @@ class TestUploadTaskIntegration(object):
             repository__yaml={"codecov": {"max_report_age": "1y ago"}},
             repository__name="example-python",
             pullid=1,
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -364,6 +369,8 @@ class TestUploadTaskIntegration(object):
             repository__yaml={"codecov": {"max_report_age": "1y ago"}},
             repository__name="example-python",
             pullid=1,
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -617,6 +624,8 @@ class TestUploadTaskIntegration(object):
             repository__yaml={"codecov": {"max_report_age": "1y ago"}},
             repository__name="example-python",
             pullid=1,
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -687,6 +696,8 @@ class TestUploadTaskIntegration(object):
             service="github",
             username="ThiagoCodecov",
             unencrypted_oauth_token="test76zow6xgh7modd88noxr245j2z25t4ustoff",
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         dbsession.add(owner)
 
@@ -761,6 +772,8 @@ class TestUploadTaskIntegration(object):
             repository__owner__username="ThiagoCodecov",
             repository__yaml={"codecov": {"max_report_age": "764y ago"}},
             repository__name="example-python",
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -826,6 +839,8 @@ class TestUploadTaskIntegration(object):
             repository__owner__username="ThiagoCodecov",
             repository__yaml={"codecov": {"max_report_age": "764y ago"}},
             repository__name="example-python",
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         dbsession.add(commit)
         dbsession.flush()
@@ -890,6 +905,8 @@ class TestUploadTaskIntegration(object):
             repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
             repository__owner__username="ThiagoCodecov",
             repository__yaml={"codecov": {"max_report_age": "764y ago"}},
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         mock_repo_provider.data = dict(repo=dict(repoid=commit.repoid))
         dbsession.add(commit)
@@ -973,6 +990,8 @@ class TestUploadTaskIntegration(object):
             repository__owner__unencrypted_oauth_token="test7lk5ndmtqzxlx06rip65nac9c7epqopclnoy",
             repository__owner__username="ThiagoCodecov",
             repository__yaml={"codecov": {"max_report_age": "764y ago"}},
+            # Setting the time to _before_ patch centric default YAMLs start date of 2024-04-30
+            repository__owner__createstamp=datetime(2023, 1, 1, tzinfo=timezone.utc),
         )
         report = CommitReport(commit_id=commit.id_)
         upload = Upload(
@@ -980,7 +999,7 @@ class TestUploadTaskIntegration(object):
             build_code="part1",
             build_url="build_url",
             env=None,
-            report_id=report.id_,
+            report=report,
             job_code="job",
             name="name",
             provider="service",


### PR DESCRIPTION
This ensures that the table that the models run on are the Django models, rather than the slightly less accurate SQLAlchemy models. 

The first 3 commits are related to getting the SQLAlchemy tables created with Django migrations. I've decided to keep the databases for each test separate (because Django transactions tests won't work properly with a persistently open SQLAlchemy DB connection). 

Some of the common fixes to the tests:
* add timezones
* set `created_at` timestamp for `owner` table to be before the patch centric YAML change (the default DB behaviour is to set that time to now, which breaks old legacy tests that check YAML)
* fix issues with missing not-null fields or unique references

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.