### PR TITLE
Keep track of in-progress Uploads

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -134,7 +134,6 @@ def mock_configuration(mocker):
                 "secret_access_key": "codecov-default-secret",
                 "verify_ssl": False,
             },
-            "redis_url": "redis://redis:@localhost:6379/",
             "smtp": {
                 "host": "mailhog",
                 "port": 1025,

--- a/services/processing/state.py
+++ b/services/processing/state.py
@@ -77,6 +77,9 @@ class ProcessingState:
     def mark_uploads_as_processing(self, upload_ids: list[int]):
         self._redis.sadd(self._redis_key("processing"), *upload_ids)
 
+    def clear_in_progress_uploads(self, upload_ids: list[int]):
+        self._redis.srem(self._redis_key("processing"), *upload_ids)
+
     def mark_upload_as_processed(self, upload_id: int):
         res = self._redis.smove(
             self._redis_key("processing"), self._redis_key("processed"), upload_id

--- a/services/processing/state.py
+++ b/services/processing/state.py
@@ -1,0 +1,103 @@
+"""
+This abstracts the "processing state" for a commit.
+
+It takes care that each upload for a specific commit is going through the following
+states:
+
+- "processing": when an upload was received and is being parsed/processed.
+- "processed": the upload has been processed and an "intermediate report" has been stored,
+  the upload is now waiting to be merged into the "master report".
+- "merged": the upload was fully merged into the "master report".
+
+The logic in this file also makes sure that processing and merging happens in an "optimal" way
+meaning that:
+
+- "postprocessing", which means triggering notifications and other followup work
+  only happens once for a commit.
+- merging should happen in batches, as that involves loading a bunch of "intermediate report"s
+  into memory, which should be bounded.
+- (ideally in the future) an upload that has been processed into an "intermediate report"
+  should be merged directly into the "master report" without doing a storage roundtrip for that
+  "intermediate report".
+"""
+
+from dataclasses import dataclass
+
+from services.redis import get_redis_connection
+
+MERGE_BATCH_SIZE = 5
+
+
+@dataclass
+class UploadNumbers:
+    processing: int
+    """
+    The number of uploads currently being processed.
+    """
+
+    processed: int
+    """
+    The number of uploads that have been processed,
+    and are waiting on being merged into the "master report".
+    """
+
+
+def should_perform_merge(uploads: UploadNumbers) -> bool:
+    """
+    Determines whether a merge should be performed.
+
+    This is the case when no more uploads are expected,
+    or we reached the desired batch size for merging.
+    """
+    return uploads.processing == 0 or uploads.processed >= MERGE_BATCH_SIZE
+
+
+def should_trigger_postprocessing(uploads: UploadNumbers) -> bool:
+    """
+    Determines whether post-processing steps, such as notifications, etc,
+    should be performed.
+
+    This is the case when no more uploads are expected,
+    and all the processed uploads have been merged into the "master report".
+    """
+    return uploads.processing == 0 and uploads.processed == 0
+
+
+class ProcessingState:
+    def __init__(self, repoid: int, commitsha: str) -> None:
+        self._redis = get_redis_connection()
+        self.repoid = repoid
+        self.commitsha = commitsha
+
+    def get_upload_numbers(self):
+        processing = self._redis.scard(self._redis_key("processing"))
+        processed = self._redis.scard(self._redis_key("processed"))
+        return UploadNumbers(processing, processed)
+
+    def mark_uploads_as_processing(self, upload_ids: list[int]):
+        self._redis.sadd(self._redis_key("processing"), *upload_ids)
+
+    def mark_upload_as_processed(self, upload_id: int):
+        res = self._redis.smove(
+            self._redis_key("processing"), self._redis_key("processed"), upload_id
+        )
+        if not res:
+            # this can happen when `upload_id` was never in the source set,
+            # which probably is the case during initial deployment as
+            # the code adding this to the initial set was not deployed yet
+            # TODO: make sure to remove this code after a grace period
+            self._redis.sadd(self._redis_key("processed"), upload_id)
+
+    def mark_uploads_as_merged(self, upload_ids: list[int]):
+        self._redis.srem(self._redis_key("processed"), *upload_ids)
+
+    def get_uploads_for_merging(self) -> set[int]:
+        return set(
+            int(id)
+            for id in self._redis.srandmember(
+                self._redis_key("processed"), MERGE_BATCH_SIZE
+            )
+        )
+
+    def _redis_key(self, state: str) -> str:
+        return f"upload-processing-state/{self.repoid}/{self.commitsha}/{state}"

--- a/services/tests/test_processing_state.py
+++ b/services/tests/test_processing_state.py
@@ -1,0 +1,71 @@
+from uuid import uuid4
+
+from services.processing.state import (
+    ProcessingState,
+    should_perform_merge,
+    should_trigger_postprocessing,
+)
+
+
+def test_single_upload():
+    state = ProcessingState(1234, uuid4().hex)
+    state.mark_uploads_as_processing([1])
+
+    state.mark_upload_as_processed(1)
+
+    # this is the only in-progress upload, nothing more to expect
+    assert should_perform_merge(state.get_upload_numbers())
+
+    assert state.get_uploads_for_merging() == {1}
+    state.mark_uploads_as_merged([1])
+
+    assert should_trigger_postprocessing(state.get_upload_numbers())
+
+
+def test_concurrent_uploads():
+    state = ProcessingState(1234, uuid4().hex)
+    state.mark_uploads_as_processing([1])
+
+    state.mark_upload_as_processed(1)
+    # meanwhile, another upload comes in:
+    state.mark_uploads_as_processing([2])
+
+    # not merging/postprocessing yet, as that will be debounced with the second upload
+    assert not should_perform_merge(state.get_upload_numbers())
+
+    state.mark_upload_as_processed(2)
+
+    assert should_perform_merge(state.get_upload_numbers())
+
+    assert state.get_uploads_for_merging() == {1, 2}
+    state.mark_uploads_as_merged([1, 2])
+
+    assert should_trigger_postprocessing(state.get_upload_numbers())
+
+
+def test_batch_merging_many_uploads():
+    state = ProcessingState(1234, uuid4().hex)
+
+    state.mark_uploads_as_processing([1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    for id in range(1, 9):
+        state.mark_upload_as_processed(id)
+
+    # we have only processed 8 out of 9. we want to do a batched merge
+    assert should_perform_merge(state.get_upload_numbers())
+    merging = state.get_uploads_for_merging()
+    assert len(merging) == 5  # = MERGE_BATCH_SIZE
+    state.mark_uploads_as_merged(merging)
+
+    # but no notifications yet
+    assert not should_trigger_postprocessing(state.get_upload_numbers())
+
+    state.mark_upload_as_processed(9)
+
+    # with the last upload being processed, we do another merge, and then trigger notifications
+    assert should_perform_merge(state.get_upload_numbers())
+    merging = state.get_uploads_for_merging()
+    assert len(merging) == 4
+    state.mark_uploads_as_merged(merging)
+
+    assert should_trigger_postprocessing(state.get_upload_numbers())

--- a/services/tests/test_redis.py
+++ b/services/tests/test_redis.py
@@ -1,10 +1,8 @@
 from services.redis import get_redis_connection
-from test_utils.base import BaseTestCase
 
 
-class TestRedis(BaseTestCase):
-    def test_get_redis_connection(self, mocker, mock_configuration):
-        mocked = mocker.patch("services.redis.Redis.from_url")
-        res = get_redis_connection()
-        assert res is not None
-        mocked.assert_called_with("redis://redis:@localhost:6379/")
+def test_get_redis_connection(mocker):
+    mocked = mocker.patch("services.redis.Redis.from_url")
+    res = get_redis_connection()
+    assert res is not None
+    mocked.assert_called_with("redis://redis:6379")

--- a/tasks/tests/unit/test_send_email_task.py
+++ b/tasks/tests/unit/test_send_email_task.py
@@ -30,7 +30,6 @@ def mock_configuration_no_smtp(mocker):
                 "secret_access_key": "codecov-default-secret",
                 "verify_ssl": False,
             },
-            "redis_url": "redis://redis:@localhost:6379/",
         },
         "setup": {
             "codecov_url": "https://codecov.io",

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -280,7 +280,7 @@ class TestUploadProcessorTask(object):
 
     @pytest.mark.django_db(databases={"default"})
     def test_upload_processor_call_with_upload_obj(
-        self, mocker, mock_configuration, dbsession, mock_storage
+        self, mocker, dbsession, mock_storage
     ):
         mocker.patch.object(
             USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID,

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -51,7 +51,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         codecov_vcr,
         mock_storage,
-        mock_redis,
         celery_app,
     ):
         mocker.patch.object(
@@ -149,11 +148,6 @@ class TestUploadProcessorTask(object):
         }
 
         mocked_1.assert_called_with(commit.commitid, None)
-        mock_redis.lock.assert_called_with(
-            f"upload_processing_lock_{commit.repoid}_{commit.commitid}",
-            blocking_timeout=5,
-            timeout=300,
-        )
 
     @pytest.mark.integration
     @pytest.mark.django_db(databases={"default"})
@@ -164,7 +158,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         codecov_vcr,
         mock_storage,
-        mock_redis,
         celery_app,
     ):
         mocker.patch.object(
@@ -272,11 +265,6 @@ class TestUploadProcessorTask(object):
         }
 
         mocked_1.assert_called_with(commit.commitid, None)
-        mock_redis.lock.assert_called_with(
-            f"upload_processing_lock_{commit.repoid}_{commit.commitid}",
-            blocking_timeout=5,
-            timeout=300,
-        )
 
     @pytest.mark.django_db(databases={"default"})
     def test_upload_processor_call_with_upload_obj(
@@ -400,7 +388,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         codecov_vcr,
         mock_storage,
-        mock_redis,
         celery_app,
     ):
         mocker.patch.object(
@@ -462,11 +449,6 @@ class TestUploadProcessorTask(object):
         assert expected_result == result
         assert commit.message == "dsidsahdsahdsa"
         mocked_1.assert_called_with(commit.commitid, None)
-        mock_redis.lock.assert_called_with(
-            f"upload_processing_lock_{commit.repoid}_{commit.commitid}",
-            blocking_timeout=5,
-            timeout=300,
-        )
 
     @pytest.mark.django_db(databases={"default"})
     def test_upload_task_call_exception_within_individual_upload(
@@ -476,7 +458,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         codecov_vcr,
         mock_storage,
-        mock_redis,
         celery_app,
     ):
         commit = CommitFactory.create(
@@ -607,7 +588,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         mock_repo_provider,
         mock_storage,
-        mock_redis,
         celery_app,
     ):
         mocked_1 = mocker.patch.object(ArchiveService, "read_chunks")
@@ -697,7 +677,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         mock_repo_provider,
         mock_storage,
-        mock_redis,
     ):
         mocked_1 = mocker.patch.object(ArchiveService, "read_chunks")
         mocked_1.return_value = None
@@ -765,7 +744,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         mock_repo_provider,
         mock_storage,
-        mock_redis,
         celery_app,
     ):
         mocked_1 = mocker.patch.object(ArchiveService, "read_chunks")
@@ -860,7 +838,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         mock_repo_provider,
         mock_storage,
-        mock_redis,
         celery_app,
     ):
         mocked_1 = mocker.patch.object(ArchiveService, "read_chunks")
