### PR TITLE
Start properly typing `processing_results` and `arguments_list`

### DIFF
--- a/services/processing/intermediate.py
+++ b/services/processing/intermediate.py
@@ -1,5 +1,4 @@
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
 
 import orjson
 import sentry_sdk
@@ -8,20 +7,9 @@ from shared.reports.editable import EditableReport
 from shared.reports.resources import Report
 
 from services.archive import ArchiveService
-from services.processing.metrics import INTERMEDIATE_REPORT_SIZE
 
-
-@dataclass
-class IntermediateReport:
-    upload_id: int
-    """
-    The `Upload` id for which this report was loaded.
-    """
-
-    report: EditableReport
-    """
-    The loaded Report.
-    """
+from .metrics import INTERMEDIATE_REPORT_SIZE
+from .types import IntermediateReport
 
 
 @sentry_sdk.trace

--- a/services/processing/merging.py
+++ b/services/processing/merging.py
@@ -1,5 +1,3 @@
-from dataclasses import dataclass
-
 import sentry_sdk
 from shared.reports.editable import EditableReport, EditableReportFile
 from shared.reports.enums import UploadState
@@ -8,23 +6,10 @@ from shared.yaml import UserYaml
 from sqlalchemy.orm import Session as DbSession
 
 from database.models.reports import Upload
-from services.processing.intermediate import IntermediateReport
 from services.report import delete_uploads_by_sessionid
 from services.report.raw_upload_processor import clear_carryforward_sessions
 
-
-@dataclass
-class MergeResult:
-    session_mapping: dict[int, int]
-    """
-    This is a mapping from the input `upload_id` to the output `session_id`
-    as it exists in the merged "master Report".
-    """
-
-    deleted_sessions: set[int]
-    """
-    The Set of carryforwarded `session_id`s that have been removed from the "master Report".
-    """
+from .types import IntermediateReport, MergeResult
 
 
 @sentry_sdk.trace

--- a/services/processing/types.py
+++ b/services/processing/types.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from typing import NotRequired, TypedDict
+
+from shared.reports.editable import EditableReport
+
+
+class UploadArguments(TypedDict):
+    # TODO(swatinem): migrate this over to `upload_id`
+    upload_pk: int
+
+
+class ProcessingResult(TypedDict):
+    upload_id: int
+    arguments: UploadArguments
+    successful: bool
+    error: NotRequired[dict]
+
+
+@dataclass
+class IntermediateReport:
+    upload_id: int
+    """
+    The `Upload` id for which this report was loaded.
+    """
+
+    report: EditableReport
+    """
+    The loaded Report.
+    """
+
+
+@dataclass
+class MergeResult:
+    session_mapping: dict[int, int]
+    """
+    This is a mapping from the input `upload_id` to the output `session_id`
+    as it exists in the merged "master Report".
+    """
+
+    deleted_sessions: set[int]
+    """
+    The Set of carryforwarded `session_id`s that have been removed from the "master Report".
+    """

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -101,11 +101,11 @@ class TestUploadProcessorTask(object):
 
         assert result["processings_so_far"] == [
             {
+                "upload_id": upload.id_,
                 "arguments": {"upload_pk": upload.id_, "url": url},
                 "successful": True,
             }
         ]
-        assert commit.message == "dsidsahdsahdsa"
 
     @pytest.mark.integration
     @pytest.mark.django_db
@@ -171,11 +171,11 @@ class TestUploadProcessorTask(object):
         )
         assert result["processings_so_far"] == [
             {
+                "upload_id": upload.id_,
                 "arguments": {"upload_pk": upload.id_, "url": url},
                 "successful": True,
             }
         ]
-        assert commit.message == "dsidsahdsahdsa"
 
     @pytest.mark.django_db
     def test_upload_processor_call_with_upload_obj(
@@ -228,11 +228,11 @@ class TestUploadProcessorTask(object):
 
         assert result["processings_so_far"] == [
             {
+                "upload_id": upload.id_,
                 "arguments": {"url": url, "upload_pk": upload.id_},
                 "successful": True,
             }
         ]
-        assert commit.message == "dsidsahdsahdsa"
         assert upload.state == "processed"
 
         # storage is overwritten with parsed contents
@@ -292,12 +292,13 @@ class TestUploadProcessorTask(object):
 
         assert result["processings_so_far"] == [
             {
+                "upload_id": upload.id_,
                 "arguments": {"upload_pk": upload.id, "url": "url"},
+                "successful": False,
                 "error": {
                     "code": UploadErrorCode.UNKNOWN_PROCESSING,
                     "params": {"location": "url"},
                 },
-                "successful": False,
             }
         ]
         assert upload.state_id == UploadState.ERROR.db_id
@@ -391,11 +392,8 @@ class TestUploadProcessorTask(object):
         )
         assert result["processings_so_far"] == [
             {
-                "arguments": {
-                    "url": "url",
-                    "what": "huh",
-                    "upload_pk": upload_1.id_,
-                },
+                "upload_id": upload_1.id_,
+                "arguments": {"url": "url", "what": "huh", "upload_pk": upload_1.id_},
                 "successful": True,
             }
         ]
