### PR TITLE
chore: fix (some) type errors in BA notify

### DIFF
--- a/services/activation.py
+++ b/services/activation.py
@@ -104,7 +104,7 @@ def activate_user(db_session, org_ownerid: int, user_ownerid: int) -> bool:
     return activation_success
 
 
-def schedule_new_user_activated_task(self, org_ownerid, user_ownerid):
+def schedule_new_user_activated_task(org_ownerid, user_ownerid):
     celery_app.send_task(
         new_user_activated_task_name,
         args=None,

--- a/services/bundle_analysis/notify/contexts/comment.py
+++ b/services/bundle_analysis/notify/contexts/comment.py
@@ -42,18 +42,14 @@ class BundleAnalysisPRCommentNotificationContext(BaseBundleAnalysisNotificationC
 
     notification_type = NotificationType.PR_COMMENT
 
-    pull: EnrichedPull = NotificationContextField[EnrichedPull]()
-    bundle_analysis_comparison: BundleAnalysisComparison = NotificationContextField[
-        BundleAnalysisComparison
-    ]()
-    commit_status_level: CommitStatusLevel = NotificationContextField[
-        CommitStatusLevel
-    ]()
-    should_use_upgrade_comment: bool = NotificationContextField[bool]()
+    pull = NotificationContextField[EnrichedPull]()
+    bundle_analysis_comparison = NotificationContextField[BundleAnalysisComparison]()
+    commit_status_level = NotificationContextField[CommitStatusLevel]()
+    should_use_upgrade_comment = NotificationContextField[bool]()
 
 
 class BundleAnalysisPRCommentContextBuilder(NotificationContextBuilder):
-    fields_of_interest: tuple[str] = (
+    fields_of_interest: tuple[str, ...] = (
         "commit_report",
         "bundle_analysis_report",
         "user_config",
@@ -176,8 +172,7 @@ class BundleAnalysisPRCommentContextBuilder(NotificationContextBuilder):
                 )
                 if successful_activation:
                     schedule_new_user_activated_task(
-                        activate_seat_info.owner_id,
-                        activate_seat_info.author_id,
+                        activate_seat_info.owner_id, activate_seat_info.author_id
                     )
                     self._notification_context.should_use_upgrade_comment = False
                 else:
@@ -215,4 +210,4 @@ class BundleAnalysisPRCommentContextBuilder(NotificationContextBuilder):
         )
 
     def get_result(self) -> BundleAnalysisPRCommentNotificationContext:
-        return self._notification_context
+        return self._notification_context  # type: ignore

--- a/services/bundle_analysis/notify/contexts/commit_status.py
+++ b/services/bundle_analysis/notify/contexts/commit_status.py
@@ -39,16 +39,12 @@ from services.urls import get_bundle_analysis_pull_url, get_commit_url
 class CommitStatusNotificationContext(BaseBundleAnalysisNotificationContext):
     notification_type = NotificationType.COMMIT_STATUS
 
-    pull: EnrichedPull | None = NotificationContextField[EnrichedPull | None]()
-    bundle_analysis_comparison: BundleAnalysisComparison = NotificationContextField[
-        BundleAnalysisComparison
-    ]()
-    commit_status_level: CommitStatusLevel = NotificationContextField[
-        CommitStatusLevel
-    ]()
-    commit_status_url: str = NotificationContextField[str]()
-    cache_ttl: int = NotificationContextField[int]()
-    should_use_upgrade_comment: bool = NotificationContextField[bool]()
+    pull = NotificationContextField[EnrichedPull | None]()
+    bundle_analysis_comparison = NotificationContextField[BundleAnalysisComparison]()
+    commit_status_level = NotificationContextField[CommitStatusLevel]()
+    commit_status_url = NotificationContextField[str]()
+    cache_ttl = NotificationContextField[int]()
+    should_use_upgrade_comment = NotificationContextField[bool]()
 
     @property
     def base_commit(self) -> Commit:
@@ -58,7 +54,7 @@ class CommitStatusNotificationContext(BaseBundleAnalysisNotificationContext):
 
 
 class CommitStatusNotificationContextBuilder(NotificationContextBuilder):
-    fields_of_interest: tuple[str] = (
+    fields_of_interest: tuple[str, ...] = (
         "commit_report",
         "bundle_analysis_report",
         "user_config",

--- a/services/bundle_analysis/notify/contexts/tests/test_comment_context.py
+++ b/services/bundle_analysis/notify/contexts/tests/test_comment_context.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from shared.config import PATCH_CENTRIC_DEFAULT_CONFIG
 from shared.yaml import UserYaml
 
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
@@ -145,7 +146,11 @@ class TestBundleAnalysisPRCommentNotificationContext:
     @pytest.mark.parametrize(
         "config, total_size_delta",
         [
-            pytest.param({}, 100, id="default_config"),
+            pytest.param(
+                PATCH_CENTRIC_DEFAULT_CONFIG,
+                100,
+                id="default_config",
+            ),
             pytest.param(
                 {"comment": {"require_bundle_changes": False}},
                 100,
@@ -281,7 +286,7 @@ class TestBundleAnalysisPRCommentNotificationContext:
         enriched_pull = get_enriched_pull_setting_up_mocks(
             dbsession, mocker, (head_commit, base_commit)
         )
-        user_yaml = UserYaml.from_dict({})
+        user_yaml = UserYaml.from_dict(PATCH_CENTRIC_DEFAULT_CONFIG)
         builder = BundleAnalysisPRCommentContextBuilder().initialize(
             head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
         )
@@ -304,7 +309,7 @@ class TestBundleAnalysisPRCommentNotificationContext:
 
     def test_initialize_from_context(self, dbsession, mocker):
         head_commit, _ = get_commit_pair(dbsession)
-        user_yaml = UserYaml.from_dict({})
+        user_yaml = UserYaml.from_dict(PATCH_CENTRIC_DEFAULT_CONFIG)
         builder = BundleAnalysisPRCommentContextBuilder().initialize(
             head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
         )

--- a/services/bundle_analysis/notify/helpers.py
+++ b/services/bundle_analysis/notify/helpers.py
@@ -1,5 +1,5 @@
 import numbers
-from typing import Iterable, Literal
+from typing import Literal
 
 from shared.bundle_analysis import BundleAnalysisComparison, BundleChange
 from shared.django_apps.codecov_auth.models import Service
@@ -43,7 +43,7 @@ def is_comment_configured(yaml: UserYaml, owner: Owner) -> None | NotificationTy
 
 def get_notification_types_configured(
     yaml: UserYaml, owner: Owner
-) -> tuple[NotificationType]:
+) -> tuple[NotificationType, ...]:
     """Gets a tuple with all the different bundle analysis notifications that we should attempt to send,
     based on the given YAML"""
     notification_types = [
@@ -65,20 +65,20 @@ def get_github_app_used(torngit: TorngitBaseAdapter | None) -> int | None:
 
 def bytes_readable(bytes: int) -> str:
     """Converts bytes into human-readable string (up to GB)"""
-    value = abs(bytes)
-    expoent_index = 0
+    value: float = abs(bytes)
+    exponent_index = 0
 
-    while value >= 1000 and expoent_index < 3:
+    while value >= 1000 and exponent_index < 3:
         value /= 1000
-        expoent_index += 1
+        exponent_index += 1
 
-    expoent_str = [" bytes", "kB", "MB", "GB"][expoent_index]
-    rounted_value = round(value, 2)
-    return f"{rounted_value}{expoent_str}"
+    exponent_str = [" bytes", "kB", "MB", "GB"][exponent_index]
+    rounded_value = round(value, 2)
+    return f"{rounded_value}{exponent_str}"
 
 
 def to_BundleThreshold(value: int | float | BundleThreshold) -> BundleThreshold:
-    if isinstance(value, Iterable) and value[0] in ["absolute", "percentage"]:
+    if isinstance(value, (list, tuple)) and value[0] in ["absolute", "percentage"]:
         return BundleThreshold(*value)
     if isinstance(value, numbers.Integral):
         return BundleThreshold("absolute", value)

--- a/services/bundle_analysis/notify/messages/tests/test_comment.py
+++ b/services/bundle_analysis/notify/messages/tests/test_comment.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from mock import AsyncMock
+from shared.config import PATCH_CENTRIC_DEFAULT_CONFIG
 from shared.torngit.exceptions import TorngitClientError
 from shared.typings.torngit import TorngitInstanceData
 from shared.validation.types import BundleThreshold
@@ -43,7 +44,7 @@ class TestCommentMesage:
         enriched_pull = get_enriched_pull_setting_up_mocks(
             dbsession, mocker, (head_commit, base_commit)
         )
-        user_yaml = UserYaml.from_dict({})
+        user_yaml = UserYaml.from_dict(PATCH_CENTRIC_DEFAULT_CONFIG)
         builder = BundleAnalysisPRCommentContextBuilder().initialize(
             head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
         )

--- a/services/bundle_analysis/notify/messages/tests/test_commit_status.py
+++ b/services/bundle_analysis/notify/messages/tests/test_commit_status.py
@@ -2,6 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from mock import AsyncMock
+from shared.config import PATCH_CENTRIC_DEFAULT_CONFIG
 from shared.torngit.exceptions import TorngitClientError
 from shared.typings.torngit import TorngitInstanceData
 from shared.yaml import UserYaml
@@ -58,15 +59,23 @@ class TestCommitStatusMessage:
         "user_config, expected",
         [
             pytest.param(
-                {}, "Bundle change: -48.89% (Threshold: 5.0%)", id="default_config"
+                PATCH_CENTRIC_DEFAULT_CONFIG,
+                "Bundle change: -48.89% (Threshold: 5.0%)",
+                id="default_config",
             ),
             pytest.param(
-                {"bundle_analysis": {"warning_threshold": 500000}},
+                {
+                    **PATCH_CENTRIC_DEFAULT_CONFIG,
+                    "bundle_analysis": {"warning_threshold": 500000},
+                },
                 "Bundle change: -372.56kB (Threshold: 500.0kB)",
                 id="success_absolute_threshold",
             ),
             pytest.param(
-                {"bundle_analysis": {"warning_threshold": 300000}},
+                {
+                    **PATCH_CENTRIC_DEFAULT_CONFIG,
+                    "bundle_analysis": {"warning_threshold": 300000},
+                },
                 "Bundle change: -372.56kB (Threshold: 300.0kB)",
                 id="warning_absolute_threshold",
             ),
@@ -105,17 +114,23 @@ class TestCommitStatusMessage:
         "user_config, expected",
         [
             pytest.param(
-                {},
+                PATCH_CENTRIC_DEFAULT_CONFIG,
                 "Passed with Warnings - Bundle change: 95.64% (Threshold: 5.0%)",
                 id="default_config",
             ),
             pytest.param(
-                {"bundle_analysis": {"warning_threshold": 500000}},
+                {
+                    **PATCH_CENTRIC_DEFAULT_CONFIG,
+                    "bundle_analysis": {"warning_threshold": 500000},
+                },
                 "Bundle change: 372.56kB (Threshold: 500.0kB)",
                 id="success_absolute_threshold",
             ),
             pytest.param(
-                {"bundle_analysis": {"warning_threshold": 300000}},
+                {
+                    **PATCH_CENTRIC_DEFAULT_CONFIG,
+                    "bundle_analysis": {"warning_threshold": 300000},
+                },
                 "Passed with Warnings - Bundle change: 372.56kB (Threshold: 300.0kB)",
                 id="warning_absolute_threshold",
             ),
@@ -191,7 +206,7 @@ class TestCommitStatusMessage:
                 should_activate_seat=ShouldActivateSeat.NO_ACTIVATE
             ),
         )
-        user_yaml = UserYaml.from_dict({})
+        user_yaml = UserYaml.from_dict(PATCH_CENTRIC_DEFAULT_CONFIG)
         builder = CommitStatusNotificationContextBuilder().initialize(
             head_commit, user_yaml, GITHUB_APP_INSTALLATION_DEFAULT_NAME
         )

--- a/services/bundle_analysis/notify/tests/test_notify_service.py
+++ b/services/bundle_analysis/notify/tests/test_notify_service.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from shared.config import PATCH_CENTRIC_DEFAULT_CONFIG
 from shared.yaml import UserYaml
 
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
@@ -106,13 +107,15 @@ class TestCreateContextForNotification:
             mock_storage,
             sample_report_number=1,
         )
-        service = BundleAnalysisNotifyService(head_commit, UserYaml.from_dict({}))
+        service = BundleAnalysisNotifyService(
+            head_commit, UserYaml.from_dict(PATCH_CENTRIC_DEFAULT_CONFIG)
+        )
         base_context = service.build_base_context()
         assert base_context.commit_report == head_commit_report
         assert base_context.bundle_analysis_report.session_count() == 19
 
     def test_create_context_success(self, dbsession, mock_storage, mocker):
-        current_yaml = UserYaml.from_dict({})
+        current_yaml = UserYaml.from_dict(PATCH_CENTRIC_DEFAULT_CONFIG)
         head_commit, base_commit = get_commit_pair(dbsession)
         head_commit_report, base_commit_report = get_report_pair(
             dbsession, (head_commit, base_commit)

--- a/services/bundle_analysis/tests/test_bundle_analysis.py
+++ b/services/bundle_analysis/tests/test_bundle_analysis.py
@@ -5,6 +5,7 @@ import pytest
 from shared.bundle_analysis.comparison import BundleChange
 from shared.bundle_analysis.models import AssetType
 from shared.bundle_analysis.storage import get_bucket_name
+from shared.config import PATCH_CENTRIC_DEFAULT_CONFIG
 from shared.yaml import UserYaml
 
 from database.enums import ReportType
@@ -82,10 +83,11 @@ def hook_mock_pull(mocker, mock_pull):
             ],
             5.56,
             {
+                **PATCH_CENTRIC_DEFAULT_CONFIG,
                 "bundle_analysis": {
                     "status": "informational",
                     "warning_threshold": ["percentage", 5.0],
-                }
+                },
             },
             dedent("""\
             ## [Bundle](URL) Report
@@ -122,10 +124,11 @@ def hook_mock_pull(mocker, mock_pull):
             ],
             5.56,
             {
+                **PATCH_CENTRIC_DEFAULT_CONFIG,
                 "bundle_analysis": {
                     "status": True,
                     "warning_threshold": ["absolute", 10000],
-                }
+                },
             },
             dedent("""\
             ## [Bundle](URL) Report
@@ -162,10 +165,11 @@ def hook_mock_pull(mocker, mock_pull):
             ],
             3.46,
             {
+                **PATCH_CENTRIC_DEFAULT_CONFIG,
                 "bundle_analysis": {
                     "status": "informational",
                     "warning_threshold": ["percentage", 5.0],
-                }
+                },
             },
             dedent("""\
             ## [Bundle](URL) Report
@@ -197,10 +201,11 @@ def hook_mock_pull(mocker, mock_pull):
             ],
             -0.52,
             {
+                **PATCH_CENTRIC_DEFAULT_CONFIG,
                 "bundle_analysis": {
                     "status": "informational",
                     "warning_threshold": ["percentage", 5.0],
-                }
+                },
             },
             dedent("""\
             ## [Bundle](URL) Report
@@ -227,10 +232,11 @@ def hook_mock_pull(mocker, mock_pull):
             ],
             0,
             {
+                **PATCH_CENTRIC_DEFAULT_CONFIG,
                 "bundle_analysis": {
                     "status": "informational",
                     "warning_threshold": ["percentage", 5.0],
-                }
+                },
             },
             dedent("""\
             ## [Bundle](URL) Report


### PR DESCRIPTION
This was not the main goal I had, but these errors were really distracting,
so fixing some type errors in BA notifiers.

One side-effect is that when loading the user_config we are now expecting the comment
config to be `bool | dict` (not `None`). This is in fact the case because we have default
config in place, but the tests didn't know that. Now they do.

I might have also caught a bug in the user activation in terms of the func args.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.