### PR TITLE
ref: Tweaks to send email task

### DIFF
--- a/tasks/send_email.py
+++ b/tasks/send_email.py
@@ -1,14 +1,13 @@
 import logging
 
 from shared.celery_config import send_email_task_name
+from shared.config import get_config
 
 import services.smtp
 from app import celery_app
-from database.models import Owner
 from helpers.email import Email
 from helpers.metrics import metrics
 from services.template import TemplateService
-from shared.config import get_config
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
@@ -20,7 +19,9 @@ class SendEmailTask(BaseCodecovTask, name=send_email_task_name):
     ):
         with metrics.timer("worker.tasks.send_email"):
             if from_addr is None:
-                from_addr = get_config("services", "smtp", "from_address", default="noreply@codecov.io")
+                from_addr = get_config(
+                    "services", "smtp", "from_address", default="noreply@codecov.io"
+                )
 
             log_extra_dict = {
                 "to_addr": to_addr,

--- a/tasks/send_email.py
+++ b/tasks/send_email.py
@@ -8,6 +8,7 @@ from database.models import Owner
 from helpers.email import Email
 from helpers.metrics import metrics
 from services.template import TemplateService
+from shared.config import get_config
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
@@ -15,36 +16,23 @@ log = logging.getLogger(__name__)
 
 class SendEmailTask(BaseCodecovTask, name=send_email_task_name):
     def run_impl(
-        self, db_session, ownerid, template_name, from_addr, subject, **kwargs
+        self, db_session, to_addr, subject, template_name, from_addr=None, **kwargs
     ):
         with metrics.timer("worker.tasks.send_email"):
+            if from_addr is None:
+                from_addr = get_config("services", "smtp", "from_address", default="noreply@codecov.io")
+
             log_extra_dict = {
+                "to_addr": to_addr,
                 "from_addr": from_addr,
                 "template_name": template_name,
                 "template_kwargs": kwargs,
-                "ownerid": ownerid,
             }
 
             log.info(
                 "Received send email task",
                 extra=log_extra_dict,
             )
-
-            owner = db_session.query(Owner).filter_by(ownerid=ownerid).first()
-            if not owner:
-                log.warning(
-                    "Unable to find owner",
-                    extra=log_extra_dict,
-                )
-                return {"email_successful": False, "err_msg": "Unable to find owner"}
-
-            to_addr = owner.email
-            if not owner.email:
-                log.warning("Owner does not have email", extra=log_extra_dict)
-                return {
-                    "email_successful": False,
-                    "err_msg": "Owner does not have email",
-                }
 
             smtp_service = services.smtp.SMTPService()
 

--- a/tasks/tests/integration/test_send_email_task.py
+++ b/tasks/tests/integration/test_send_email_task.py
@@ -39,10 +39,10 @@ class TestSendEmailTask:
 
         result = task.run_impl(
             dbsession,
-            owner.ownerid,
+            owner.email,
+            "TestSubject",
             "test",
             "test@codecov.io",
-            "TestSubject",
             username=owner.username,
         )
 

--- a/tasks/tests/unit/test_send_email_task.py
+++ b/tasks/tests/unit/test_send_email_task.py
@@ -41,6 +41,7 @@ def mock_configuration_no_smtp(mocker):
     mock_config.set_params(our_config)
     return mock_config
 
+
 class TestSendEmailTask(object):
     def test_send_email(
         self,
@@ -214,4 +215,3 @@ class TestSendEmailTask(object):
             "email_successful": False,
             "err_msg": "Cannot send email because SMTP is not configured for this installation of codecov",
         }
-


### PR DESCRIPTION
Updates the send email task to 
1. take a to-address instead of an owner and
2. make from-address optional, pulling from config if not set explicitly in the call.