### PR TITLE
Delete intermediate report files used in parallel Processing

### DIFF
--- a/services/archive.py
+++ b/services/archive.py
@@ -38,13 +38,13 @@ class MinioEndpoints(Enum):
 # Service class for performing archive operations. Meant to work against the
 # underlying StorageService
 class ArchiveService(object):
-    root = None
+    root: str
     """
     The root level of the archive. In s3 terms,
     this would be the name of the bucket
     """
 
-    storage_hash = None
+    storage_hash: str
     """
     A hash key of the repo for internal storage
     """
@@ -251,6 +251,13 @@ class ArchiveService(object):
         Generic method to delete a file from the archive.
         """
         self.storage.delete_file(self.root, path)
+
+    @sentry_sdk.trace()
+    def delete_files(self, paths: list[str]) -> list[bool]:
+        """
+        Batch-deletes the gives list of files.
+        """
+        return self.storage.delete_files(self.root, paths)
 
     def delete_repo_files(self) -> int:
         """

--- a/tasks/parallel_verification.py
+++ b/tasks/parallel_verification.py
@@ -72,21 +72,34 @@ class ParallelVerificationTask(BaseCodecovTask, name=parallel_verification_task_
         )
 
         # Retrieve serial results
-        serial_files_and_sessions = json.loads(
-            archive_service.read_file(
-                parallel_path_to_serial_path(
-                    parallel_paths["files_and_sessions_path"], last_upload_pk
-                )
-            )
+        serial_fas_path = parallel_path_to_serial_path(
+            parallel_paths["files_and_sessions_path"], last_upload_pk
         )
-        serial_chunks = archive_service.read_file(
-            parallel_path_to_serial_path(parallel_paths["chunks_path"], last_upload_pk)
-        ).decode(errors="replace")
+        serial_files_and_sessions = json.loads(
+            archive_service.read_file(serial_fas_path)
+        )
+        serial_chunks_path = parallel_path_to_serial_path(
+            parallel_paths["chunks_path"], last_upload_pk
+        )
+        serial_chunks = archive_service.read_file(serial_chunks_path).decode(
+            errors="replace"
+        )
         serial_report = report_service.build_report(
             serial_chunks,
             serial_files_and_sessions["files"],
             serial_files_and_sessions["sessions"],
             None,
+        )
+
+        # after the comparison is done, these files are not needed anymore,
+        # and should be cleaned up
+        archive_service.delete_files(
+            [
+                parallel_paths["files_and_sessions_path"],
+                parallel_paths["chunks_path"],
+                serial_fas_path,
+                serial_chunks_path,
+            ]
         )
 
         top_level_totals_match = True

--- a/tasks/tests/integration/test_upload_e2e.py
+++ b/tasks/tests/integration/test_upload_e2e.py
@@ -279,6 +279,13 @@ end_of_record
             }
         )
 
+    # we expect the following files:
+    # chunks+json for the base commit
+    # 4 * raw uploads
+    # chunks+json, `files_array` and `comparison` for the finished upload
+    archive = mock_storage.storage["archive"]
+    assert len(archive) == 2 + 4 + 4
+
     report_service = ReportService(UserYaml({}))
     report = report_service.get_existing_report_for_commit(commit, report_code=None)
 
@@ -332,7 +339,7 @@ end_of_record
         (2, 4),
     ]
 
-    archive = mock_storage.storage["archive"]
+    assert len(archive) == 2 + 5 + 4
     repo_hash = ArchiveService.get_archive_hash(repository)
     raw_chunks_path = f"v4/repos/{repo_hash}/commits/{commitid}/chunks.txt"
     assert raw_chunks_path in archive
@@ -617,3 +624,10 @@ end_of_record
     assert {upload.order_number for upload in uploads} == {
         session.id for session in base_sessions.values()
     }
+
+    # we expect the following files:
+    # chunks+json, `files_array` for the base commit
+    # 6 * raw uploads
+    # chunks+json, `files_array` for the carryforwarded commit (no `comparison`)
+    archive = mock_storage.storage["archive"]
+    assert len(archive) == 3 + 6 + 3


### PR DESCRIPTION
This makes sure the following intermediate files are being cleaned up / deleted after parallel processing:

- The "partial Report" files, after merging
- The copy of the *initial* and the *final* "master Report" used in parallel verification
- The parallel version of the "master Report" used for verification