### PR TITLE
bundle analysis: add logging for fail to parse

### DIFF
--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 from dataclasses import dataclass
@@ -25,6 +26,8 @@ from services.archive import ArchiveService
 from services.report import BaseReportService
 from services.storage import get_storage_client
 from services.timeseries import repository_datasets_query
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -290,6 +293,11 @@ class BundleAnalysisReportService(BaseReportService):
                     "result": "parser_error",
                     "plugin_name": plugin_name,
                 },
+            )
+            log.error(
+                "Unable to parse upload for bundle analysis",
+                exc_info=True,
+                extra=dict(repoid=commit.repoid, commit=commit.commitid),
             )
             return ProcessingResult(
                 upload=upload,


### PR DESCRIPTION
Add a logging for printing errors for parsing. 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.