### PR TITLE
Add a metric to count `carryforward_mode=labels` usage

### DIFF
--- a/services/processing/metrics.py
+++ b/services/processing/metrics.py
@@ -1,0 +1,7 @@
+from shared.metrics import Counter
+
+LABELS_USAGE = Counter(
+    "worker_labels_usage",
+    "Number of various real-world `carryforward_mode=labels` usages",
+    ["codepath"],
+)

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -36,6 +36,7 @@ from services.processing.loading import (
     load_intermediate_reports,
 )
 from services.processing.merging import merge_reports, update_uploads
+from services.processing.metrics import LABELS_USAGE
 from services.processing.state import ProcessingState, should_trigger_postprocessing
 from services.redis import get_redis_connection
 from services.report import ReportService
@@ -401,6 +402,10 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
             commit.state = "skipped"
 
         if self.should_clean_labels_index(commit_yaml, processing_results):
+            # NOTE: according to tracing, the cleanup task is never actually run.
+            # reasons for that might be that we indeed *never* have any flags
+            # configured for `carryforward_mode=labels`, or the logic is somehow wrong?
+            LABELS_USAGE.labels(codepath="cleanup_task").inc()
             task = self.app.tasks[clean_labels_index_task_name].apply_async(
                 kwargs={
                     "repoid": repoid,


### PR DESCRIPTION
This introduces a metric to count the various usages of `carryforward_mode=labels`. It also adds some comments to those places explaining whether the logic might be over- or undercounting the actual real-world usage.