### PR TITLE
feat: don't do flake detection on private repos not on the pro plan

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -2,7 +2,6 @@ from shared.rollouts import Feature
 
 # Declare the feature variants and parameters via Django Admin
 FLAKY_TEST_DETECTION = Feature("flaky_test_detection")
-FLAKY_SHADOW_MODE = Feature("flaky_shadow_mode")
 
 CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER = Feature("carryforward_base_search_range")
 

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -406,11 +406,11 @@ def not_private_and_free_or_team(repo: Repository):
 
 
 def should_do_flaky_detection(repo: Repository, commit_yaml: UserYaml) -> bool:
-    should_config = read_yaml_field(
+    has_flaky_configured = read_yaml_field(
         commit_yaml, ("test_analytics", "flake_detection"), True
     )
-    should_feature = FLAKY_TEST_DETECTION.check_value(
+    feature_enabled = FLAKY_TEST_DETECTION.check_value(
         identifier=repo.repoid, default=True
     )
-    should_plan = not_private_and_free_or_team(repo)
-    return should_config and (should_feature or should_plan)
+    has_valid_plan_repo_or_owner = not_private_and_free_or_team(repo)
+    return has_flaky_configured and (feature_enabled or has_valid_plan_repo_or_owner)

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -2,7 +2,11 @@ import mock
 import pytest
 from shared.torngit.exceptions import TorngitClientError
 
-from database.tests.factories import CommitFactory, RepositoryFactory
+from database.tests.factories import (
+    CommitFactory,
+    OwnerFactory,
+    RepositoryFactory,
+)
 from helpers.notifier import NotifierResult
 from services.test_results import (
     FlakeInfo,
@@ -257,16 +261,9 @@ def test_notify_fail_no_pull(
 def test_should_do_flake_detection(
     dbsession, mocker, config, feature_flag, private, plan, ex_result
 ):
-    repo = RepositoryFactory()
+    owner = OwnerFactory(plan=plan)
+    repo = RepositoryFactory(private=private, owner=owner)
     dbsession.add(repo)
-    dbsession.flush()
-
-    if private:
-        repo.private = True
-    else:
-        repo.private = False
-
-    repo.owner.plan = plan
     dbsession.flush()
 
     mocked_feature = mocker.patch("services.test_results.FLAKY_TEST_DETECTION")

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -1,7 +1,8 @@
 import mock
+import pytest
 from shared.torngit.exceptions import TorngitClientError
 
-from database.tests.factories import CommitFactory
+from database.tests.factories import CommitFactory, RepositoryFactory
 from helpers.notifier import NotifierResult
 from services.test_results import (
     FlakeInfo,
@@ -11,8 +12,10 @@ from services.test_results import (
     generate_failure_info,
     generate_flags_hash,
     generate_test_id,
+    should_do_flaky_detection,
 )
 from services.urls import services_short_dict
+from services.yaml import UserYaml
 
 
 def mock_repo_service():
@@ -238,3 +241,39 @@ def test_notify_fail_no_pull(
 
     notification_result = tn.notify()
     assert notification_result == NotifierResult.NO_PULL
+
+
+@pytest.mark.parametrize(
+    "config,feature_flag,private,plan,ex_result",
+    [
+        (False, True, False, "users-inappm", False),
+        (True, True, True, "users-basic", True),
+        (True, False, False, "users-basic", True),
+        (True, False, True, "users-basic", False),
+        (True, False, False, "users-inappm", True),
+        (True, False, True, "users-inappm", True),
+    ],
+)
+def test_should_do_flake_detection(
+    dbsession, mocker, config, feature_flag, private, plan, ex_result
+):
+    repo = RepositoryFactory()
+    dbsession.add(repo)
+    dbsession.flush()
+
+    if private:
+        repo.private = True
+    else:
+        repo.private = False
+
+    repo.owner.plan = plan
+    dbsession.flush()
+
+    mocked_feature = mocker.patch("services.test_results.FLAKY_TEST_DETECTION")
+    mocked_feature.check_value.return_value = feature_flag
+
+    yaml = {"test_analytics": {"flake_detection": config}}
+
+    result = should_do_flaky_detection(repo, UserYaml.from_dict(yaml))
+
+    assert result == ex_result

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -30,7 +30,7 @@ from services.repository import (
     fetch_and_update_pull_request_information,
     get_repo_provider_service,
 )
-from services.test_results import should_write_flaky_detection
+from services.test_results import should_do_flaky_detection
 from services.yaml.reader import read_yaml_field
 from tasks.base import BaseCodecovTask
 from tasks.process_flakes import process_flakes_task_name
@@ -534,7 +534,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         current_yaml: UserYaml,
     ):
         # but only if flake processing is enabled for this repo
-        if should_write_flaky_detection(repository, current_yaml):
+        if should_do_flaky_detection(repository, current_yaml):
             self.app.tasks[process_flakes_task_name].apply_async(
                 kwargs=dict(
                     repo_id=repository.repoid, commit_id_list=[pull_head], branch=branch

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -227,6 +227,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                 commits,
                 base_ancestors_tree,
                 current_yaml,
+                repository,
             )
             db_session.commit()
         except TorngitClientError:
@@ -336,6 +337,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         commits_on_pr: Sequence,
         ancestors_tree_on_base: Dict[str, Any],
         current_yaml,
+        repository: Repository,
     ) -> dict:
         """Updates commits considering what the new PR situation is.
 
@@ -403,7 +405,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
 
                 if db_session.query(Test).filter(Test.repoid == repoid).count() > 0:
                     self.trigger_process_flakes(
-                        repoid, pull.head, pull_dict["head"]["branch"], current_yaml
+                        repository, pull.head, pull_dict["head"]["branch"], current_yaml
                     )
 
             # set the rest of the commits to deleted (do not show in the UI)
@@ -525,12 +527,18 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         return regular_was_squash
 
     def trigger_process_flakes(
-        self, repoid: int, pull_head: str, branch: str, current_yaml: UserYaml
+        self,
+        repository: Repository,
+        pull_head: str,
+        branch: str,
+        current_yaml: UserYaml,
     ):
         # but only if flake processing is enabled for this repo
-        if should_write_flaky_detection(repoid, current_yaml):
+        if should_write_flaky_detection(repository, current_yaml):
             self.app.tasks[process_flakes_task_name].apply_async(
-                kwargs=dict(repo_id=repoid, commit_id_list=[pull_head], branch=branch)
+                kwargs=dict(
+                    repo_id=repository.repoid, commit_id_list=[pull_head], branch=branch
+                )
             )
 
     def trigger_ai_pr_review(self, enriched_pull: EnrichedPull, current_yaml: UserYaml):

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -401,12 +401,11 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         repoid: int,
         failures: list[TestResultsNotificationFailure],
     ) -> dict[str, FlakeInfo]:
-        flaky_test_ids = dict()
         failure_test_ids = [failure.test_id for failure in failures]
 
         matching_flakes = list(
             db_session.query(Flake)
-            .filter(  # type:ignore
+            .filter(
                 Flake.repoid == repoid,
                 Flake.testid.in_(failure_test_ids),
                 Flake.end_date.is_(None),
@@ -416,8 +415,10 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             .all()
         )
 
-        for flake in matching_flakes:
-            flaky_test_ids[flake.testid] = FlakeInfo(flake.fail_count, flake.count)
+        flaky_test_ids = {
+            flake.testid: FlakeInfo(flake.fail_count, flake.count)
+            for flake in matching_flakes
+        }
 
         return flaky_test_ids
 

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -141,7 +141,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         assert commit, "commit not found"
 
         repo = db_session.query(Repository).filter_by(repoid=repoid).first()
-        if should_write_flaky_detection(repoid, commit_yaml):
+        if should_write_flaky_detection(repo, commit_yaml):
             if commit.merged is True or commit.branch == repo.branch:
                 self.app.tasks[process_flakes_task_name].apply_async(
                     kwargs=dict(
@@ -326,7 +326,12 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
                     QUEUE_NOTIFY_KEY: False,
                 }
 
-        flaky_tests = self.get_flaky_tests(db_session, commit_yaml, repoid, failures)
+        flaky_tests = dict()
+
+        if should_read_flaky_detection(repo, commit_yaml):
+            flaky_tests = self.get_flaky_tests(
+                db_session, commit_yaml, repoid, failures
+            )
 
         failures = sorted(failures, key=lambda x: x.duration_seconds)[:3]
 
@@ -348,7 +353,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
                 TestResultsFlow.TEST_RESULTS_NOTIFY,
             ):
                 metrics.timing(
-                    f"test_results_notif_latency.{"flaky" if should_read_flaky_detection(repoid, commit_yaml) else "non_flaky"}",
+                    f"test_results_notif_latency.{"flaky" if should_read_flaky_detection(repo, commit_yaml) else "non_flaky"}",
                     begin_to_notify,
                 )
             notifier_result: NotifierResult = notifier.notify()
@@ -397,28 +402,25 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         repoid: int,
         failures: list[TestResultsNotificationFailure],
     ) -> dict[str, FlakeInfo]:
-        if should_read_flaky_detection(repoid, commit_yaml):
-            flaky_test_ids = dict()
-            failure_test_ids = [failure.test_id for failure in failures]
+        flaky_test_ids = dict()
+        failure_test_ids = [failure.test_id for failure in failures]
 
-            matching_flakes = list(
-                db_session.query(Flake)
-                .filter(  # type:ignore
-                    Flake.repoid == repoid,
-                    Flake.testid.in_(failure_test_ids),
-                    Flake.end_date.is_(None),
-                    Flake.count != (Flake.recent_passes_count + Flake.fail_count),
-                )
-                .limit(100)
-                .all()
+        matching_flakes = list(
+            db_session.query(Flake)
+            .filter(  # type:ignore
+                Flake.repoid == repoid,
+                Flake.testid.in_(failure_test_ids),
+                Flake.end_date.is_(None),
+                Flake.count != (Flake.recent_passes_count + Flake.fail_count),
             )
+            .limit(100)
+            .all()
+        )
 
-            for flake in matching_flakes:
-                flaky_test_ids[flake.testid] = FlakeInfo(flake.fail_count, flake.count)
+        for flake in matching_flakes:
+            flaky_test_ids[flake.testid] = FlakeInfo(flake.fail_count, flake.count)
 
-            return flaky_test_ids
-
-        return dict()
+        return flaky_test_ids
 
     def check_if_no_success(self, previous_result):
         return all(

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -959,11 +959,8 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
     ):
         commit_yaml = {
             "codecov": {"max_report_age": False},
+            "test_analytics": {"flake_detection": True},
         }
-        if flake_detection == "FLAKY_TEST_DETECTION":
-            commit_yaml["test_analytics"] = {"flake_detection": True}
-        elif flake_detection is None:
-            commit_yaml["test_analytics"] = {"flake_detection": False}
 
         repoid, commit, pull, test_instances = test_results_setup
 
@@ -987,20 +984,15 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 
         assert expected_result == result
 
-        if flake_detection is None:
-            test_results_mock_app.tasks[
-                "app.tasks.flakes.ProcessFlakesTask"
-            ].apply_async.assert_not_called()
-        else:
-            test_results_mock_app.tasks[
-                "app.tasks.flakes.ProcessFlakesTask"
-            ].apply_async.assert_called_with(
-                kwargs={
-                    "repo_id": repoid,
-                    "commit_id_list": [commit.commitid],
-                    "branch": "main",
-                },
-            )
+        test_results_mock_app.tasks[
+            "app.tasks.flakes.ProcessFlakesTask"
+        ].apply_async.assert_called_with(
+            kwargs={
+                "repo_id": repoid,
+                "commit_id_list": [commit.commitid],
+                "branch": "main",
+            },
+        )
         test_results_mock_app.tasks[
             "app.tasks.cache_rollup.CacheTestRollupsTask"
         ].apply_async.assert_called_with(

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -944,9 +944,6 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
         )
 
     @pytest.mark.integration
-    @pytest.mark.parametrize(
-        "flake_detection", [None, "FLAKY_TEST_DETECTION", "FLAKY_SHADOW_MODE"]
-    )
     def test_upload_finisher_task_call_main_branch(
         self,
         mocker,
@@ -959,11 +956,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
         test_results_mock_app,
         mock_repo_provider_comments,
         test_results_setup,
-        flake_detection,
     ):
-        if flake_detection:
-            mock_feature = mocker.patch(f"services.test_results.{flake_detection}")
-            mock_feature.check_value.return_value = True
         commit_yaml = {
             "codecov": {"max_report_age": False},
         }
@@ -1190,21 +1183,12 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 
         assert expected_result == result
 
-        if plan == "users-basic":
-            test_results_mock_app.tasks[
-                "app.tasks.flakes.ProcessFlakesTask"
-            ].apply_async.assert_not_called()
-            mocked_get_flaky_tests.assert_not_called()
-        else:
-            test_results_mock_app.tasks[
-                "app.tasks.flakes.ProcessFlakesTask"
-            ].apply_async.assert_called_with(
-                kwargs={
-                    "repo_id": repoid,
-                    "commit_id_list": [commit.commitid],
-                    "branch": "main",
-                },
-            )
-            mocked_get_flaky_tests.assert_called_with(
-                dbsession, mocker.ANY, repoid, mocker.ANY
-            )
+        test_results_mock_app.tasks[
+            "app.tasks.flakes.ProcessFlakesTask"
+        ].apply_async.assert_called_with(
+            kwargs={
+                "repo_id": repoid,
+                "commit_id_list": [commit.commitid],
+                "branch": "main",
+            },
+        )


### PR DESCRIPTION
- remove flaky_shadow_mode feature flag
- simplify should_{write,read}_flaky_detection functions to
  general should_do_flake_detection that checks whether to do either
- add check to make sure repo is not private and on a free plan or
  team plan
- the new logic is:
    - if a user has explicitly set flake_detection to false in their
      yaml we don't do flake detection
    - else:
        - if a user is part of the feature flag we do flake detection
        - else if the repo is private then we require them to be on a
          pro plan
        - else we do flake detection