### PR TITLE
fix: comment config can be bool

### DIFF
--- a/services/bundle_analysis/notify/contexts/__init__.py
+++ b/services/bundle_analysis/notify/contexts/__init__.py
@@ -3,10 +3,7 @@ from functools import cached_property
 from typing import Generic, Literal, Self, TypeVar
 
 import sentry_sdk
-from shared.bundle_analysis import (
-    BundleAnalysisReport,
-    BundleAnalysisReportLoader,
-)
+from shared.bundle_analysis import BundleAnalysisReport, BundleAnalysisReportLoader
 from shared.torngit.base import TorngitBaseAdapter
 from shared.validation.types import BundleThreshold
 from shared.yaml import UserYaml
@@ -20,9 +17,7 @@ from services.bundle_analysis.notify.types import (
     NotificationType,
     NotificationUserConfig,
 )
-from services.repository import (
-    get_repo_provider_service,
-)
+from services.repository import get_repo_provider_service
 from services.storage import get_storage_client
 
 T = TypeVar("T")
@@ -192,16 +187,18 @@ class NotificationContextBuilder:
 
         This allows all notifiers to access configuration for any notifier and already have the defaults
         """
-        required_changes: bool | Literal["bundle_increase"] = (
-            self.current_yaml.read_yaml_field(
-                "comment", "require_bundle_changes", _else=False
+        comment_config: bool | dict = self.current_yaml.read_yaml_field("comment")
+        if not comment_config:
+            required_changes = False
+            required_changes_threshold = BundleThreshold("absolute", 0)
+        else:
+            required_changes: bool | Literal["bundle_increase"] = comment_config.get(
+                "require_bundle_changes", False
             )
-        )
-        required_changes_threshold: int | float = self.current_yaml.read_yaml_field(
-            "comment",
-            "bundle_change_threshold",
-            _else=BundleThreshold("absolute", 0),
-        )
+            required_changes_threshold: int | float = comment_config.get(
+                "bundle_change_threshold",
+                BundleThreshold("absolute", 0),
+            )
         warning_threshold: int | float = self.current_yaml.read_yaml_field(
             "bundle_analysis",
             "warning_threshold",

--- a/services/bundle_analysis/notify/contexts/tests/test_contexts.py
+++ b/services/bundle_analysis/notify/contexts/tests/test_contexts.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from shared.validation.types import BundleThreshold
 from shared.yaml import UserYaml
 
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
@@ -14,6 +15,7 @@ from services.bundle_analysis.notify.contexts import (
     NotificationContextBuilder,
     NotificationContextBuildError,
 )
+from services.bundle_analysis.notify.types import NotificationUserConfig
 
 
 class TestBaseBundleAnalysisNotificationContextBuild:
@@ -67,7 +69,40 @@ class TestBaseBundleAnalysisNotificationContextBuild:
             builder.load_bundle_analysis_report()
         assert exp.value.failed_step == "load_bundle_analysis_report"
 
-    def test_build_context(self, dbsession, mock_storage, mocker):
+    @pytest.mark.parametrize(
+        "config, expected_user_config",
+        [
+            pytest.param(
+                {
+                    "comment": {
+                        "layout": "reach,diff,flags,tree,reach",
+                        "behavior": "default",
+                        "show_carryforward_flags": False,
+                    }
+                },
+                NotificationUserConfig(
+                    required_changes=False,
+                    warning_threshold=BundleThreshold("percentage", 5.0),
+                    status_level="informational",
+                    required_changes_threshold=BundleThreshold("absolute", 0),
+                ),
+                id="default_site_config",
+            ),
+            pytest.param(
+                {"comment": False},
+                NotificationUserConfig(
+                    required_changes=False,
+                    warning_threshold=BundleThreshold("percentage", 5.0),
+                    status_level="informational",
+                    required_changes_threshold=BundleThreshold("absolute", 0),
+                ),
+                id="comment_is_bool",
+            ),
+        ],
+    )
+    def test_build_context(
+        self, dbsession, mock_storage, mocker, config, expected_user_config
+    ):
         head_commit, base_commit = get_commit_pair(dbsession)
         head_commit_report, _ = get_report_pair(dbsession, (head_commit, base_commit))
         save_mock_bundle_analysis_report(
@@ -77,11 +112,14 @@ class TestBaseBundleAnalysisNotificationContextBuild:
             sample_report_number=1,
         )
         builder = NotificationContextBuilder().initialize(
-            head_commit, UserYaml.from_dict({}), GITHUB_APP_INSTALLATION_DEFAULT_NAME
+            head_commit,
+            UserYaml.from_dict(config),
+            GITHUB_APP_INSTALLATION_DEFAULT_NAME,
         )
         context = builder.build_context().get_result()
         assert context.commit_report == head_commit_report
         assert context.bundle_analysis_report.session_count() == 19
+        assert context.user_config == expected_user_config
         assert [
             bundle_report.name
             for bundle_report in context.bundle_analysis_report.bundle_reports()


### PR DESCRIPTION
Fixes WORKER-PA8
The "comment" is allowed to be `bool` type, and that breaks the user_config loading.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.