### PR TITLE
Retry `UploadFinisher` when Report is locked

### DIFF
--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+import random
 import re
 from enum import Enum
 
@@ -42,7 +43,11 @@ from services.yaml import read_yaml_field
 from tasks.base import BaseCodecovTask
 from tasks.parallel_verification import parallel_verification_task
 from tasks.upload_clean_labels_index import task_name as clean_labels_index_task_name
-from tasks.upload_processor import UPLOAD_PROCESSING_LOCK_NAME, UploadProcessorTask
+from tasks.upload_processor import (
+    MAX_RETRIES,
+    UPLOAD_PROCESSING_LOCK_NAME,
+    UploadProcessorTask,
+)
 
 log = logging.getLogger(__name__)
 
@@ -154,70 +159,84 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 for upload in processing_results["parallel_incremental_result"]
             ]
 
-            report_lock = (
-                acquire_report_lock(repoid, commitid, self.hard_time_limit_task)
-                if parallel_processing is ParallelProcessing.PARALLEL
-                else contextlib.nullcontext()
-            )
-            with report_lock:
-                report_service = ReportService(commit_yaml)
-                archive_service = report_service.get_archive_service(repository)
-                report = perform_report_merging(
-                    report_service,
-                    archive_service,
-                    commit_yaml,
-                    commit,
-                    upload_ids,
-                    parallel_processing,
+            try:
+                report_lock = (
+                    get_report_lock(repoid, commitid, self.hard_time_limit_task)
+                    if parallel_processing is ParallelProcessing.PARALLEL
+                    else contextlib.nullcontext()
                 )
-
-                log.info(
-                    "Saving combined report",
-                    extra=dict(
-                        repoid=repoid,
-                        commit=commitid,
-                        processing_results=processing_results,
-                        parent_task=self.request.parent_id,
-                    ),
-                )
-
-                if parallel_processing is ParallelProcessing.PARALLEL:
-                    pr = processing_results["processings_so_far"][0]["arguments"].get(
-                        "pr"
-                    )
-                    processor_task = UploadProcessorTask()
-                    processor_task.save_report_results(
-                        db_session,
+                with report_lock:
+                    report_service = ReportService(commit_yaml)
+                    archive_service = report_service.get_archive_service(repository)
+                    report = perform_report_merging(
                         report_service,
-                        repository,
+                        archive_service,
+                        commit_yaml,
                         commit,
-                        report,
-                        pr,
-                        report_code,
+                        upload_ids,
+                        parallel_processing,
                     )
-                    state.mark_uploads_as_merged(upload_ids)
 
-                else:
-                    parallel_paths = report_service.save_parallel_report_to_archive(
-                        commit, report, report_code
-                    )
-                    # now that we've built the report and stored it to GCS, we have what we need to
-                    # compare the results with the current upload pipeline. We end execution of the
-                    # finisher task here so that we don't cause any additional side-effects
-
-                    # The verification task that will compare the results of the serial flow and
-                    # the parallel flow, and log the result to determine if parallel flow is
-                    # working properly.
-                    parallel_verification_task.apply_async(
-                        kwargs=dict(
+                    log.info(
+                        "Saving combined report",
+                        extra=dict(
                             repoid=repoid,
-                            commitid=commitid,
-                            commit_yaml=commit_yaml,
-                            report_code=report_code,
-                            parallel_paths=parallel_paths,
+                            commit=commitid,
                             processing_results=processing_results,
+                            parent_task=self.request.parent_id,
                         ),
                     )
+
+                    if parallel_processing is ParallelProcessing.PARALLEL:
+                        pr = processing_results["processings_so_far"][0][
+                            "arguments"
+                        ].get("pr")
+                        processor_task = UploadProcessorTask()
+                        processor_task.save_report_results(
+                            db_session,
+                            report_service,
+                            repository,
+                            commit,
+                            report,
+                            pr,
+                            report_code,
+                        )
+                        state.mark_uploads_as_merged(upload_ids)
+
+                    else:
+                        parallel_paths = report_service.save_parallel_report_to_archive(
+                            commit, report, report_code
+                        )
+                        # now that we've built the report and stored it to GCS, we have what we need to
+                        # compare the results with the current upload pipeline. We end execution of the
+                        # finisher task here so that we don't cause any additional side-effects
+
+                        # The verification task that will compare the results of the serial flow and
+                        # the parallel flow, and log the result to determine if parallel flow is
+                        # working properly.
+                        parallel_verification_task.apply_async(
+                            kwargs=dict(
+                                repoid=repoid,
+                                commitid=commitid,
+                                commit_yaml=commit_yaml,
+                                report_code=report_code,
+                                parallel_paths=parallel_paths,
+                                processing_results=processing_results,
+                            ),
+                        )
+            except LockError:
+                max_retry = 200 * 3**self.request.retries
+                retry_in = min(random.randint(max_retry // 2, max_retry), 60 * 60 * 5)
+                log.warning(
+                    "Unable to acquire report lock. Retrying",
+                    extra=dict(
+                        commit=commitid,
+                        repoid=repoid,
+                        countdown=retry_in,
+                        number_retries=self.request.retries,
+                    ),
+                )
+                self.retry(max_retries=MAX_RETRIES, countdown=retry_in)
 
             cleanup_intermediate_reports(archive_service, commit.commitid, upload_ids)
 
@@ -520,7 +539,7 @@ RegisteredUploadTask = celery_app.register_task(UploadFinisherTask())
 upload_finisher_task = celery_app.tasks[RegisteredUploadTask.name]
 
 
-def acquire_report_lock(repoid: int, commitid: str, hard_time_limit: int) -> Lock:
+def get_report_lock(repoid: int, commitid: str, hard_time_limit: int) -> Lock:
     lock_name = UPLOAD_PROCESSING_LOCK_NAME(repoid, commitid)
     redis_connection = get_redis_connection()
     return redis_connection.lock(


### PR DESCRIPTION
Instead of failing with a `LockError`, this copy-pasted the same retry logic as the `UploadProcessor` has.

---

Fixes [WORKER-PJE](https://codecov.sentry.io/issues/5974196957/)