### PR TITLE
Do not `rewrite_readable` legacy Reports

### DIFF
--- a/services/report/parser/legacy.py
+++ b/services/report/parser/legacy.py
@@ -3,7 +3,6 @@ from io import BytesIO
 
 import sentry_sdk
 
-from helpers.metrics import metrics
 from services.report.parser.types import LegacyParsedRawReport, ParsedUploadedReportFile
 
 
@@ -106,7 +105,6 @@ class LegacyReportParser(object):
                 }
 
     @sentry_sdk.trace
-    @metrics.timer("services.report.parser.parse_raw_report_from_bytes")
     def parse_raw_report_from_bytes(self, raw_report: bytes) -> LegacyParsedRawReport:
         raw_report, _, _compat_report_str = raw_report.partition(
             self.ignore_from_now_on_marker

--- a/services/report/parser/types.py
+++ b/services/report/parser/types.py
@@ -73,11 +73,11 @@ class ParsedRawReport(object):
         if self.has_toc():
             for file in self.get_toc():
                 buffer.write(f"{file}\n".encode("utf-8"))
-            buffer.write("<<<<<< network\n\n".encode("utf-8"))
+            buffer.write(b"<<<<<< network\n\n")
         for file in self.uploaded_files:
             buffer.write(f"# path={file.filename}\n".encode("utf-8"))
             buffer.write(file.contents)
-            buffer.write("\n<<<<<< EOF\n\n".encode("utf-8"))
+            buffer.write(b"\n<<<<<< EOF\n\n")
         buffer.seek(0)
         return buffer
 

--- a/tasks/tests/samples/sample_uploaded_report_1.txt
+++ b/tasks/tests/samples/sample_uploaded_report_1.txt
@@ -7,6 +7,7 @@ coverage.xml
 tests/__init__.py
 tests/test_sample.py
 <<<<<< network
+
 # path=coverage.xml
 <?xml version="1.0" ?>
 <coverage branch-rate="0" branches-covered="0" branches-valid="0" complexity="0" line-rate="0.7917" lines-covered="19" lines-valid="24" timestamp="1558110577401" version="4.5.3">
@@ -66,6 +67,7 @@ tests/test_sample.py
     </packages>
 </coverage>
 <<<<<< EOF
+
 # path=codecov.yaml
 codecov:
   notify:
@@ -92,5 +94,6 @@ parsers:
 comment:
   layout: "header, diff"
   behavior: default
-  require_changes: no<<<<<< EOF
+  require_changes: no
+<<<<<< EOF
 


### PR DESCRIPTION
These reports are already "readable", so there is no need to rewrite them.
Should save a GCS write call in that case for a small speedup.