### PR TITLE
Only show VCR logs on errors

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pathlib import Path
 
@@ -163,6 +164,9 @@ def empty_configuration(mocker):
 
 @pytest.fixture
 def codecov_vcr(request):
+    vcr_log = logging.getLogger("vcr")
+    vcr_log.setLevel(logging.ERROR)
+
     current_path = Path(request.node.fspath)
     current_path_name = current_path.name.replace(".py", "")
     cassete_path = current_path.parent / "cassetes" / current_path_name


### PR DESCRIPTION
These logs were getting really noisy when testing locally (especially when running with verbose mode `-vv`). Removing unnecessary logs should make it more manageable to debug, especially since the VCR logs aren't super useful. If someone wants the full log, they can remove this or override manually.

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.