### PR TITLE
Do not clear the `LogContext` on task finish

### DIFF
--- a/helpers/log_context.py
+++ b/helpers/log_context.py
@@ -1,6 +1,6 @@
 import contextvars
 import logging
-from dataclasses import asdict, dataclass, replace
+from dataclasses import asdict, dataclass
 
 import sentry_sdk
 from sentry_sdk import get_current_span
@@ -144,15 +144,6 @@ def set_log_context(context: LogContext):
     """
     _log_context.set(context)
     context.add_to_sentry()
-
-
-def update_log_context(context: dict):
-    """
-    Add new fields to the log context without removing old ones.
-    """
-    current_context: LogContext = _log_context.get()
-    new_context = replace(current_context, **context)
-    set_log_context(new_context)
 
 
 def get_log_context() -> LogContext:

--- a/helpers/tests/unit/test_log_context.py
+++ b/helpers/tests/unit/test_log_context.py
@@ -4,12 +4,7 @@ from asgiref.sync import async_to_sync
 from sqlalchemy.exc import IntegrityError
 
 from database.tests.factories.core import CommitFactory, OwnerFactory, RepositoryFactory
-from helpers.log_context import (
-    LogContext,
-    get_log_context,
-    set_log_context,
-    update_log_context,
-)
+from helpers.log_context import LogContext, get_log_context, set_log_context
 
 
 def create_db_records(dbsession):
@@ -129,14 +124,6 @@ def test_set_and_get_log_context(dbsession):
     # async functions
     asyncio.run(check_context_in_coroutine())
     async_to_sync(check_context_in_coroutine)()
-
-
-def test_update_log_context(dbsession):
-    log_context = LogContext(repo_id=1)
-    set_log_context(log_context)
-
-    update_log_context({"commit_sha": "abcde", "owner_id": 5})
-    assert get_log_context() == LogContext(repo_id=1, commit_sha="abcde", owner_id=5)
 
 
 def test_as_dict(dbsession, mocker):

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -285,7 +285,6 @@ class BaseCodecovTask(celery_app.Task):
             finally:
                 self.wrap_up_dbsession(db_session)
                 self._commit_django()
-                set_log_context(LogContext())
 
     def wrap_up_dbsession(self, db_session):
         """


### PR DESCRIPTION
Previously, this would unset the `LogContext` back to an empty version at the end of the task `run` hook. However this would also unset all the previously set Sentry tags. As the Sentry Celery integration automatically wraps the `run` function, the Sentry tags have to persist past the end of said function.

This will now only set an initialized `LogContext` when entering `run`, and keep that around until the next task overwrites it. That way, we should also get an initialized context for any async code that runs outside of the `run` scope.