### PR TITLE
create LogContext ContextVar and populate in tasks/base.py

### DIFF
--- a/helpers/log_context.py
+++ b/helpers/log_context.py
@@ -1,0 +1,83 @@
+import contextvars
+import logging
+from dataclasses import dataclass, replace
+
+from database.models.core import Commit, Repository
+
+log = logging.getLogger("log_context")
+
+
+@dataclass
+class LogContext:
+    """
+    Class containing all the information we may want to add in logs and metrics.
+    """
+
+    task_name: str = "???"
+    task_id: str = "???"
+
+    _populated_from_db = False
+    owner_id: int | None = None
+    repo_id: int | None = None
+    commit_sha: str | None = None
+    commit_id: int | None = None
+
+    def populate_from_sqlalchemy(self, dbsession):
+        """
+        Attempt to use the information we have to fill in other context fields. For
+        example, if we have `self.repo_id` but not `self.owner_id`, we can look up
+        the latter in the database.
+
+        Ignore exceptions; no need to fail a task for a missing context field.
+        """
+        if self._populated_from_db:
+            return
+
+        try:
+            if self.repo_id:
+                if not self.owner_id:
+                    self.owner_id = (
+                        dbsession.query(Repository.ownerid)
+                        .filter(Repository.repoid == self.repo_id)
+                        .first()[0]
+                    )
+
+                if self.commit_sha and not self.commit_id:
+                    self.commit_id = (
+                        dbsession.query(Commit.id_)
+                        .filter(
+                            Commit.repoid == self.repo_id,
+                            Commit.commitid == self.commit_sha,
+                        )
+                        .first()[0]
+                    )
+        except Exception:
+            log.exception("Failed to populate log context")
+
+        self._populated_from_db = True
+
+
+_log_context = contextvars.ContextVar("log_context", default=LogContext())
+
+
+def set_log_context(context: LogContext):
+    """
+    Overwrite whatever is currently in the log context.
+    """
+    _log_context.set(context)
+
+
+def update_log_context(context: dict):
+    """
+    Add new fields to the log context without removing old ones.
+    """
+    current_context: LogContext = _log_context.get()
+    new_context = replace(current_context, **context)
+    set_log_context(new_context)
+
+
+def get_log_context() -> LogContext:
+    """
+    Access the log context.
+    """
+    return _log_context.get()

