### PR TITLE
Remove some test usage of `ReportDetails`

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/4b937001e7c3ac9ad22ec7c9b0e83ac4135566fe.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/78f9525e09c1ae7e853836162c8103e32e51bd9a.tar.gz#egg=shared
 https://github.com/codecov/test-results-parser/archive/ef39a0888acd62d02a316a852a15d755c74e78c6.tar.gz#egg=test-results-parser
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -361,7 +361,7 @@ sentry-sdk[celery]==2.13.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/4b937001e7c3ac9ad22ec7c9b0e83ac4135566fe.tar.gz
+shared @ https://github.com/codecov/shared/archive/78f9525e09c1ae7e853836162c8103e32e51bd9a.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -3252,9 +3252,6 @@ class TestReportService(BaseTestCase):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(report_id=current_report_row.id_)
-        dbsession.add(report_details)
-        dbsession.flush()
         report_service = ReportService({})
         res = report_service.save_report(commit, report)
         storage_hash = report_service.get_archive_service(
@@ -3961,9 +3958,6 @@ class TestReportService(BaseTestCase):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(report_id=current_report_row.id_)
-        dbsession.add(report_details)
-        dbsession.flush()
         report_service = ReportService({})
         report_service.save_report(commit, sample_report)
         res = report_service.initialize_and_save_report(commit)
@@ -4154,10 +4148,8 @@ class TestReportService(BaseTestCase):
     ):
         parent_commit = CommitFactory()
         parent_commit_report = CommitReport(commit_id=parent_commit.id_)
-        parent_report_details = ReportDetails(report_id=parent_commit_report.id_)
         dbsession.add(parent_commit)
         dbsession.add(parent_commit_report)
-        dbsession.add(parent_report_details)
         dbsession.flush()
 
         commit = CommitFactory.create(

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -11,7 +11,7 @@ from shared.storage.exceptions import FileNotInStorageError
 from shared.torngit.exceptions import TorngitObjectNotFoundError
 from shared.upload.constants import UploadErrorCode
 
-from database.models import CommitReport, ReportDetails, UploadError
+from database.models import CommitReport, UploadError
 from database.tests.factories import CommitFactory, UploadFactory
 from helpers.exceptions import (
     ReportEmptyError,
@@ -87,11 +87,6 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
         dbsession.flush()
         result = UploadProcessorTask().run_impl(
             dbsession,
@@ -199,11 +194,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         result = UploadProcessorTask().run_impl(
             dbsession,
             {},
@@ -295,11 +285,6 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
         dbsession.flush()
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
         upload = UploadFactory.create(
@@ -422,11 +407,6 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
         dbsession.flush()
         upload = UploadFactory.create(
             report=current_report_row, state="started", storage_path=url
@@ -625,11 +605,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"
         )
@@ -780,11 +755,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"
         )
@@ -866,11 +836,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"
         )
@@ -947,11 +912,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"
         )
@@ -990,11 +950,6 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
         dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"


### PR DESCRIPTION
A lot of places and assertions still exist.
As long as we are still writing out the `ReportDetails` and `files_array`, it still makes sense to assert that we do not regress.