### PR TITLE
Switch to `orjson` as faster JSON implementation

### DIFF
--- a/database/utils.py
+++ b/database/utils.py
@@ -1,8 +1,8 @@
-import json
 import logging
 import time
 from typing import Any, Callable, Optional
 
+import orjson
 from shared.storage.exceptions import FileNotInStorageError
 from shared.utils.ReportEncoder import ReportEncoder
 
@@ -102,7 +102,7 @@ class ArchiveField:
                 # we're within the timeout window
                 try:
                     file_str = archive_service.read_file(archive_field)
-                    result = self.rehydrate_fn(obj, json.loads(file_str))
+                    result = self.rehydrate_fn(obj, orjson.loads(file_str))
                     if error:
                         # we previously errored and now it succeeded
                         log.info(

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ mock
 openai
 opentelemetry-instrumentation-celery>=0.45b0
 opentelemetry-sdk>=1.24.0
+orjson
 pre-commit
 psycopg2
 PyJWT>=2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -234,6 +234,8 @@ opentelemetry-semantic-conventions==0.45b0
     # via
     #   opentelemetry-instrumentation-celery
     #   opentelemetry-sdk
+orjson==3.10.7
+    # via -r requirements.in
 packaging==24.1
     # via pytest
 platformdirs==3.11.0

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -4,10 +4,10 @@ import logging
 import sys
 import uuid
 from dataclasses import dataclass
-from json import loads
 from time import time
 from typing import Any, Mapping, Sequence
 
+import orjson
 import sentry_sdk
 from asgiref.sync import async_to_sync
 from celery.exceptions import SoftTimeLimitExceeded
@@ -865,7 +865,7 @@ class ReportService(BaseReportService):
         # `report_json` is an `ArchiveField`, so this will trigger an upload
         # FIXME: we do an unnecessary `loads` roundtrip because of this abstraction,
         # and we should just save the `report_json` to archive storage directly instead.
-        commit.report_json = loads(report_json)
+        commit.report_json = orjson.loads(report_json)
 
         # `report` is an accessor which implicitly queries `CommitReport`
         if commit_report := commit.report:

--- a/services/report/languages/coveralls.py
+++ b/services/report/languages/coveralls.py
@@ -1,5 +1,4 @@
-import json
-
+import orjson
 import sentry_sdk
 
 from services.report.languages.base import BaseLanguageProcessor
@@ -27,7 +26,7 @@ def from_json(report: dict, report_builder_session: ReportBuilderSession) -> Non
         # or a string with a json-encoded list.
         coverage: str | list = file["coverage"]
         if isinstance(coverage, str):
-            coverage = json.loads(coverage)
+            coverage = orjson.loads(coverage)
 
         for ln, cov in enumerate(coverage, start=1):
             if cov is not None:

--- a/services/report/parser/version_one.py
+++ b/services/report/parser/version_one.py
@@ -1,9 +1,9 @@
 import base64
-import json
 import logging
 import zlib
 from io import BytesIO
 
+import orjson
 import sentry_sdk
 
 from services.report.parser.types import (
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 class VersionOneReportParser(object):
     @sentry_sdk.trace
     def parse_raw_report_from_bytes(self, raw_report: bytes):
-        data = json.loads(raw_report)
+        data = orjson.loads(raw_report)
         return VersionOneParsedRawReport(
             toc=data["network_files"],
             env=None,

--- a/services/report/report_processor.py
+++ b/services/report/report_processor.py
@@ -1,8 +1,8 @@
-import json
 import logging
 from typing import Literal
 from xml.etree.ElementTree import Element
 
+import orjson
 import sentry_sdk
 from lxml import etree
 from shared.metrics import Counter, Histogram
@@ -119,7 +119,7 @@ def report_type_matching(
         return raw_report, "txt"
 
     try:
-        processed = json.load(report.file_contents)
+        processed = orjson.load(report.file_contents)
         if isinstance(processed, dict) or isinstance(processed, list):
             return processed, "json"
     except ValueError:

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -4,9 +4,9 @@ import time
 import uuid
 from copy import deepcopy
 from datetime import datetime
-from json import loads
 from typing import Any, Dict, List, Optional
 
+import orjson
 import sentry_sdk
 from asgiref.sync import async_to_sync
 from celery import chain, chord
@@ -177,7 +177,7 @@ class UploadContext:
         log.debug("Fetching arguments from redis %s", uploads_list_key)
         while arguments := self.redis_connection.lpop(uploads_list_key, count=50):
             for arg in arguments:
-                yield loads(arg)
+                yield orjson.loads(arg)
 
     def normalize_arguments(self, commit: Commit, arguments: dict[str, Any]):
         """

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -1,11 +1,11 @@
 import contextlib
 import functools
-import json
 import logging
 import re
 from concurrent.futures import ThreadPoolExecutor
 from enum import Enum
 
+import orjson
 from redis.exceptions import LockError
 from redis.lock import Lock
 from shared.celery_config import (
@@ -262,7 +262,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         # tell when the report is final.
         try:
             if commit.report_json:
-                report_json_size = len(json.dumps(commit.report_json))
+                report_json_size = len(orjson.dumps(commit.report_json))
                 archive_service = ArchiveService(commit.repository)
                 chunks_size = len(
                     archive_service.read_chunks(commit.commitid, report_code)
@@ -540,7 +540,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
             )
 
             try:
-                files_and_sessions = json.loads(archive_service.read_file(fas_path))
+                files_and_sessions = orjson.loads(archive_service.read_file(fas_path))
                 chunks = archive_service.read_file(chunks_path).decode(errors="replace")
                 report = report_service.build_report(
                     chunks,
@@ -572,7 +572,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
             chunks = archive_service.read_file(partial_report["chunks_path"]).decode(
                 errors="replace"
             )
-            files_and_sessions = json.loads(
+            files_and_sessions = orjson.loads(
                 archive_service.read_file(partial_report["files_and_sessions_path"])
             )
             report = report_service.build_report(


### PR DESCRIPTION
`orjson` is supposed to be a faster JSON parser/serializer, with benchmark claiming its ~3x faster at parsing, and up to ~10x faster serializing.

Here I mostly changed the `loads` codepaths, and most of the `dumps` ones that do not define a custom serializer implementation.