### PR TITLE
Gracefully upgrade existing tasks to parallel processing

### DIFF
--- a/helpers/parallel.py
+++ b/helpers/parallel.py
@@ -77,18 +77,13 @@ class ParallelProcessing(Enum):
     @classmethod
     def from_task_args(
         cls,
-        repoid: int,
         in_parallel: bool = False,
         is_final: bool = False,
+        run_fully_parallel: bool = False,
         **kwargs,
     ) -> ParallelProcessing:
-        feature = ParallelFeature.load(repoid)
-
-        if feature is ParallelFeature.SERIAL:
-            return ParallelProcessing.SERIAL
-        if feature is ParallelFeature.PARALLEL:
+        if run_fully_parallel:
             return ParallelProcessing.PARALLEL
-
         if in_parallel:
             return ParallelProcessing.EXPERIMENT_PARALLEL
         if is_final:

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -679,6 +679,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 arguments_list=[arguments],
                 report_code=commit_report.code,
                 parallel_idx=arguments["upload_pk"],
+                run_fully_parallel=run_fully_parallel,
                 in_parallel=True,
                 is_final=False,
             )
@@ -696,6 +697,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 "commitid": commit.commitid,
                 "commit_yaml": commit_yaml,
                 "report_code": commit_report.code,
+                "run_fully_parallel": run_fully_parallel,
                 "in_parallel": True,
                 _kwargs_key(UploadFlow): checkpoints.data,
             },

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -134,7 +134,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         assert commit, "Commit not found in database."
         repository = commit.repository
 
-        parallel_processing = ParallelProcessing.from_task_args(repoid, **kwargs)
+        parallel_processing = ParallelProcessing.from_task_args(**kwargs)
 
         if parallel_processing.is_parallel:
             # need to transform processing_results produced by chord to get it into the

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -89,7 +89,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             ),
         )
 
-        parallel_processing = ParallelProcessing.from_task_args(repoid, **kwargs)
+        parallel_processing = ParallelProcessing.from_task_args(**kwargs)
 
         if parallel_processing.is_parallel:
             log.info(


### PR DESCRIPTION
The parallel upload processing feature flag had an edge-case where toggling the feature flag would effect all *already running* tasks, moving them from experiment mode to fully parallel mode.

Now this decision is being made at the very beginning in `Upload`, and the scheduled tasks adhere to that decision.