@@ -410,13 +408,14 @@ class TestUploadProcessorTask(object):
         )
         assert result["processings_so_far"] == [
             {
+                "upload_id": upload_2.id_,
                 "arguments": {
                     "extra_param": 45,
                     "url": "url2",
                     "upload_pk": upload_2.id_,
                 },
-                "error": {"code": "report_expired", "params": {}},
                 "successful": False,
+                "error": {"code": "report_expired", "params": {}},
             },
         ]
         assert commit.state == "complete"
@@ -457,10 +456,17 @@ class TestUploadProcessorTask(object):
             UserYaml({"codecov": {"max_report_age": False}}),
             {"upload_pk": upload.id_},
         )
-        assert result["processings_so_far"][0]["error"] == {
-            "code": "file_not_in_storage",
-            "params": {"location": "locationlocation"},
-        }
+        assert result["processings_so_far"] == [
+            {
+                "upload_id": upload.id_,
+                "arguments": {"upload_pk": upload.id_},
+                "successful": False,
+                "error": {
+                    "code": "file_not_in_storage",
+                    "params": {"location": "locationlocation"},
+                },
+            }
+        ]
         assert commit.state == "complete"
         assert upload.state == "error"
 
@@ -558,11 +564,8 @@ class TestUploadProcessorTask(object):
         )
         assert result["processings_so_far"] == [
             {
-                "arguments": {
-                    "url": "url",
-                    "what": "huh",
-                    "upload_pk": upload_1.id_,
-                },
+                "upload_id": upload_1.id_,
+                "arguments": {"url": "url", "what": "huh", "upload_pk": upload_1.id_},
                 "successful": True,
             }
         ]
@@ -577,13 +580,14 @@ class TestUploadProcessorTask(object):
         )
         assert result["processings_so_far"] == [
             {
+                "upload_id": upload_2.id_,
                 "arguments": {
                     "extra_param": 45,
                     "url": "url2",
                     "upload_pk": upload_2.id_,
                 },
-                "error": {"code": "report_empty", "params": {}},
                 "successful": False,
+                "error": {"code": "report_empty", "params": {}},
             },
         ]
         assert commit.state == "complete"
@@ -649,13 +653,10 @@ class TestUploadProcessorTask(object):
         )
         assert result["processings_so_far"] == [
             {
-                "arguments": {
-                    "url": "url",
-                    "what": "huh",
-                    "upload_pk": upload_1.id_,
-                },
-                "error": {"code": "report_empty", "params": {}},
+                "upload_id": upload_1.id_,
+                "arguments": {"url": "url", "what": "huh", "upload_pk": upload_1.id_},
                 "successful": False,
+                "error": {"code": "report_empty", "params": {}},
             }
         ]
 
@@ -669,13 +670,14 @@ class TestUploadProcessorTask(object):
         )
         assert result["processings_so_far"] == [
             {
+                "upload_id": upload_2.id_,
                 "arguments": {
                     "extra_param": 45,
                     "url": "url2",
                     "upload_pk": upload_2.id_,
                 },
-                "error": {"code": "report_expired", "params": {}},
                 "successful": False,
+                "error": {"code": "report_expired", "params": {}},
             },
         ]
         assert len(upload_2.errors) == 1

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -182,12 +182,14 @@ class TestUploadTaskIntegration(object):
             arguments={
                 "url": url,
                 "build": "some_random_build",
+                "upload_id": first_session.id,
                 "upload_pk": first_session.id,
             },
             arguments_list=[
                 {
                     "url": url,
                     "build": "some_random_build",
+                    "upload_id": first_session.id,
                     "upload_pk": first_session.id,
                 }
             ],
@@ -277,6 +279,7 @@ class TestUploadTaskIntegration(object):
             params={
                 "url": storage_path,
                 "build_code": "some_random_build",
+                "upload_id": upload.id,
                 "upload_pk": upload.id,
             },
         )
