### PR TITLE
Cache and move `load_commit_diff` out of Report lock

### DIFF
--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -649,7 +649,7 @@ class TestUploadFinisherTask(object):
                 dbsession,
                 [
                     {
-                        "processings_so_far": [{"successful": True}],
+                        "processings_so_far": [{"successful": True, "arguments": {}}],
                         "parallel_incremental_result": {"upload_pk": 1},
                     }
                 ],


### PR DESCRIPTION
Moves the `load_commit_diff` portion out of `save_report_results`.

This way, the whole commit diff loading can be moved outside of the Report merge lock. Additionally, the function was decorated with a cache, as the diff for a commit will never change.