### PR TITLE
base task: attempt to log CheckpointLogger errors for on_timeout and on_failure

### DIFF
--- a/helpers/checkpoint_logger/flows.py
+++ b/helpers/checkpoint_logger/flows.py
@@ -19,6 +19,8 @@ from helpers.checkpoint_logger import (
     "NOTIF_ERROR_NO_REPORT",
     "NOTIFIED_ERROR",
     "ERROR_NOTIFYING_ERROR",
+    "CELERY_ERROR_TIMEOUT",
+    "CELERY_ERROR_FAILURE",
 )
 @success_events(
     "SKIPPING_NOTIFICATION",
@@ -60,9 +62,11 @@ class UploadFlow(BaseFlow):
     NOTIF_TOO_MANY_RETRIES = auto()
     NOTIF_STALE_HEAD = auto()
     NOTIF_ERROR_NO_REPORT = auto()
+    CELERY_ERROR_TIMEOUT = auto()
+    CELERY_ERROR_FAILURE = auto()
 
 
-@failure_events("TEST_RESULTS_ERROR")
+@failure_events("TEST_RESULTS_ERROR", "CELERY_ERROR_TIMEOUT", "CELERY_ERROR_FAILURE")
 @success_events("TEST_RESULTS_NOTIFY")
 @subflows(
     ("test_results_notification_latency", "TEST_RESULTS_BEGIN", "TEST_RESULTS_NOTIFY"),
@@ -80,3 +84,5 @@ class TestResultsFlow(BaseFlow):
     FLAKE_DETECTION_NOTIFY = auto()
     TEST_RESULTS_ERROR = auto()
     TEST_RESULTS_FINISHER_BEGIN = auto()
+    CELERY_ERROR_TIMEOUT = auto()
+    CELERY_ERROR_FAILURE = auto()


### PR DESCRIPTION
the `UploadFlow` reliability metrics rely on there being a checkpoint logged for every way the flow can end, whether it's a success or a failure. looking at the data, it appears 40-60% of flow endings aren't captured. this means we can't totally trust our calculated reliability rate

i am not totally clear on how celery calls `on_failure()` and `on_timeout()`, but this PR attempts to load any checkpoints data it can find in them and log an error event. ideally this will increase our share of captured endings and make the metrics more accurate

`on_timeout()` is a member on a celery `Request` which we've subclassed as `BaseCodecovRequest`. it doesn't receive `kwargs` as an argument, but [according to docs](https://docs.celeryq.dev/en/stable/reference/celery.worker.request.html#celery.worker.request.Request.kwargs) it has a `kwargs` property which presumably holds the kwargs that the task was scheduled with. `on_failure()` is a member on the task and one of its arguments is `kwargs`. a non-retried `UploadTask` will not have any checkpoints data in its kwargs, but i think a retried `UploadTask` and future tasks should at least have a beginning checkpoint.

doing this creates a possibility that some endings will be double-counted:
- a `SoftTimeLimitException` may result in _both_ `on_timeout()` and `on_failure()` being called
- a `SoftTimeLimitException` allows the task to clean up gracefully. if it takes too long, a hard `TimeLimitException` is raised? and it's possible if this happens that `on_timeout()` will be called twice
- generally if we catch an error inside the celery task we still tell celery the task finished successfully and go to `on_success()`, but i don't know for sure that there are not cases where we log an error and then also wind up in `on_failure()` or `on_retry()`