@@ -403,6 +406,7 @@ class TestUploadTaskIntegration(object):
                 {
                     "url": storage_path,
                     "build_code": "some_random_build",
+                    "upload_id": upload.id,
                     "upload_pk": upload.id,
                 }
             ],
@@ -659,8 +663,14 @@ class TestUploadTaskIntegration(object):
                 repoid=commit.repoid,
                 commitid="abf6d4df662c47e32460020ab14abf9303581429",
                 commit_yaml={"codecov": {"max_report_age": "1y ago"}},
-                arguments={**arguments, "upload_pk": mocker.ANY},
-                arguments_list=[{**arguments, "upload_pk": mocker.ANY}],
+                arguments={
+                    **arguments,
+                    "upload_id": mocker.ANY,
+                    "upload_pk": mocker.ANY,
+                },
+                arguments_list=[
+                    {**arguments, "upload_id": mocker.ANY, "upload_pk": mocker.ANY}
+                ],
                 report_code=None,
                 run_fully_parallel=True,
                 in_parallel=True,
@@ -789,8 +799,18 @@ class TestUploadTaskIntegration(object):
             commit,
             {"codecov": {"max_report_age": "764y ago"}},
             [
-                {"build": "part1", "url": "url1", "upload_pk": mocker.ANY},
-                {"build": "part2", "url": "url2", "upload_pk": mocker.ANY},
+                {
+                    "build": "part1",
+                    "url": "url1",
+                    "upload_id": mocker.ANY,
+                    "upload_pk": mocker.ANY,
+                },
+                {
+                    "build": "part2",
+                    "url": "url2",
+                    "upload_id": mocker.ANY,
+                    "upload_pk": mocker.ANY,
+                },
             ],
             commit.report,
             mocker.ANY,
@@ -845,8 +865,18 @@ class TestUploadTaskIntegration(object):
             commit,
             {"codecov": {"max_report_age": "764y ago"}},
             [
-                {"build": "part1", "url": "url1", "upload_pk": mocker.ANY},
-                {"build": "part2", "url": "url2", "upload_pk": mocker.ANY},
+                {
+                    "build": "part1",
+                    "url": "url1",
+                    "upload_id": mocker.ANY,
+                    "upload_pk": mocker.ANY,
+                },
+                {
+                    "build": "part2",
+                    "url": "url2",
+                    "upload_id": mocker.ANY,
+                    "upload_pk": mocker.ANY,
+                },
             ],
             commit.report,
             mocker.ANY,
@@ -922,8 +952,18 @@ class TestUploadTaskIntegration(object):
             commit,
             {"codecov": {"max_report_age": "764y ago"}},
             [
-                {"build": "part1", "url": "url1", "upload_pk": first_session.id},
-                {"build": "part2", "url": "url2", "upload_pk": second_session.id},
+                {
+                    "build": "part1",
+                    "url": "url1",
+                    "upload_id": first_session.id,
+                    "upload_pk": first_session.id,
+                },
+                {
+                    "build": "part2",
+                    "url": "url2",
+                    "upload_id": second_session.id,
+                    "upload_pk": second_session.id,
+                },
             ],
             commit.report,
             mocker.ANY,
@@ -1013,8 +1053,8 @@ class TestUploadTaskIntegration(object):
                 {
                     "build": "part1",
                     "url": "url1",
-                    "upload_pk": upload.id_,
                     "upload_id": upload.id_,
+                    "upload_pk": upload.id_,
                 }
             ],
             report,
@@ -1135,7 +1175,7 @@ class TestUploadTaskUnit(object):
         mocked_chord = mocker.patch("tasks.upload.chord")
         commit = CommitFactory.create()
         commit_yaml = {"codecov": {"max_report_age": "100y ago"}}
-        argument_list = [{"upload_pk": 1}]
+        argument_list = [{"upload_id": 1, "upload_pk": 1}]
         dbsession.add(commit)
         dbsession.flush()
         upload_args = UploadContext(
@@ -1159,7 +1199,7 @@ class TestUploadTaskUnit(object):
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml=commit_yaml,
-            arguments={"upload_pk": 1},
+            arguments={"upload_id": 1, "upload_pk": 1},
             arguments_list=argument_list,
             report_code=None,
             run_fully_parallel=True,


### PR DESCRIPTION
This also returns more information in the `ProcessingResult`, in order to clean it up in a forwards compatible way, as well as laying the groundwork for eventually updating the `Upload` state and error only once in the finisher instead of touching that DB object twice in the processor and finisher.