### PR TITLE
Rewrite the core `UploadProcessor` logic

### DIFF
--- a/services/processing/processing.py
+++ b/services/processing/processing.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Callable, NotRequired, TypedDict
+from collections.abc import Callable
+from typing import NotRequired, TypedDict
 
 import sentry_sdk
 from celery.exceptions import CeleryError

--- a/services/processing/processing.py
+++ b/services/processing/processing.py
@@ -1,0 +1,108 @@
+import logging
+from typing import Callable, NotRequired, TypedDict
+
+import sentry_sdk
+from shared.yaml import UserYaml
+from sqlalchemy.orm import Session as DbSession
+
+from database.models.core import Commit
+from database.models.reports import Upload
+from helpers.reports import delete_archive_setting
+from services.archive import ArchiveService
+from services.processing.intermediate import save_intermediate_report
+from services.processing.state import ProcessingState
+from services.report import ProcessingError, RawReportInfo, Report, ReportService
+from services.report.parser.types import VersionOneParsedRawReport
+
+log = logging.getLogger(__name__)
+
+
+class UploadArguments(TypedDict):
+    # TODO(swatinem): migrate this over to `upload_id`
+    upload_pk: int
+
+
+class ProcessingResult(TypedDict):
+    arguments: UploadArguments
+    successful: bool
+    error: NotRequired[dict]
+
+
+@sentry_sdk.trace
+def process_upload(
+    on_processing_error: Callable[[ProcessingError], None],
+    db_session: DbSession,
+    repo_id: int,
+    commit_sha: str,
+    commit_yaml: UserYaml,
+    arguments: UploadArguments,
+) -> dict:
+    upload_id = arguments["upload_pk"]
+
+    commit = (
+        db_session.query(Commit)
+        .filter(Commit.repoid == repo_id, Commit.commitid == commit_sha)
+        .first()
+    )
+    assert commit
+
+    upload = db_session.query(Upload).filter_by(id_=upload_id).first()
+    assert upload
+
+    state = ProcessingState(repo_id, commit_sha)
+    # this in a noop in normal cases, but relevant for task retries:
+    state.mark_uploads_as_processing([upload_id])
+
+    report_service = ReportService(commit_yaml)
+    archive_service = report_service.get_archive_service(commit.repository)
+
+    result = ProcessingResult(arguments=arguments, successful=False)
+
+    try:
+        report = Report()
+        report_info = RawReportInfo()
+        processing_result = report_service.build_report_from_raw_content(
+            report, report_info, upload
+        )
+
+        if error := processing_result.error:
+            on_processing_error(error)  # NOTE: this might throw a `Retry`
+            result["error"] = error.as_dict()
+        else:
+            result["successful"] = True
+        log.info("Finished processing upload", extra={"result": result})
+
+        report_service.update_upload_with_processing_result(upload, processing_result)
+        save_intermediate_report(archive_service, commit_sha, upload_id, report)
+        state.mark_upload_as_processed(upload_id)
+
+        rewrite_or_delete_upload(archive_service, commit_yaml, report_info)
+
+    except Exception:
+        # this is a noop in the success case, but makes sure unrecoverable errors
+        # or retries are not blocking later merge/notify stages
+        state.clear_in_progress_uploads([upload_id])
+
+    # TODO(swatinem): migrate this to just `return result`:
+    return {
+        "processings_so_far": [result],
+        "parallel_incremental_result": {"upload_pk": upload_id},
+    }
+
+
+def rewrite_or_delete_upload(
+    archive_service: ArchiveService, commit_yaml: UserYaml, report_info: RawReportInfo
+):
+    should_delete_archive_setting = delete_archive_setting(commit_yaml)
+    archive_url = report_info.archive_url
+
+    if should_delete_archive_setting and not report_info.error:
+        if not archive_url.startswith("http"):
+            archive_service.delete_file(archive_url)
+
+    elif isinstance(report_info.raw_report, VersionOneParsedRawReport):
+        # only a version 1 report needs to be "rewritten readable"
+
+        archive_service.write_file(
+            archive_url, report_info.raw_report.content().getvalue()
+        )

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -1,28 +1,23 @@
 import logging
-from typing import Any
 
 import sentry_sdk
 from asgiref.sync import async_to_sync
