### PR TITLE
Clean up some carry-forward related code

### DIFF
--- a/helpers/labels.py
+++ b/helpers/labels.py
@@ -1,7 +1,5 @@
 from enum import Enum
-from typing import Set, Union
 
-import sentry_sdk
 from shared.reports.resources import Report
 
 # The SpecialLabelsEnum enum is place to hold sentinels for labels with special
@@ -33,46 +31,43 @@ class SpecialLabelsEnum(Enum):
         self.corresponding_index = index
 
 
-@sentry_sdk.trace
-def get_labels_per_session(report: Report, sess_id: int) -> Union[Set[str], Set[int]]:
+def get_labels_per_session(report: Report, sess_id: int) -> set[str | int]:
     """Returns a Set with the labels present in a session from report, EXCLUDING the SpecialLabel.
 
     The return value can either be a set of strings (the labels themselves) OR
     a set of ints (the label indexes). The label can be looked up from the index
     using Report.lookup_label_by_id(label_id) (assuming Report._labels_idx is set)
     """
-    all_labels = set()
-    for rf in report:
-        for _, line in rf.lines:
+    all_labels: set[str | int] = set()
+
+    for file in report:
+        for _, line in file.lines:
             if line.datapoints:
                 for datapoint in line.datapoints:
                     if datapoint.sessionid == sess_id:
                         all_labels.update(datapoint.label_ids or [])
-    return all_labels - set(
-        [
-            SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
-            SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_index,
-        ]
-    )
+
+    return all_labels - {
+        SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+        SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_index,
+    }
 
 
-@sentry_sdk.trace
-def get_all_report_labels(report: Report) -> Union[Set[str], Set[int]]:
+def get_all_report_labels(report: Report) -> set[str | int]:
     """Returns a Set with the labels present in report EXCLUDING the SpecialLabel.
 
     The return value can either be a set of strings (the labels themselves) OR
     a set of ints (the label indexes). The label can be looked up from the index
     using Report.lookup_label_by_id(label_id) (assuming Report._labels_idx is set)
     """
-    all_labels = set()
-    for rf in report:
-        for _, line in rf.lines:
+    all_labels: set[str | int] = set()
+    for file in report:
+        for _, line in file.lines:
             if line.datapoints:
                 for datapoint in line.datapoints:
                     all_labels.update(datapoint.label_ids or [])
-    return all_labels - set(
-        [
-            SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
-            SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_index,
-        ]
-    )
+
+    return all_labels - {
+        SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_label,
+        SpecialLabelsEnum.CODECOV_ALL_LABELS_PLACEHOLDER.corresponding_index,
+    }

--- a/services/path_fixer/tests/unit/test_path_fixer.py
+++ b/services/path_fixer/tests/unit/test_path_fixer.py
@@ -107,9 +107,6 @@ class TestBasePathAwarePathFixer(object):
         assert base_aware_pf("sample/path.c") == "path.c"
         assert base_aware_pf("another/path.py") == "another/path.py"
         assert base_aware_pf("/another/path.py") == "another/path.py"
-        assert len(base_aware_pf.unexpected_results) == 0
-        assert base_aware_pf.log_abnormalities() is False
-        assert not base_aware_pf.log_abnormalities()
 
     def test_basepath_uses_own_result_if_main_is_none(self):
         toc = ["project/__init__.py", "tests/__init__.py", "tests/test_project.py"]
@@ -118,13 +115,6 @@ class TestBasePathAwarePathFixer(object):
         base_aware_pf = pf.get_relative_path_aware_pathfixer(base_path)
         assert pf("__init__.py") is None
         assert base_aware_pf("__init__.py") == "project/__init__.py"
-        assert base_aware_pf.log_abnormalities()
-        assert len(base_aware_pf.unexpected_results) == 1
-        assert base_aware_pf.unexpected_results.pop() == {
-            "original_path": "__init__.py",
-            "original_path_fixer_result": None,
-            "base_path_aware_result": "project/__init__.py",
-        }
 
     def test_basepath_uses_own_result_if_main_is_none_multuple_base_paths(self):
         toc = ["project/__init__.py", "tests/__init__.py", "tests/test_project.py"]
