### PR TITLE
lcov Branches should override Lines

### DIFF
--- a/services/report/languages/lcov.py
+++ b/services/report/languages/lcov.py
@@ -180,7 +180,8 @@ def _process_file(
             coverage_type,
             missing_branches=(missing_branches if missing_branches != [] else None),
         )
-        _file.append(ln, _line)
+        # instead of using `.append`/merge, this rather overwrites the line:
+        _file[ln] = _line
 
     return _file
 

--- a/services/report/languages/tests/unit/test_lcov.py
+++ b/services/report/languages/tests/unit/test_lcov.py
@@ -195,3 +195,23 @@ class TestLcov(BaseTestCase):
                 (1, 1, None, [[0, 1, None, None, None]], None, None),
             ]
         }
+
+    def test_regression_partial_branch(self):
+        # See https://github.com/codecov/feedback/issues/513
+        text = b"""
+SF:foo.c
+DA:1047,731835
+BRDA:1047,0,0,0
+BRDA:1047,0,1,1
+end_of_record
+"""
+        report_builder_session = create_report_builder_session()
+        lcov.from_txt(text, report_builder_session)
+        report = report_builder_session.output_report()
+        processed_report = self.convert_report_to_better_readable(report)
+
+        assert processed_report["archive"] == {
+            "foo.c": [
+                (1047, "1/2", "b", [[0, "1/2", ["0:0"], None, None]], None, None),
+            ]
+        }


### PR DESCRIPTION
The `append/merge` operation on lines does not work properly when merging a covered line with a partial branch.

Therefore, prefer the branch coverage by overwriting any existing line records.

---

This was a regression from https://github.com/codecov/worker/pull/684 and fixes https://github.com/codecov/feedback/issues/513