### PR TITLE
Enable cache monitoring in Sentry Redis integration

### DIFF
--- a/helpers/sentry.py
+++ b/helpers/sentry.py
@@ -41,7 +41,7 @@ def initialize_sentry() -> None:
             CeleryIntegration(monitor_beat_tasks=True),
             DjangoIntegration(signals_spans=False),
             SqlalchemyIntegration(),
-            RedisIntegration(),
+            RedisIntegration(cache_prefixes=["cache:"]),
             HttpxIntegration(),
         ],
         release=os.getenv("SENTRY_RELEASE", version_str),


### PR DESCRIPTION
According to https://docs.sentry.io/platforms/python/integrations/redis/#options, adding an appropriate `cache_prefix` should make sure that things get automatically populated in the Sentry "Caches" insights page.

It might still be worth manually instrumenting the underlying cache code in `shared` though.