### PR TITLE
Fix notifications with an empty HEAD report

### DIFF
--- a/services/notification/notifiers/codecov_slack_app.py
+++ b/services/notification/notifiers/codecov_slack_app.py
@@ -84,6 +84,7 @@ class CodecovSlackAppNotifier(AbstractBaseNotifier):
             message = "unknown"
             notation = ""
             comparison_url = None
+        head_report = comparison.head.report
         return {
             "url": comparison_url,
             "message": message,
@@ -99,7 +100,7 @@ class CodecovSlackAppNotifier(AbstractBaseNotifier):
                 if comparison.project_coverage_base
                 else None
             ),
-            "head_totals_c": str(comparison.head.report.totals.coverage),
+            "head_totals_c": str(head_report.totals.coverage) if head_report else "0",
         }
 
     def notify(self, comparison: ComparisonProxy) -> NotificationResult:

--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -303,8 +303,11 @@ class StatusProjectMixin(object):
     def _get_project_status(
         self, comparison: ComparisonProxy | FilteredComparison
     ) -> tuple[str, str]:
-        head_report_totals = comparison.head.report.totals
-        if head_report_totals.coverage is None:
+        if (
+            not comparison.head.report
+            or (head_report_totals := comparison.head.report.totals) is None
+            or head_report_totals.coverage is None
+        ):
             state = self.notifier_yaml_settings.get("if_not_found", "success")
             message = "No coverage information found on head"
             return (state, message)

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -346,6 +346,7 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 and not self.send_notifications_if_commit_differs_from_pulls_head(
                     commit, enriched_pull, current_yaml
                 )
+                and empty_upload is None
             ):
                 log.info(
                     "Not sending notifications for commit when it differs from pull's most recent head",
@@ -531,7 +532,10 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
         This is done to make sure the patch coverage reported by notifications and UI is the same
         (because they come from the same source)
         """
-        if comparison.comparison.patch_coverage_base_commitid is None:
+        if (
+            comparison.comparison.patch_coverage_base_commitid is None
+            or not comparison.has_head_report()
+        ):
             # Can't get diff to calculate patch totals
             return
         head_commit = comparison.head.commit


### PR DESCRIPTION
There were a couple of errors spread around the notification code assuming that a `head.report` always exists, which is not necessarily the case.

In particular that would be the case when using `empty-upload` or `manual_trigger`.

---

Fixes [WORKER-P6A](https://codecov.sentry.io/issues/5801299347/)