### PR TITLE
move repo.updatestamp update from Upload to UploadFinisher

### DIFF
--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -167,7 +167,6 @@ class TestUploadTaskIntegration(object):
         assert commit.parent_commit_id is None
         assert commit.report is not None
         assert commit.report.details is not None
-        assert commit.repository.updatestamp > repo_updatestamp
         sessions = commit.report.uploads
         assert len(sessions) == 1
         first_session = (

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -3,7 +3,6 @@ import logging
 import time
 import uuid
 from copy import deepcopy
-from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 import orjson
@@ -416,7 +415,6 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
         )
         assert commit, "Commit not found in database."
         repository = commit.repository
-        repository.updatestamp = datetime.now()
         repository_service = None
 
         was_updated, was_setup = False, False

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -1,6 +1,7 @@
 import logging
 import random
 import re
+from datetime import datetime
 from enum import Enum
 
 import sentry_sdk
@@ -162,6 +163,10 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
             self.retry(max_retries=MAX_RETRIES, countdown=retry_in)
 
         cleanup_intermediate_reports(archive_service, commit.commitid, upload_ids)
+
+        # Mark the repository as updated so it will appear earlier in the list
+        # of recently-active repositories
+        repository.updatestamp = datetime.now()
 
         if not should_trigger_postprocessing(state.get_upload_numbers()):
             return


### PR DESCRIPTION
this is a low-hanging fruit for reducing database locking. instead of doing this write in the repos table for _every_ `UploadTask`, let's do it for `UploadFinisher` which should run less

that said, the `UploadFinisher` task will hold the lock longer