@@ -137,9 +127,3 @@ class TestBasePathAwarePathFixer(object):
             base_aware_pf("__init__.py", bases_to_try=["/home/travis/build/project"])
             == "project/__init__.py"
         )
-        assert base_aware_pf.log_abnormalities()
-        assert base_aware_pf.unexpected_results.pop() == {
-            "original_path": "__init__.py",
-            "original_path_fixer_result": None,
-            "base_path_aware_result": "project/__init__.py",
-        }

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -466,12 +466,9 @@ class ReportService(BaseReportService):
                     # sess is an encoded dict
                     if sess.get("st") == "carriedforward":
                         report_class = EditableReport
-        with metrics.timer(
-            f"services.report.ReportService.build_report.{report_class.__name__}"
-        ):
-            return report_class.from_chunks(
-                chunks=chunks, files=files, sessions=sessions, totals=totals
-            )
+        return report_class.from_chunks(
+            chunks=chunks, files=files, sessions=sessions, totals=totals
+        )
 
     def get_archive_service(self, repository: Repository) -> ArchiveService:
         return ArchiveService(repository)

--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -168,7 +168,7 @@ def process_raw_upload(
     )
     # Adjust sessions removed carryforward sessions that are being replaced
     if session.flags:
-        session_adjustment = _adjust_sessions(
+        session_adjustment = clear_carryforward_sessions(
             report, temporary_report, session.flags, commit_yaml, upload
         )
     else:
@@ -284,7 +284,7 @@ def make_sure_label_indexes_match(
 
 
 @sentry_sdk.trace
-def _adjust_sessions(
+def clear_carryforward_sessions(
     original_report: Report,
     to_merge_report: Report,
     to_merge_flags: list[str],

--- a/services/report/tests/unit/test_sessions.py
+++ b/services/report/tests/unit/test_sessions.py
@@ -223,7 +223,7 @@ class TestAdjustSession(BaseTestCase):
         second_report = Report(sessions={3: first_to_merge_session})
         current_yaml = UserYaml({})
         assert _adjust_sessions(
-            sample_first_report, second_report, first_to_merge_session, current_yaml
+            sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([], [])
         assert first_value == self.convert_report_to_better_readable(
             sample_first_report
@@ -240,7 +240,7 @@ class TestAdjustSession(BaseTestCase):
             }
         )
         assert _adjust_sessions(
-            sample_first_report, second_report, first_to_merge_session, current_yaml
+            sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([0], [])
         print(self.convert_report_to_better_readable(sample_first_report))
         assert self.convert_report_to_better_readable(sample_first_report) == {
@@ -436,7 +436,7 @@ class TestAdjustSession(BaseTestCase):
         )
         first_value = self.convert_report_to_better_readable(sample_first_report)
         assert _adjust_sessions(
-            sample_first_report, second_report, first_to_merge_session, current_yaml
+            sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([], [0])
         after_result = self.convert_report_to_better_readable(sample_first_report)
         assert after_result == first_value
@@ -486,7 +486,7 @@ class TestAdjustSession(BaseTestCase):
         assert _adjust_sessions(
             sample_first_report,
             second_report,
-            first_to_merge_session,
+            ["enterprise"],
             current_yaml,
             upload=upload,
         ) == SessionAdjustmentResult([], [0])
@@ -520,7 +520,7 @@ class TestAdjustSession(BaseTestCase):
         )
         second_report.append(second_report_file)
         assert _adjust_sessions(
-            sample_first_report, second_report, first_to_merge_session, current_yaml
+            sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([], [0])
         print(self.convert_report_to_better_readable(sample_first_report))
         assert self.convert_report_to_better_readable(sample_first_report) == {
@@ -767,7 +767,7 @@ class TestAdjustSession(BaseTestCase):
         second_report.append(second_report_file)
         second_report.append(a_report_file)
         assert _adjust_sessions(
-            sample_first_report, second_report, first_to_merge_session, current_yaml
+            sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([0], [])
         res = self.convert_report_to_better_readable(sample_first_report)
         # print(res["report"]["sessions"])

--- a/services/report/tests/unit/test_sessions.py
+++ b/services/report/tests/unit/test_sessions.py
@@ -16,7 +16,7 @@ from helpers.labels import SpecialLabelsEnum
 from rollouts import USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID
 from services.report.raw_upload_processor import (
     SessionAdjustmentResult,
-    _adjust_sessions,
+    clear_carryforward_sessions,
 )
 from test_utils.base import BaseTestCase
 
@@ -222,7 +222,7 @@ class TestAdjustSession(BaseTestCase):
         first_to_merge_session = Session(flags=["enterprise"], id=3)
         second_report = Report(sessions={3: first_to_merge_session})
         current_yaml = UserYaml({})
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([], [])
         assert first_value == self.convert_report_to_better_readable(
@@ -239,7 +239,7 @@ class TestAdjustSession(BaseTestCase):
                 }
             }
         )
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([0], [])
         print(self.convert_report_to_better_readable(sample_first_report))
@@ -435,7 +435,7 @@ class TestAdjustSession(BaseTestCase):
             }
         )
         first_value = self.convert_report_to_better_readable(sample_first_report)
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([], [0])
         after_result = self.convert_report_to_better_readable(sample_first_report)
@@ -483,7 +483,7 @@ class TestAdjustSession(BaseTestCase):
                 )
             },
         )
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             sample_first_report,
             second_report,
             ["enterprise"],
@@ -519,7 +519,7 @@ class TestAdjustSession(BaseTestCase):
             ),
         )
         second_report.append(second_report_file)
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([], [0])
         print(self.convert_report_to_better_readable(sample_first_report))