@@ -951,7 +928,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         mock_repo_provider,
         mock_storage,
-        mock_redis,
         celery_app,
     ):
         mocked_1 = mocker.patch.object(ArchiveService, "read_chunks")
@@ -996,7 +972,6 @@ class TestUploadProcessorTask(object):
         dbsession,
         mock_repo_provider,
         mock_storage,
-        mock_redis,
         celery_app,
     ):
         mocked_1 = mocker.patch.object(ArchiveService, "read_chunks")

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -37,6 +37,7 @@ from helpers.reports import delete_archive_setting
 from helpers.save_commit_error import save_commit_error
 from services.archive import ArchiveService
 from services.bundle_analysis.report import BundleAnalysisReportService
+from services.processing.state import ProcessingState
 from services.redis import download_archive_from_redis, get_redis_connection
 from services.report import (
     BaseReportService,
@@ -671,6 +672,11 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         checkpoints: CheckpointLogger,
         run_fully_parallel: bool,
     ):
+        state = ProcessingState(commit.repoid, commit.commitid)
+        state.mark_uploads_as_processing(
+            [int(upload["upload_pk"]) for upload in argument_list]
+        )
+
         parallel_processing_tasks = [
             upload_processor_task.s(
                 repoid=commit.repoid,


### PR DESCRIPTION
This introduces a new component that is responsible for keeping track of the processing status of individual uploads.

The goal here is that this state tracking can make batched Report merging and debounced notifications a lot more intentional.

The state tracking is achieved by keeping sets of `upload_id`s in Redis, one for in-progress (currently being parsed) Uploads, another for processed (and waiting to be merged) Uploads.

---

This is part of https://github.com/codecov/engineering-team/issues/2618