### PR TITLE
Clear CFF `Upload`s as they are overwritten

### DIFF
--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -33,7 +33,7 @@ class SessionAdjustmentResult:
 @dataclass
 class UploadProcessingResult:
     report: Report  # NOTE: this is just returning the input argument, and primarily used in tests
-    session_adjustment: SessionAdjustmentResult  # NOTE: this is only ever used in tests
+    session_adjustment: SessionAdjustmentResult
 
 
 @sentry_sdk.trace

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -4059,7 +4059,7 @@ class TestReportService(BaseTestCase):
         assert len(upload_obj.errors) == 0
         processing_result = ProcessingResult(
             session=Session(),
-            error=None,
+            session_adjustment=SessionAdjustmentResult([], []),
         )
         assert (
             ReportService({}).update_upload_with_processing_result(


### PR DESCRIPTION
The `Upload`s in the database should mirror the `Session`s within a stored `Report`.

However, so far this was not the case for carryforwarded sessions/uploads. The `Session`s were removed from the `Report` as they were being overridden by new uploads, but that was not the case for the `Upload` rows in the database which were created from the carry-forwarded `Session`s on initial `Report` carry-forwarding.

This change will now make sure that the `Upload`s in the database match the `Session`s in the `Report`.