@@ -766,7 +766,7 @@ class TestAdjustSession(BaseTestCase):
         )
         second_report.append(second_report_file)
         second_report.append(a_report_file)
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([0], [])
         res = self.convert_report_to_better_readable(sample_first_report)

--- a/services/report/tests/unit/test_sessions_encoded_labels.py
+++ b/services/report/tests/unit/test_sessions_encoded_labels.py
@@ -73,7 +73,7 @@ class TestAdjustSession(BaseTestCase):
         second_file = EditableReportFile("second_file.py")
         first_report.append(first_file)
         first_report.append(second_file)
-        # print(self.convert_report_to_better_readable(first_report)["archive"])
+
         assert self.convert_report_to_better_readable(first_report)["archive"] == {
             "first_file.py": [
                 (
@@ -241,7 +241,7 @@ class TestAdjustSession(BaseTestCase):
         second_file = EditableReportFile("second_file.py")
         first_report.append(first_file)
         first_report.append(second_file)
-        # print(self.convert_report_to_better_readable(first_report)["archive"])
+
         assert self.convert_report_to_better_readable(first_report)["archive"] == {
             "first_file.py": [
                 (
@@ -405,7 +405,7 @@ class TestAdjustSession(BaseTestCase):
         current_yaml = UserYaml({})
         # No change to the report cause there's no session to CF
         assert _adjust_sessions(
-            report_under_test, second_report, first_to_merge_session, current_yaml
+            report_under_test, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([], [])
         assert first_value == self.convert_report_to_better_readable(report_under_test)
 
@@ -420,9 +420,8 @@ class TestAdjustSession(BaseTestCase):
             }
         )
         assert _adjust_sessions(
-            sample_first_report, second_report, first_to_merge_session, current_yaml
+            sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([0], [])
-        print(self.convert_report_to_better_readable(sample_first_report))
         assert self.convert_report_to_better_readable(sample_first_report) == {
             "archive": {
                 "first_file.py": [
@@ -650,7 +649,7 @@ class TestAdjustSession(BaseTestCase):
         assert _adjust_sessions(
             report_under_test,
             second_report,
-            first_to_merge_session,
+            ["enterprise"],
             current_yaml,
             upload=upload,
         ) == SessionAdjustmentResult([], [0])
@@ -798,11 +797,11 @@ class TestAdjustSession(BaseTestCase):
         assert _adjust_sessions(
             sample_first_report,
             second_report,
-            first_to_merge_session,
+            ["enterprise"],
             current_yaml,
             upload=upload,
         ) == SessionAdjustmentResult([], [0])
-        print(self.convert_report_to_better_readable(sample_first_report))
+
         assert self.convert_report_to_better_readable(sample_first_report) == {
             "archive": {
                 "first_file.py": [
@@ -1067,12 +1066,12 @@ class TestAdjustSession(BaseTestCase):
         assert _adjust_sessions(
             sample_first_report,
             second_report,
-            first_to_merge_session,
+            ["enterprise"],
             current_yaml,
             upload=upload,
         ) == SessionAdjustmentResult([0], [])
+
         res = self.convert_report_to_better_readable(sample_first_report)
-        # print(res["report"]["sessions"])
         assert res["report"]["sessions"] == {
             "1": {
                 "t": None,
@@ -1120,10 +1119,7 @@ class TestAdjustSession(BaseTestCase):
                 "se": {},
             },
         }
-        print(self.convert_report_to_better_readable(sample_first_report)["archive"])
-        assert self.convert_report_to_better_readable(sample_first_report)[
-            "archive"
-        ] == {
+        assert res["archive"] == {
             "first_file.py": [
                 (
                     1,
@@ -1219,98 +1215,3 @@ class TestAdjustSession(BaseTestCase):
                 ),
             ]
         }
-
-
-{
-    "first_file.py": [
-        (
-            1,
-            14,
-            None,
-            [[3, 7, None, None, None], [2, 14, None, None, None]],
-            None,
-            None,
-            [
-                (2, 14, None, [2, 1]),
-                (3, 7, None, [2]),
-            ],
-        ),
-        (
-            2,
-            15,
-            None,
-            [[1, 1, None, None, None], [3, 15, None, None, None]],
-            None,
-            None,
-            [
-                (1, 1, None, [1]),
-                (3, 15, None, [2, 1]),
-            ],
-        ),
-        (
-            3,
-            9,
-            None,
-            [[2, 2, None, None, None], [1, 9, None, None, None]],
-            None,
-            None,
-            [
-                (1, 9, None, [1]),
-                (1, 9, None, [2]),
-                (2, 2, None, [1]),
-            ],
-        ),
-        (
-            4,
-            17,
-            None,
-            [
-                [3, 3, None, None, None],
-                [2, 10, None, None, None],
-                [1, 17, None, None, None],
-            ],
-            None,
-            None,
-            [
-                (1, 17, None, [0]),
-                (2, 10, None, [1]),
-                (2, 10, None, [2]),
-                (3, 3, None, [1]),
-            ],
-        ),
-        (
-            5,
-            18,
-            None,
-            [[3, 11, None, None, None], [2, 18, None, None, None]],
-            None,
-            None,
-            [
-                (2, 18, None, [0]),
-                (3, 11, None, [1]),
-                (3, 11, None, [2]),
-            ],
-        ),
-        (
-            6,
-            19,
-            None,
-            [[1, 5, None, None, None], [3, 19, None, None, None]],
-            None,
-            None,
-            [(1, 5, None, [2]), (3, 19, None, [0])],
-        ),
-        (
-            7,
-            13,
-            None,
-            [[2, 6, None, None, None], [1, 13, None, None, None]],
-            None,
-            None,
-            [
-                (1, 13, None, [2, 1]),
-                (2, 6, None, [2]),
-            ],
-        ),
-    ]
-}

--- a/services/report/tests/unit/test_sessions_encoded_labels.py
+++ b/services/report/tests/unit/test_sessions_encoded_labels.py
@@ -16,7 +16,7 @@ from helpers.labels import SpecialLabelsEnum
 from rollouts import USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID
 from services.report.raw_upload_processor import (
     SessionAdjustmentResult,
-    _adjust_sessions,
+    clear_carryforward_sessions,
     make_sure_label_indexes_match,
 )
 from test_utils.base import BaseTestCase
@@ -404,7 +404,7 @@ class TestAdjustSession(BaseTestCase):
         second_report = Report(sessions={3: first_to_merge_session})
         current_yaml = UserYaml({})
         # No change to the report cause there's no session to CF
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             report_under_test, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([], [])
         assert first_value == self.convert_report_to_better_readable(report_under_test)
@@ -419,7 +419,7 @@ class TestAdjustSession(BaseTestCase):
                 }
             }
         )
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([0], [])
         assert self.convert_report_to_better_readable(sample_first_report) == {
@@ -646,7 +646,7 @@ class TestAdjustSession(BaseTestCase):
 
         first_value = self.convert_report_to_better_readable(sample_first_report)
         # This makes changes to the not-label-encoded original report, encoding them
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             report_under_test,
             second_report,
             ["enterprise"],
@@ -794,7 +794,7 @@ class TestAdjustSession(BaseTestCase):
             ),
         )
         second_report.append(second_report_file)
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             sample_first_report,
             second_report,
             ["enterprise"],
@@ -1063,7 +1063,7 @@ class TestAdjustSession(BaseTestCase):
         )
         second_report.append(second_report_file)
         second_report.append(a_report_file)
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             sample_first_report,
             second_report,
             ["enterprise"],

--- a/services/repository.py
+++ b/services/repository.py
@@ -91,7 +91,7 @@ def get_repo_provider_service_for_specific_commit(
 def get_repo_provider_service(
     repository: Repository,
     installation_name_to_use: Optional[str] = GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-) -> torngit.base.TorngitBaseAdapter:
+) -> TorngitBaseAdapter:
     adapter_auth_info = get_adapter_auth_information(
         repository.owner,
         repository=repository,

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -2308,7 +2308,7 @@ class TestReportService(BaseTestCase):
         report.add_session(to_merge_session)
         assert sorted(report.sessions.keys()) == [2, 3, 4]
         assert _adjust_sessions(
-            report, Report(), to_merge_session, UserYaml(yaml_dict)
+            report, Report(), ["enterprise"], UserYaml(yaml_dict)
         ) == SessionAdjustmentResult(
             fully_deleted_sessions=[2, 3], partially_deleted_sessions=[]
         )
@@ -2378,7 +2378,7 @@ class TestReportService(BaseTestCase):
         report.add_session(first_to_merge_session)
         assert sorted(report.sessions.keys()) == [0, 1, 2, 3, 4]
         assert _adjust_sessions(
-            report, Report(), first_to_merge_session, UserYaml(yaml_dict)
+            report, Report(), ["enterprise"], UserYaml(yaml_dict)
         ) == SessionAdjustmentResult(
             fully_deleted_sessions=[2, 3], partially_deleted_sessions=[]
         )
@@ -2454,7 +2454,7 @@ class TestReportService(BaseTestCase):
         report.add_session(second_to_merge_session)
         assert sorted(report.sessions.keys()) == [0, 1, 3, 4]
         assert _adjust_sessions(
-            report, Report(), second_to_merge_session, UserYaml(yaml_dict)
+            report, Report(), ["unit"], UserYaml(yaml_dict)
         ) == SessionAdjustmentResult(
             fully_deleted_sessions=[], partially_deleted_sessions=[]
         )

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -31,7 +31,7 @@ from services.report import (
 from services.report import log as report_log
 from services.report.raw_upload_processor import (
     SessionAdjustmentResult,
-    _adjust_sessions,
+    clear_carryforward_sessions,
 )
 from test_utils.base import BaseTestCase
 
@@ -2307,7 +2307,7 @@ class TestReportService(BaseTestCase):
         to_merge_session = Session(flags=["enterprise"])
         report.add_session(to_merge_session)
         assert sorted(report.sessions.keys()) == [2, 3, 4]
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             report, Report(), ["enterprise"], UserYaml(yaml_dict)
         ) == SessionAdjustmentResult(
             fully_deleted_sessions=[2, 3], partially_deleted_sessions=[]
@@ -2377,7 +2377,7 @@ class TestReportService(BaseTestCase):
         first_to_merge_session = Session(flags=["enterprise"])
         report.add_session(first_to_merge_session)
         assert sorted(report.sessions.keys()) == [0, 1, 2, 3, 4]
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             report, Report(), ["enterprise"], UserYaml(yaml_dict)
         ) == SessionAdjustmentResult(
             fully_deleted_sessions=[2, 3], partially_deleted_sessions=[]
@@ -2453,7 +2453,7 @@ class TestReportService(BaseTestCase):
         second_to_merge_session = Session(flags=["unit"])
         report.add_session(second_to_merge_session)
         assert sorted(report.sessions.keys()) == [0, 1, 3, 4]
-        assert _adjust_sessions(
+        assert clear_carryforward_sessions(
             report, Report(), ["unit"], UserYaml(yaml_dict)
         ) == SessionAdjustmentResult(
             fully_deleted_sessions=[], partially_deleted_sessions=[]

--- a/tasks/tests/integration/test_upload_e2e.py
+++ b/tasks/tests/integration/test_upload_e2e.py
@@ -161,7 +161,9 @@ def test_full_upload(
 
     repoid = repository.repoid
     commitid = uuid4().hex
-    commit = CommitFactory.create(repository=repository, commitid=commitid, pullid=12)
+    commit = CommitFactory.create(
+        repository=repository, commitid=commitid, pullid=12, _report_json=None
+    )
     dbsession.add(commit)
     dbsession.flush()
 

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -561,17 +561,16 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                     ),
                 )
 
-            sessionid = next(iter(incremental_report.sessions))
-            incremental_report.sessions[sessionid].id = sessionid
-
-            session_id, session = cumulative_report.add_session(
-                incremental_report.sessions[parallel_idx], use_id_from_session=True
+            session = incremental_report.sessions[parallel_idx]
+            session.id = parallel_idx
+            _session_id, session = cumulative_report.add_session(
+                session, use_id_from_session=True
             )
-            session.id = session_id
 
-            clear_carryforward_sessions(
-                cumulative_report, incremental_report, session, UserYaml(commit_yaml)
-            )
+            if flags := session.flags:
+                clear_carryforward_sessions(
+                    cumulative_report, incremental_report, flags, UserYaml(commit_yaml)
+                )
             # ReportService.update_upload_with_processing_result should use this result
             # to update the state of Upload. Once the experiment is finished, Upload.state should
             # be set to: parallel_processed (instead of processed)

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -24,7 +24,7 @@ from database.models import Commit, Pull
 from helpers.checkpoint_logger import _kwargs_key
 from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import UploadFlow
-from helpers.metrics import KiB, MiB, metrics
+from helpers.metrics import KiB, MiB
 from rollouts import PARALLEL_UPLOAD_PROCESSING_BY_REPO
 from services.archive import ArchiveService, MinioEndpoints
 from services.comparison import get_or_create_comparison
@@ -168,10 +168,9 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 ),
             )
 
-            with metrics.timer(f"{self.metrics_prefix}.save_parallel_report_results"):
-                parallel_paths = report_service.save_parallel_report_to_archive(
-                    commit, report, report_code
-                )
+            parallel_paths = report_service.save_parallel_report_to_archive(
+                commit, report, report_code
+            )
             # now that we've built the report and stored it to GCS, we have what we need to
             # compare the results with the current upload pipeline. We end execution of the
             # finisher task here so that we don't cause any additional side-effects

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -30,7 +30,7 @@ from services.archive import ArchiveService, MinioEndpoints
 from services.comparison import get_or_create_comparison
 from services.redis import get_redis_connection
 from services.report import ReportService
-from services.report.raw_upload_processor import _adjust_sessions
+from services.report.raw_upload_processor import clear_carryforward_sessions
 from services.yaml import read_yaml_field
 from tasks.base import BaseCodecovTask
 from tasks.parallel_verification import parallel_verification_task
@@ -569,7 +569,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
             )
             session.id = session_id
 
-            _adjust_sessions(
+            clear_carryforward_sessions(
                 cumulative_report, incremental_report, session, UserYaml(commit_yaml)
             )
             # ReportService.update_upload_with_processing_result should use this result


### PR DESCRIPTION
This just moves some code around, removes excessive logging and metrics, and aims to make things a bit more readable.

---

Feel free to review this with "ignore whitespace", as it does some re-indenting.