### PR TITLE
Fix ReducedError to make it more similar to Django Model

### DIFF
--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -334,9 +334,18 @@ class TestResultReportTotals(CodecovBaseModel, MixinBaseClass):
     error = Column(types.String(100), nullable=True)
 
 
-class ReducedError(CodecovBaseModel, MixinBaseClass):
+class ReducedError(CodecovBaseModel):
     __tablename__ = "reports_reducederror"
+    id_ = Column("id", types.BigInteger, primary_key=True)
     message = Column(types.Text)
+    created_at = Column(types.DateTime(timezone=True), default=get_utc_now)
+    updated_at = Column(
+        types.DateTime(timezone=True), onupdate=get_utc_now, default=get_utc_now
+    )
+
+    @property
+    def id(self):
+        return self.id_
 
 
 class Flake(CodecovBaseModel, MixinBaseClassNoExternalID):


### PR DESCRIPTION
In particular, this table doesn't actually have an external id.

This was pulled out from #729 

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.