### PR TITLE
add commit/owner/repo/sentry context to all log messages

### DIFF
--- a/helpers/logging_config.py
+++ b/helpers/logging_config.py
@@ -12,8 +12,13 @@ class BaseLogger(JsonFormatter):
         super(BaseLogger, self).add_fields(log_record, record, message_dict)
 
         log_context = get_log_context()
+
+        # Leaving these fields where they were for saved queries
         log_record["task_name"] = log_context.task_name
         log_record["task_id"] = log_context.task_id
+
+        # Context collected in "context" log field. Task name/ID also present.
+        log_record["context"] = log_context.as_dict()
 
     def format_json_on_new_lines(self, json_str):
         # Parse the input JSON string

--- a/helpers/tests/unit/test_log_context.py
+++ b/helpers/tests/unit/test_log_context.py
@@ -47,7 +47,9 @@ def test_populate_just_owner(dbsession):
     log_context = LogContext(owner_id=owner.ownerid)
     log_context.populate_from_sqlalchemy(dbsession)
 
-    assert log_context == LogContext(owner_id=owner.ownerid)
+    assert log_context == LogContext(
+        owner_id=owner.ownerid, owner_username="codecove2e", owner_service="github"
+    )
 
 
 def test_populate_just_repo(dbsession):
@@ -55,7 +57,13 @@ def test_populate_just_repo(dbsession):
     log_context = LogContext(repo_id=repo.repoid)
     log_context.populate_from_sqlalchemy(dbsession)
 
-    assert log_context == LogContext(repo_id=repo.repoid, owner_id=owner.ownerid)
+    assert log_context == LogContext(
+        repo_id=repo.repoid,
+        repo_name="example-python",
+        owner_id=owner.ownerid,
+        owner_username="codecove2e",
+        owner_service="github",
+    )
 
 
 def test_populate_just_commit_sha(dbsession):
@@ -66,6 +74,22 @@ def test_populate_just_commit_sha(dbsession):
     assert log_context == LogContext(commit_sha=commit.commitid)
 
 
+def test_populate_just_commit_id(dbsession):
+    owner, repo, commit = create_db_records(dbsession)
+    log_context = LogContext(commit_id=commit.id_)
+    log_context.populate_from_sqlalchemy(dbsession)
+
+    assert log_context == LogContext(
+        repo_id=repo.repoid,
+        repo_name="example-python",
+        owner_id=owner.ownerid,
+        owner_username="codecove2e",
+        owner_service="github",
+        commit_sha=commit.commitid,
+        commit_id=commit.id_,
+    )
+
+
 def test_populate_repo_and_commit_sha(dbsession):
     owner, repo, commit = create_db_records(dbsession)
     log_context = LogContext(repo_id=repo.repoid, commit_sha=commit.commitid)
@@ -73,7 +97,10 @@ def test_populate_repo_and_commit_sha(dbsession):
 
     assert log_context == LogContext(
         repo_id=repo.repoid,
+        repo_name="example-python",
         owner_id=owner.ownerid,
+        owner_username="codecove2e",
+        owner_service="github",
         commit_sha=commit.commitid,
         commit_id=commit.id_,
     )
@@ -110,3 +137,22 @@ def test_update_log_context(dbsession):
 
     update_log_context({"commit_sha": "abcde", "owner_id": 5})
     assert get_log_context() == LogContext(repo_id=1, commit_sha="abcde", owner_id=5)
+
+
+def test_as_dict(dbsession):
+    owner, repo, commit = create_db_records(dbsession)
+    log_context = LogContext(commit_id=commit.id_, task_name="foo", task_id="bar")
+    log_context.populate_from_sqlalchemy(dbsession)
+
+    # Ensure that `_populated_from_db` flag is stripped
+    assert log_context.as_dict() == {
+        "task_name": "foo",
+        "task_id": "bar",
+        "commit_id": commit.id_,
+        "commit_sha": commit.commitid,
+        "repo_id": repo.repoid,
+        "repo_name": repo.name,
+        "owner_id": owner.ownerid,
+        "owner_username": owner.username,
+        "owner_service": owner.service,
+    }

--- a/helpers/tests/unit/test_logging_config.py
+++ b/helpers/tests/unit/test_logging_config.py
@@ -29,7 +29,8 @@ class TestLoggingConfig(object):
         get_current_env.return_value = Environment.production
         assert get_logging_config_dict() == config_dict
 
-    def test_add_fields_no_task(self, mocker):
+    def test_add_fields_empty_log_context(self, mocker):
+        set_log_context(LogContext())
         log_record, record, message_dict = {}, mocker.MagicMock(), {"message": "aaa"}
         log_formatter = CustomLocalJsonFormatter()
         log_formatter.add_fields(log_record, record, message_dict)
@@ -38,16 +39,23 @@ class TestLoggingConfig(object):
             "method_calls": [],
             "task_id": "???",
             "task_name": "???",
+            "context": LogContext().as_dict(),
         }
 
-    def test_add_fields_with_task(self, mocker):
-        set_log_context(LogContext(task_name="lkjhg", task_id="abcdef"))
+    def test_add_fields_populated_log_context(self, mocker):
+        log_context = LogContext(
+            task_name="lkjhg", task_id="abcdef", repo_id=5, owner_id=3
+        )
+        set_log_context(log_context)
+
         log_record, record, message_dict = {}, mocker.MagicMock(), {"message": "aaa"}
         log_formatter = CustomLocalJsonFormatter()
         log_formatter.add_fields(log_record, record, message_dict)
+
         assert log_record == {
             "message": "aaa",
             "method_calls": [],
             "task_id": "abcdef",
             "task_name": "lkjhg",
+            "context": log_context.as_dict(),
         }


### PR DESCRIPTION
currently worker logs have celery task information that you can query in GCP Logs Explorer with something like
```
jsonPayload.task_name="app.tasks.compute_comparison.ComputeComparison"
jsonPayload.task_id="c70bf145-dbcc-43ff-970d-dcf9251e289f"
```

those fields are still there, but this PR adds a lot more:
- task info (new location) `jsonPayload.context.task_name` and `jsonPayload.context.task_id`
- repo info `jsonPayload.context.repo_name` and `jsonPayload.context.repo_id`
- owner info `jsonPayload.context.owner_name`, `jsonPayload.context.owner_service`, `jsonPayload.context.owner_id`
- commit info `jsonPayload.context.commit_sha` and `jsonPayload.context.commit_id`
  - note: in many places we call the SHA the `commitid` but here the SHA is `commit_sha` and the database ID is `commit_id`
- sentry info `jsonPayload.context.sentry_trace_id`

some queries you'll be able to run in GCP Logs Explorer:
- all logs for our worker repo:
  ```
  jsonPayload.context.owner_service="github"
  jsonPayload.context.owner_username="codecov"
  jsonPayload.context.repo_name="worker"
  ```
- all logs for a commit across tasks:
  ```
  -- technically you should also include the repo/owner in case of mirrors/forks
  jsonPayload.context.commit_sha="186d5c6f82b0ab4dac20d276f2cc56113099a649"
  ```
- all logs for a sentry trace (including API logs that have been tagged!)
  ```
  jsonPayload.context.sentry_trace_id="" OR jsonPayload.sentry_trace_id="31cfa9b2c81e41b6a662f9de639d80b6"
  ```

some fields will be nulled out. for example `SyncRepos` is an owner-scoped operation so it will have owner info but not repo/commit info. but uploads are commit-specific so `Upload` should have commit, repo, and owner info.

we log URLs that include owner/repo names in many places so adding them to the auto-populated log context doesn't introduce any new concerns