-from celery.exceptions import CeleryError, SoftTimeLimitExceeded
 from shared.celery_config import upload_processor_task_name
 from shared.config import get_config
 from shared.torngit.exceptions import TorngitError
 from shared.yaml import UserYaml
-from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session as DbSession
 
 from app import celery_app
 from database.enums import CommitErrorTypes
-from database.models import Commit, Upload
+from database.models import Commit
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME, Pull
 from helpers.cache import cache
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
-from helpers.reports import delete_archive_setting
 from helpers.save_commit_error import save_commit_error
-from services.processing.intermediate import save_intermediate_report
-from services.processing.state import ProcessingState
-from services.report import ProcessingResult, RawReportInfo, Report, ReportService
-from services.report.parser.types import VersionOneParsedRawReport
+from services.processing.processing import UploadArguments, process_upload
+from services.report import ProcessingError, Report, ReportService
 from services.repository import get_repo_provider_service
 from tasks.base import BaseCodecovTask
 
@@ -66,225 +61,36 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
 
     def run_impl(
         self,
-        db_session,
+        db_session: DbSession,
         *args,
-        repoid,
-        commitid,
-        commit_yaml,
-        arguments_list,
-        arguments=None,
-        report_code=None,
-        **kwargs,
-    ):
-        repoid = int(repoid)
-        log.info("Received upload processor task", extra={"arguments": arguments})
-
-        # TODO(swatinem): this makes us forwards-compatible to remove `arguments_list` in the future
-        if arguments and not arguments_list:
-            arguments_list = [arguments]
-
-        return self.process_upload(
-            db_session=db_session,
-            previous_results={},
-            repoid=repoid,
-            commitid=commitid,
-            commit_yaml=commit_yaml,
-            arguments_list=arguments_list,
-            report_code=report_code,
-        )
-
-    @sentry_sdk.trace
-    def process_upload(
-        self,
-        db_session,
-        previous_results: dict,
         repoid: int,
         commitid: str,
         commit_yaml: dict,
-        arguments_list: list[dict],
-        report_code,
+        arguments: UploadArguments,
+        **kwargs,
     ):
