### PR TITLE
Replace sentry_sdk metrics with statsd metrics

### DIFF
--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -414,7 +414,9 @@ class BundleAnalysisReportService(BaseReportService):
                 commit=commit,
             )
         except Exception:
-            metrics.incr(f"bundle_analysis_upload.parser_error.{commit.repository.repoid}")
+            metrics.incr(
+                f"bundle_analysis_upload.parser_error.{commit.repository.repoid}"
+            )
             return ProcessingResult(
                 upload=upload,
                 commit=commit,

--- a/services/failure_normalizer.py
+++ b/services/failure_normalizer.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 import regex
 import sentry_sdk
 
+from helpers.metrics import metrics
+
 predefined_dict_of_regexes_to_match = {
     "UUID": [
         r"[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}"
@@ -100,7 +102,7 @@ class FailureNormalizer:
 
     @sentry_sdk.trace
     def normalize_failure_message(self, failure_message: str):
-        with sentry_sdk.metrics.timing("failure_normalizer.normalize_failure_message"):
+        with metrics.timer("failure_normalizer.normalize_failure_message"):
             key_ordering = self.key_analysis_order or self.dict_of_regex.keys()
             for key in key_ordering:
                 list_of_compiled_regex = self.dict_of_regex[key]

--- a/services/notification/notifiers/comment/__init__.py
+++ b/services/notification/notifiers/comment/__init__.py
@@ -2,7 +2,6 @@ import logging
 from datetime import datetime, timezone
 from typing import Any, List, Mapping
 
-import sentry_sdk
 from asgiref.sync import async_to_sync
 from shared.torngit.base import TorngitBaseAdapter
 from shared.torngit.exceptions import (
@@ -83,8 +82,14 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
         # TODO: remove this when we don't need it anymore
         # this line is measuring how often we try to comment on a PR that is closed
         if comparison.pull is not None and comparison.pull.state != "open":
-            integration_status = "repo_with_integration" if self.repository_service.data["repo"]["using_integration"] else "repo_without_integration"
-            metrics.incr(f"notifiers.comment.pull_closed_notifying_anyways.{integration_status}")
+            integration_status = (
+                "repo_with_integration"
+                if self.repository_service.data["repo"]["using_integration"]
+                else "repo_without_integration"
+            )
+            metrics.incr(
+                f"notifiers.comment.pull_closed_notifying_anyways.{integration_status}"
+            )
 
         for condition in self.notify_conditions:
             condition_result = condition.check_condition(

--- a/tasks/parallel_verification.py
+++ b/tasks/parallel_verification.py
@@ -6,6 +6,7 @@ from shared.celery_config import parallel_verification_task_name
 
 from app import celery_app
 from database.models import Commit
+from helpers.metrics import metrics
 from services.report import ReportService
 from tasks.base import BaseCodecovTask
 
@@ -146,10 +147,8 @@ class ParallelVerificationTask(BaseCodecovTask, name=parallel_verification_task_
         )
 
         is_success = top_level_totals_match and file_level_totals_match
-        sentry_sdk.metrics.incr(
-            "parallel_verification.comparisons",
-            tags={"result": "success" if is_success else "failure"},
-        )
+        status = "success" if is_success else "failure"
+        metrics.incr(f"parallel_verification.comparisons.{status}")
         if not is_success:
             with sentry_sdk.new_scope() as scope:
                 if file_level_mismatched_files:

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -9,7 +9,6 @@ from typing import Any, Dict, List, Sequence
 import sqlalchemy.orm
 from asgiref.sync import async_to_sync
 from redis.exceptions import LockError
-from sentry_sdk import metrics as sentry_metrics
 from shared.celery_config import notify_task_name, pulls_task_name
 from shared.reports.types import Change
 from shared.torngit.exceptions import TorngitClientError
@@ -498,13 +497,13 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         )
 
         if regular_was_squash == experiment_was_squash:
-            sentry_metrics.incr("sync_pull_merge_commit_sha", tags={"success": "true"})
+            metrics.incr("sync_pull_merge_commit_sha.success")
             log.info(
                 "Sync Pull merge commit sha experiment succeeded",
                 extra=dict(repoid=repoid, pullid=pullid),
             )
         else:
-            sentry_metrics.incr("sync_pull_merge_commit_sha", tags={"success": "false"})
+            metrics.incr("sync_pull_merge_commit_sha.failure")
             log.info(
                 "Sync Pull merge commit sha experiment failed",
                 extra=dict(repoid=repoid, pullid=pullid),


### PR DESCRIPTION
<!-- Describe your PR here. -->

This PR replaces the deprecated `sentry_sdk.metrics` with `statsd` metrics throughout the worker codebase. This change is necessary as Sentry SDK metrics are being phased out.

Key changes:
- Removed all instances of sentry_sdk.metrics and replaced them with statsd metrics (imported as `metrics` from `helpers.metrics`)
- Converted tagged sentry_sdk metrics to use dot-separated naming conventions
- Ensured that the metrics object is properly imported where needed

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.