### PR TITLE
Fix `flags` being a `list` in TestResults arguments

### DIFF
--- a/services/test_results.py
+++ b/services/test_results.py
@@ -55,7 +55,7 @@ class TestResultsReportService(BaseReportService):
         self, normalized_arguments: Mapping[str, str], commit_report: CommitReport
     ) -> Upload:
         upload = super().create_report_upload(normalized_arguments, commit_report)
-        flags = normalized_arguments.get("flags", "").split(",")
+        flags = normalized_arguments.get("flags") or []
         self._attach_flags_to_upload(upload, flags)
         return upload
 


### PR DESCRIPTION
This fixes a regression from https://github.com/codecov/worker/pull/718:

Seems like `flags` is a comma-separated string in all upload types except `TestResults`, where it is already a list.

Fixes [ECDN-WORKER-D7C](https://codecov.sentry.io/issues/5879541242/), fixes [WORKER-PBY](https://codecov.sentry.io/issues/5879476288/)