### PR TITLE
feat: add script for rerunning test result uploads

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -147,6 +147,7 @@ class Repository(CodecovBaseModel):
     webhook_secret = Column(types.Text)
     activated = Column(types.Boolean, default=False)
     bundle_analysis_enabled = Column(types.Boolean, default=False)
+    test_analytics_enabled = Column(types.Boolean, default=False)
     upload_token = Column(postgresql.UUID, server_default=FetchedValue())
 
     # DEPRECATED - prefer GithubAppInstallation.is_repo_covered_by_integration

--- a/one_off_script.py
+++ b/one_off_script.py
@@ -5,9 +5,12 @@ import django
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_scaffold.settings")
 django.setup()
 
-if __name__ == "__main__":
-    from one_off_scripts.backfill_daily_test_rollups import run_impl
-    from one_off_scripts.backfill_test_flag_bridges import backfill_test_flag_bridges
 
-    run_impl()
-    backfill_test_flag_bridges()
+if __name__ == "__main__":
+    # from one_off_scripts.backfill_daily_test_rollups import run_impl
+    from one_off_scripts.rerun_uploads import rerun_test_results_uploads
+
+    rerun_test_results_uploads("2024-09-25", "2024-09-27")
+
+    # run_impl()
+    # backfill_test_flag_bridges()

--- a/one_off_scripts/__init__.py
+++ b/one_off_scripts/__init__.py
@@ -1,6 +1,0 @@
-import os
-
-import django
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "django_scaffold.settings")
-django.setup()

--- a/one_off_scripts/celery_stuff.py
+++ b/one_off_scripts/celery_stuff.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+
+from celery import Celery, signature
+from shared.celery_config import BaseCeleryConfig
+
+celery_app = Celery("tasks")
+celery_app.config_from_object("shared.celery_config:BaseCeleryConfig")
+
+default_task_name = BaseCeleryConfig.task_default_queue
+
+
+def create_signature(name, args=None, kwargs=None, immutable=False):
+    queue_name = default_task_name
+    headers = dict(created_timestamp=datetime.now().isoformat())
+    return signature(
+        name,
+        args=args,
+        kwargs=kwargs,
+        app=celery_app,
+        queue=queue_name,
+        headers=headers,
+        immutable=immutable,
+    )

--- a/one_off_scripts/rerun_uploads.py
+++ b/one_off_scripts/rerun_uploads.py
@@ -1,0 +1,52 @@
+import datetime as dt
+
+from celery import chord
+from shared.django_apps.reports.models import (
+    CommitReport,
+    ReportSession,
+)
+
+from one_off_scripts.celery_stuff import create_signature
+
+
+def rerun_test_results_uploads(start_date, end_date):
+    relevant_reports = (
+        CommitReport.objects.filter(
+            created_at__gt=dt.datetime(2024, 9, 25, 0, 0, 0, 0, dt.UTC),
+            created_at__lt=dt.datetime(2024, 9, 28, 0, 0, 0, 0, dt.UTC),
+        )
+        .select_related("testresultreporttotals")
+        .filter(testresultreporttotals__isnull=True)
+    )
+
+    for report in relevant_reports:
+        print(report)
+        commit = report.commit
+        relevant_uploads = ReportSession.objects.filter(report=report)
+
+        print(relevant_uploads)
+
+        chord(
+            [
+                create_signature(
+                    "app.tasks.test_results.TestResultsProcessor",
+                    kwargs=dict(
+                        repoid=commit.repository_id,
+                        commitid=commit.commitid,
+                        commit_yaml=dict(),
+                        arguments_list=[
+                            {"upload_pk": upload.id} for upload in relevant_uploads
+                        ],
+                        report_code=None,
+                    ),
+                )
+            ],
+            create_signature(
+                "app.tasks.test_results.TestResultsFinisherTask",
+                kwargs=dict(
+                    repoid=commit.repository_id,
+                    commitid=commit.commitid,
+                    commit_yaml=dict(),
+                ),
+            ),
+        ).apply_async()


### PR DESCRIPTION
we had an issue from the 25th to the 28th where the test results processing step was failing

this one off script looks for all commit reports created between those days that is missing a TestResultReportTotals object (which insinutates that the test result processing failed) and tries to run it again using a celery chord
