### PR TITLE
Clean up usage of `parallel_idx`

### DIFF
--- a/helpers/parallel_upload_processing.py
+++ b/helpers/parallel_upload_processing.py
@@ -3,7 +3,7 @@ import sentry_sdk
 
 @sentry_sdk.trace
 def save_incremental_report_results(
-    report_service, commit, report, parallel_idx, report_code
+    report_service, commit, report, upload_id, report_code
 ):
     commitid = commit.commitid
     archive_service = report_service.get_archive_service(commit.repository)
@@ -14,17 +14,17 @@ def save_incremental_report_results(
     _, files_and_sessions = report.to_database()
 
     chunks_url = archive_service.write_parallel_experiment_file(
-        commitid, chunks, report_code, f"incremental/chunk{parallel_idx}"
+        commitid, chunks, report_code, f"incremental/chunk{upload_id}"
     )
     files_and_sessions_url = archive_service.write_parallel_experiment_file(
         commitid,
         files_and_sessions,
         report_code,
-        f"incremental/files_and_sessions{parallel_idx}",
+        f"incremental/files_and_sessions{upload_id}",
     )
 
     parallel_incremental_result = {
-        "parallel_idx": parallel_idx,
+        "upload_pk": upload_id,
         "chunks_path": chunks_url,
         "files_and_sessions_path": files_and_sessions_url,
     }

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -678,7 +678,6 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 commit_yaml=commit_yaml,
                 arguments_list=[arguments],
                 report_code=commit_report.code,
-                parallel_idx=arguments["upload_pk"],
                 run_fully_parallel=run_fully_parallel,
                 in_parallel=True,
                 is_final=False,

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -583,9 +583,8 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 report_class=EditableReport,
             )
             return {
-                "parallel_idx": partial_report["parallel_idx"],
-                "report": report,
                 "upload_pk": partial_report["upload_pk"],
+                "report": report,
             }
 
         def merge_report(cumulative_report: Report, obj):
@@ -598,7 +597,6 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                         repoid=repoid,
                         commit=commitid,
                         upload_pk=obj["upload_pk"],
-                        parallel_idx=obj["parallel_idx"],
                     ),
                 )
 

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -286,7 +286,6 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
                     upload_id,
                     report_code,
                 )
-                parallel_incremental_result["upload_pk"] = upload_id
 
                 log.info(
                     "Saved incremental report results to storage",


### PR DESCRIPTION
I replaced this by just using the upload_id a while back, so this PR here will just finish that cleanup by just removing the `parallel_idx` completely.