--- a/helpers/tests/unit/test_log_context.py
+++ b/helpers/tests/unit/test_log_context.py
@@ -1,0 +1,112 @@
+import asyncio
+
+from asgiref.sync import async_to_sync
+from sqlalchemy.exc import IntegrityError
+
+from database.tests.factories.core import CommitFactory, OwnerFactory, RepositoryFactory
+from helpers.log_context import (
+    LogContext,
+    get_log_context,
+    set_log_context,
+    update_log_context,
+)
+
+
+def create_db_records(dbsession):
+    owner = OwnerFactory.create(
+        service="github",
+        username="codecove2e",
+        unencrypted_oauth_token="test76zow6xgh7modd88noxr245j2z25t4ustoff",
+    )
+    dbsession.add(owner)
+
+    repo = RepositoryFactory.create(
+        owner=owner,
+        yaml={"codecov": {"max_report_age": "1y ago"}},
+        name="example-python",
+    )
+    dbsession.add(repo)
+
+    commit = CommitFactory.create(
+        message="",
+        commitid="c5b67303452bbff57cc1f49984339cde39eb1db5",
+        repository=repo,
+    )
+    dbsession.add(commit)
+
+    dbsession.commit()
+    dbsession.expire(owner)
+    dbsession.expire(repo)
+    dbsession.expire(commit)
+
+    return owner, repo, commit
+
+
+def test_populate_just_owner(dbsession):
+    owner, _repo, _commit = create_db_records(dbsession)
+    log_context = LogContext(owner_id=owner.ownerid)
+    log_context.populate_from_sqlalchemy(dbsession)
+
+    assert log_context == LogContext(owner_id=owner.ownerid)
+
+
+def test_populate_just_repo(dbsession):
+    owner, repo, _commit = create_db_records(dbsession)
+    log_context = LogContext(repo_id=repo.repoid)
+    log_context.populate_from_sqlalchemy(dbsession)
+
+    assert log_context == LogContext(repo_id=repo.repoid, owner_id=owner.ownerid)
+
+
+def test_populate_just_commit_sha(dbsession):
+    _owner, _repo, commit = create_db_records(dbsession)
+    log_context = LogContext(commit_sha=commit.commitid)
+    log_context.populate_from_sqlalchemy(dbsession)
+
+    assert log_context == LogContext(commit_sha=commit.commitid)
+
+
+def test_populate_repo_and_commit_sha(dbsession):
+    owner, repo, commit = create_db_records(dbsession)
+    log_context = LogContext(repo_id=repo.repoid, commit_sha=commit.commitid)
+    log_context.populate_from_sqlalchemy(dbsession)
+
+    assert log_context == LogContext(
+        repo_id=repo.repoid,
+        owner_id=owner.ownerid,
+        commit_sha=commit.commitid,
+        commit_id=commit.id_,
+    )
+
+
+def test_populate_ignores_db_exceptions(dbsession, mocker):
+    owner, repo, commit = create_db_records(dbsession)
+    log_context = LogContext(repo_id=repo.repoid, commit_sha=commit.commitid)
+    mocker.patch.object(dbsession, "query", side_effect=IntegrityError("", {}, None))
+
+    # If this succeeds, the exception thrown by dbsession was ignored
+    log_context.populate_from_sqlalchemy(dbsession)
+
+
+def test_set_and_get_log_context(dbsession):
+    log_context = LogContext(repo_id=1, commit_sha="abcde", commit_id=2, owner_id=3)
+    set_log_context(log_context)
+
+    assert get_log_context() == log_context
+
+    async def check_context_in_coroutine():
+        coro_log_context = get_log_context()
+        assert coro_log_context == log_context
+
+    # Check that the ContextVar is propagated through multiple ways of running
+    # async functions
+    asyncio.run(check_context_in_coroutine())
+    async_to_sync(check_context_in_coroutine)()
+
+
+def test_update_log_context(dbsession):
+    log_context = LogContext(repo_id=1)
+    set_log_context(log_context)
+
+    update_log_context({"commit_sha": "abcde", "owner_id": 5})
+    assert get_log_context() == LogContext(repo_id=1, commit_sha="abcde", owner_id=5)

--- a/helpers/tests/unit/test_logging_config.py
+++ b/helpers/tests/unit/test_logging_config.py
@@ -1,4 +1,5 @@
 from helpers.environment import Environment
+from helpers.log_context import LogContext, set_log_context
 from helpers.logging_config import (
     CustomLocalJsonFormatter,
     config_dict,
@@ -40,8 +41,7 @@ class TestLoggingConfig(object):
         }
 
     def test_add_fields_with_task(self, mocker):
-        _ = mocker.patch("helpers.logging_config.task_name", "lkjhg")
-        _ = mocker.patch("helpers.logging_config.task_id", "abcdef")
+        set_log_context(LogContext(task_name="lkjhg", task_id="abcdef"))
         log_record, record, message_dict = {}, mocker.MagicMock(), {"message": "aaa"}
         log_formatter = CustomLocalJsonFormatter()
         log_formatter.add_fields(log_record, record, message_dict)


### PR DESCRIPTION
new functions for managing log context:
- `get_log_context()`
- `set_log_context(LogContext())`
- `update_log_context({"repo_id": 5})`

`tasks/base.py` / `helpers/logging_config.py` use this new `ContextVar` log context instead of globals to put the task name and id on each log message. in separate PRs, we can continue on to:
- automatically add `repo_id`/`owner_id`/`commit_sha` to log messages when available
- get rid of `MetricContext`, making SQL metrics much less cumbersome to work with
- store `CheckpointLogger` data in the `ContextVar` to clean up usage a bit

### history
the globals were put in because previously we got the task details from `get_current_task()` and its `request` member. the request is definitely a thread-local variable and `get_current_task()` may also rely on thread-local state, so when we started pushing things into `async_to_sync()` which runs on a worker thread that context was getting dropped

this PR uses a `ContextVar` instead which is similar to thread locals but should work with Python's non-thread-based cooperative multitasking

caveat: for things run via `async_to_sync()` and `asyncio.run()`, they only inherit copies of the parent's context. so they should get the context set by the parent, but if they make changes the parent will not be able to see them.