### PR TITLE
Add missing required non-NULL `Owner` column

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -82,6 +82,8 @@ class Owner(CodecovBaseModel):
     stripe_customer_id = Column(types.Text, server_default=FetchedValue())
     stripe_subscription_id = Column(types.Text, server_default=FetchedValue())
     onboarding_completed = Column(types.Boolean, default=False)
+    upload_token_required_for_public_repos = Column(types.Boolean, default=True)
+
     bot_id = Column(
         "bot",
         types.Integer,

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/36791fe3c18a0dbdf7296ffbdffbf2137fa9fc06.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/88117b96a4b420d88549b8df2649c3eb9c61c2a5.tar.gz#egg=shared
 https://github.com/codecov/test-results-parser/archive/1507de2241601d678e514c08b38426e48bb6d47d.tar.gz#egg=test-results-parser
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -357,7 +357,7 @@ sentry-sdk[celery]==2.13.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/36791fe3c18a0dbdf7296ffbdffbf2137fa9fc06.tar.gz
+shared @ https://github.com/codecov/shared/archive/88117b96a4b420d88549b8df2649c3eb9c61c2a5.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
A recent migration has added the `upload_token_required_for_public_repos` column to `Owner`, which was not updated properly in the `worker` code, and inserts to that table are now failing because of a missing default.

This does the same as https://github.com/codecov/shared/pull/373 for the `sqlalchemy` based models.