### PR TITLE
fix: adjust_base behavior

### DIFF
--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -210,16 +210,17 @@ class StatusProjectMixin(object):
         quantized_base_adjusted_coverage = base_adjusted_coverage.quantize(
             Decimal("0.00000")
         )
-        if abs(quantized_base_adjusted_coverage - head_coverage) < Decimal("0.01"):
-            rounded_difference = round_number(
-                self.current_yaml, head_coverage - base_adjusted_coverage
+        if quantized_base_adjusted_coverage - head_coverage < Decimal("0.005"):
+            rounded_difference = max(
+                0,
+                round_number(self.current_yaml, head_coverage - base_adjusted_coverage),
             )
             rounded_base_adjusted_coverage = round_number(
                 self.current_yaml, base_adjusted_coverage
             )
             return (
                 "success",
-                f", passed because coverage increased by {rounded_difference:+}% when compared to adjusted base ({rounded_base_adjusted_coverage}%)",
+                f", passed because coverage increased by {rounded_difference}% when compared to adjusted base ({rounded_base_adjusted_coverage}%)",
             )
         return None
 


### PR DESCRIPTION
The math was not math-ing (i.e. it would only work if the difference between BASE and HEAD
was within 0.01, in absolute value)
Now the math allows the HEAD to be infinitely greater than the base when suceeding.

Added better tests as well. Reduced wiggle room to 0.005.

closes https://github.com/codecov/feedback/issues/463

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.