-        processings_so_far: list[dict] = previous_results.get("processings_so_far", [])
-        n_processed = 0
-        n_failed = 0
-
-        commit = (
-            db_session.query(Commit)
-            .filter(Commit.repoid == repoid, Commit.commitid == commitid)
-            .first()
+        log.info(
+            "Received upload processor task",
+            extra={"arguments": arguments, "commit_yaml": commit_yaml},
         )
-        assert commit, "Commit not found in database."
 
-        report_service = ReportService(UserYaml(commit_yaml))
-        archive_service = report_service.get_archive_service(commit.repository)
-        report = Report()
-
-        state = ProcessingState(repoid, commitid)
-        upload_ids = [int(upload["upload_pk"]) for upload in arguments_list]
-        # this in a noop in normal cases, but relevant for task retries:
-        state.mark_uploads_as_processing(upload_ids)
-
-        raw_reports: list[RawReportInfo] = []
-        try:
-            for arguments in arguments_list:
-                upload_obj = (
-                    db_session.query(Upload)
-                    .filter_by(id_=arguments["upload_pk"])
-                    .first()
-                )
+        def on_processing_error(error: ProcessingError):
+            # the error is only retried on the first pass
+            if error.is_retryable and self.request.retries == 0:
                 log.info(
-                    f"Processing individual report {arguments.get('reportid')}",
-                    extra=dict(
-                        repoid=repoid,
-                        commit=commitid,
-                        arguments=arguments,
-                        commit_yaml=commit_yaml,
-                        upload=upload_obj.id_,
-                        parent_task=self.request.parent_id,
-                    ),
+                    "Scheduling a retry due to retryable error",
+                    extra={"error": error.as_dict()},
                 )
-                individual_info: dict[str, Any] = {"arguments": arguments}
-                try:
-                    raw_report_info = RawReportInfo()
-                    processing_result = self.process_individual_report(
-                        report_service,
-                        commit,
-                        report,
-                        upload_obj,
-                        raw_report_info,
-                    )
-                    # NOTE: this is only used because test mocking messes with the return value here.
-                    # in normal flow, the function mutates the argument instead.
-                    if processing_result.report:
-                        report = processing_result.report
-                except (CeleryError, SoftTimeLimitExceeded, SQLAlchemyError):
-                    raise
+                self.retry(max_retries=MAX_RETRIES, countdown=FIRST_RETRY_DELAY)
 
-                if error := processing_result.error:
-                    n_failed += 1
-                    individual_info["successful"] = False
-                    individual_info["error"] = error.as_dict()
-
-                else:
-                    n_processed += 1
-                    individual_info["successful"] = True
-                processings_so_far.append(individual_info)
-
-                if raw_report_info.raw_report:
-                    raw_reports.append(raw_report_info)
-
-            log.info(
-                f"Finishing the processing of {n_processed} reports",
-                extra=dict(
-                    repoid=repoid,
-                    commit=commitid,
-                    parent_task=self.request.parent_id,
-                ),
-            )
-
-            upload_id = int(arguments_list[0]["upload_pk"])
-            save_intermediate_report(archive_service, commitid, upload_id, report)
-            state.mark_upload_as_processed(upload_id)
-
-            log.info(
-                "Saved incremental report results to storage",
-                extra=dict(
-                    repoid=repoid,
-                    commit=commitid,
-                ),
-            )
-
-            if raw_reports:
-                self.postprocess_raw_reports(report_service, commit, raw_reports)
-
-            log.info(
-                f"Processed {n_processed} reports (+ {n_failed} failed)",
-                extra=dict(
-                    repoid=repoid,
-                    commit=commitid,
-                    commit_yaml=commit_yaml,
-                    parent_task=self.request.parent_id,
-                ),
-            )
-
-            processing_results: dict = {
-                "processings_so_far": processings_so_far,
-                "parallel_incremental_result": {"upload_pk": upload_id},
-            }
-            return processing_results
-        except CeleryError:
-            raise
-        except Exception:
-            commit.state = "error"
-            log.exception(
-                "Could not properly process commit",
-                extra=dict(repoid=repoid, commit=commitid),
-            )
-            raise
-        finally:
-            # this is a noop in the success case, but makes sure unrecoverable errors
-            # are not blocking later merge/notify stages
-            state.clear_in_progress_uploads(upload_ids)
-
-    @sentry_sdk.trace
-    def process_individual_report(
-        self,
-        report_service: ReportService,
-        commit: Commit,
-        report: Report,
-        upload: Upload,
-        raw_report_info: RawReportInfo,
-    ) -> ProcessingResult:
-        processing_result = report_service.build_report_from_raw_content(
-            report, raw_report_info, upload
+        return process_upload(
+            on_processing_error,
+            db_session,
+            int(repoid),
+            commitid,
+            UserYaml(commit_yaml),
+            arguments,
         )
-        if (
-            processing_result.error is not None
-            and processing_result.error.is_retryable
-            and self.request.retries == 0  # the error is only retried on the first pass
-        ):
-            log.info(
-                f"Scheduling a retry in {FIRST_RETRY_DELAY} due to retryable error",
-                extra=dict(
-                    repoid=commit.repoid,
-                    commit=commit.commitid,
-                    upload_id=upload.id,
-                    processing_result_error_code=processing_result.error.code,
-                    processing_result_error_params=processing_result.error.params,
-                    parent_task=self.request.parent_id,
-                ),
-            )
-            self.retry(max_retries=MAX_RETRIES, countdown=FIRST_RETRY_DELAY)
-
-        report_service.update_upload_with_processing_result(upload, processing_result)
-
-        return processing_result
-
-    @sentry_sdk.trace
-    def postprocess_raw_reports(
-        self,
-        report_service: ReportService,
-        commit: Commit,
-        reports: list[RawReportInfo],
-    ):
-        should_delete_archive_setting = delete_archive_setting(
-            report_service.current_yaml
-        )
-        archive_service = report_service.get_archive_service(commit.repository)
-
-        for report_info in reports:
-            archive_url = report_info.archive_url
-
-            if should_delete_archive_setting and not report_info.error:
-                if not archive_url.startswith("http"):
-                    archive_service.delete_file(archive_url)
-
-            elif isinstance(report_info.raw_report, VersionOneParsedRawReport):
-                # only a version 1 report needs to be "rewritten readable"
-
-                archive_service.write_file(
-                    archive_url, report_info.raw_report.content().getvalue()
-                )
 
 
 RegisteredUploadTask = celery_app.register_task(UploadProcessorTask())


### PR DESCRIPTION
The code has been moved out of the `UploadProcessor` task into its own file, and adapted in such a way that it will only deal with a single upload per task invocation.