### PR TITLE
Stop writing `ReportDetails`/`files_array`

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/opentelem-python/archive/refs/tags/v0.0.4a1.tar.gz#egg=codecovopentelem
-https://github.com/codecov/shared/archive/cde98920fbec05ad7f71f934fed35a5eebab4dd3.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/6e68957eb90e234cbec237ede814e1d36b170291.tar.gz#egg=shared
 https://github.com/codecov/test-results-parser/archive/ef39a0888acd62d02a316a852a15d755c74e78c6.tar.gz#egg=test-results-parser
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -361,7 +361,7 @@ sentry-sdk[celery]==2.13.0
     # via
     #   -r requirements.in
     #   shared
-shared @ https://github.com/codecov/shared/archive/cde98920fbec05ad7f71f934fed35a5eebab4dd3.tar.gz
+shared @ https://github.com/codecov/shared/archive/6e68957eb90e234cbec237ede814e1d36b170291.tar.gz
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -9,7 +9,7 @@ from shared.reports.types import ReportLine, ReportTotals
 from shared.torngit.exceptions import TorngitRateLimitError
 from shared.yaml import UserYaml
 
-from database.models import CommitReport, ReportDetails, RepositoryFlag, Upload
+from database.models import CommitReport, RepositoryFlag, Upload
 from database.tests.factories import CommitFactory, UploadFactory
 from helpers.exceptions import RepositoryWithoutValidBotError
 from services.archive import ArchiveService
@@ -3123,7 +3123,6 @@ class TestReportService(BaseTestCase):
                 "setup": {
                     "save_report_data_in_storage": {
                         "only_codecov": False,
-                        "report_details_files_array": True,
                     },
                 }
             }
@@ -3133,9 +3132,6 @@ class TestReportService(BaseTestCase):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(report_id=current_report_row.id_)
-        dbsession.add(report_details)
         dbsession.flush()
         sample_report.sessions[0].archive = "path/to/upload/location"
         sample_report.sessions[
@@ -3201,48 +3197,6 @@ class TestReportService(BaseTestCase):
         assert second_upload.totals is None
         assert second_upload.upload_extras == {}
         assert second_upload.upload_type == "carriedforward"
-        assert report_details.files_array == [
-            {
-                "filename": "file_1.go",
-                "file_index": 0,
-                "file_totals": ReportTotals(
-                    files=0,
-                    lines=8,
-                    hits=5,
-                    misses=3,
-                    partials=0,
-                    coverage="62.50000",
-                    branches=0,
-                    methods=0,
-                    messages=0,
-                    sessions=0,
-                    complexity=10,
-                    complexity_total=2,
-                    diff=0,
-                ),
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_2.py",
-                "file_index": 1,
-                "file_totals": ReportTotals(
-                    files=0,
-                    lines=2,
-                    hits=1,
-                    misses=0,
-                    partials=1,
-                    coverage="50.00000",
-                    branches=1,
-                    methods=0,
-                    messages=0,
-                    sessions=0,
-                    complexity=0,
-                    complexity_total=0,
-                    diff=0,
-                ),
-                "diff_totals": None,
-            },
-        ]
 
     def test_save_report_empty_report(self, dbsession, mock_storage):
         report = Report()
@@ -3251,9 +3205,6 @@ class TestReportService(BaseTestCase):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(report_id=current_report_row.id_)
-        dbsession.add(report_details)
         dbsession.flush()
         report_service = ReportService({})
         res = report_service.save_report(commit, report)
@@ -3292,61 +3243,17 @@ class TestReportService(BaseTestCase):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(report_id=current_report_row.id_)
-        dbsession.add(report_details)
-        dbsession.flush()
         report_service = ReportService({})
         res = report_service.save_report(commit, sample_report)
         storage_hash = report_service.get_archive_service(
             commit.repository
         ).storage_hash
+
         assert res == {
             "url": f"v4/repos/{storage_hash}/commits/{commit.commitid}/chunks.txt"
         }
         assert len(current_report_row.uploads) == 0
-        assert report_details.files_array == [
-            {
-                "filename": "file_1.go",
-                "file_index": 0,
-                "file_totals": ReportTotals(
-                    files=0,
-                    lines=8,
-                    hits=5,
-                    misses=3,
-                    partials=0,
-                    coverage="62.50000",
-                    branches=0,
-                    methods=0,
-                    messages=0,
-                    sessions=0,
-                    complexity=10,
-                    complexity_total=2,
-                    diff=0,
-                ),
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_2.py",
-                "file_index": 1,
-                "file_totals": ReportTotals(
-                    files=0,
-                    lines=2,
-                    hits=1,
-                    misses=0,
-                    partials=1,
-                    coverage="50.00000",
-                    branches=1,
-                    methods=0,
-                    messages=0,
-                    sessions=0,
-                    complexity=0,
-                    complexity_total=0,
-                    diff=0,
-                ),
-                "diff_totals": None,
-            },
-        ]
-        expected = {
+        assert commit.report_json == {
             "files": {
                 "file_1.go": [
                     0,
@@ -3394,12 +3301,6 @@ class TestReportService(BaseTestCase):
                 },
             },
         }
-        assert (
-            commit.report_json["sessions"]["0"]["t"] == expected["sessions"]["0"]["t"]
-        )
-        assert commit.report_json["sessions"]["0"] == expected["sessions"]["0"]
-        assert commit.report_json["sessions"] == expected["sessions"]
-        assert commit.report_json == expected
         assert res["url"] in mock_storage.storage["archive"]
         expected_content = "\n".join(
             [
@@ -3482,9 +3383,6 @@ class TestReportService(BaseTestCase):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(report_id=current_report_row.id_)
-        dbsession.add(report_details)
-        dbsession.flush()
         report_service = ReportService({})
         f = ReportFile("hahafile.txt")
         f.append(1, ReportLine.create(1))
@@ -3507,49 +3405,7 @@ class TestReportService(BaseTestCase):
             "url": f"v4/repos/{storage_hash}/commits/{commit.commitid}/chunks.txt"
         }
         assert len(current_report_row.uploads) == 0
-        assert report_details.files_array == [
-            {
-                "filename": "file_1.go",
-                "file_index": 0,
-                "file_totals": ReportTotals(
-                    files=0,
-                    lines=8,
-                    hits=5,
-                    misses=3,
-                    partials=0,
-                    coverage="62.50000",
-                    branches=0,
-                    methods=0,
-                    messages=0,
-                    sessions=0,
-                    complexity=10,
-                    complexity_total=2,
-                    diff=0,
-                ),
-                "diff_totals": None,
-            },
-            {
-                "filename": "poultry.c",
-                "file_index": 1,
-                "file_totals": ReportTotals(
-                    files=0,
-                    lines=1,
-                    hits=1,
-                    misses=0,
-                    partials=0,
-                    coverage="100",
-                    branches=0,
-                    methods=0,
-                    messages=0,
-                    sessions=0,
-                    complexity=0,
-                    complexity_total=0,
-                    diff=0,
-                ),
-                "diff_totals": None,
-            },
-        ]
-        expected = {
+        assert commit.report_json == {
             "files": {
                 "file_1.go": [
                     0,
@@ -3597,13 +3453,6 @@ class TestReportService(BaseTestCase):
                 },
             },
         }
-        assert (
-            commit.report_json["sessions"]["0"]["t"] == expected["sessions"]["0"]["t"]
-        )
-        assert commit.report_json["sessions"]["0"] == expected["sessions"]["0"]
-        assert commit.report_json["sessions"] == expected["sessions"]
-        assert commit.report_json["files"] == expected["files"]
-        assert commit.report_json == expected
         assert res["url"] in mock_storage.storage["archive"]
         expected_content = "\n".join(
             [
@@ -3645,8 +3494,6 @@ class TestReportService(BaseTestCase):
         report_service = ReportService({})
         r = report_service.initialize_and_save_report(commit)
         assert r is not None
-        assert r.details is not None
-        assert r.details.files_array == []
         assert len(mock_storage.storage["archive"]) == 0
 
     def test_initialize_and_save_report_report_but_no_details(
@@ -3662,8 +3509,6 @@ class TestReportService(BaseTestCase):
         r = report_service.initialize_and_save_report(commit)
         dbsession.refresh(report_row)
         assert r is not None
-        assert r.details is not None
-        assert r.details.files_array == []
         assert len(mock_storage.storage["archive"]) == 0
 
     @pytest.mark.django_db(databases={"default"})
@@ -3726,24 +3571,6 @@ class TestReportService(BaseTestCase):
             "carriedforward_from": parent_commit.commitid
         }
         assert second_upload.upload_type == "carriedforward"
-        assert r.details is not None
-        assert sorted(f["filename"] for f in r.details.files_array) == [
-            "file_00.py",
-            "file_01.py",
-            "file_02.py",
-            "file_03.py",
-            "file_04.py",
-            "file_05.py",
-            "file_06.py",
-            "file_07.py",
-            "file_08.py",
-            "file_09.py",
-            "file_10.py",
-            "file_11.py",
-            "file_12.py",
-            "file_13.py",
-            "file_14.py",
-        ]
 
     @pytest.mark.django_db(databases={"default"})
     def test_initialize_and_save_report_report_but_no_details_carryforward_needed(
@@ -3808,36 +3635,14 @@ class TestReportService(BaseTestCase):
             "carriedforward_from": parent_commit.commitid
         }
         assert second_upload.upload_type == "carriedforward"
-        assert r.details is not None
-        assert sorted(f["filename"] for f in r.details.files_array) == [
-            "file_00.py",
-            "file_01.py",
-            "file_02.py",
-            "file_03.py",
-            "file_04.py",
-            "file_05.py",
-            "file_06.py",
-            "file_07.py",
-            "file_08.py",
-            "file_09.py",
-            "file_10.py",
-            "file_11.py",
-            "file_12.py",
-            "file_13.py",
-            "file_14.py",
-        ]
 
     def test_initialize_and_save_report_needs_backporting(
         self, dbsession, sample_commit_with_report_big, mock_storage, mocker
     ):
         commit = sample_commit_with_report_big
         report_service = ReportService({})
-        mocker.patch.object(
-            ReportDetails, "_should_write_to_storage", return_value=True
-        )
         r = report_service.initialize_and_save_report(commit)
         assert r is not None
-        assert r.details is not None
         assert len(r.uploads) == 4
         first_upload = dbsession.query(Upload).filter_by(order_number=0).first()
         assert sorted([f.flag_name for f in first_upload.flags]) == []
@@ -3856,98 +3661,6 @@ class TestReportService(BaseTestCase):
             .count()
             == 2
         )
-        assert r.details.files_array == [
-            {
-                "filename": "file_00.py",
-                "file_index": 0,
-                "file_totals": [0, 14, 12, 0, 2, "85.71429", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_01.py",
-                "file_index": 1,
-                "file_totals": [0, 11, 8, 0, 3, "72.72727", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_10.py",
-                "file_index": 10,
-                "file_totals": [0, 10, 6, 1, 3, "60.00000", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_11.py",
-                "file_index": 11,
-                "file_totals": [0, 23, 15, 1, 7, "65.21739", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_12.py",
-                "file_index": 12,
-                "file_totals": [0, 14, 8, 0, 6, "57.14286", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_13.py",
-                "file_index": 13,
-                "file_totals": [0, 15, 9, 0, 6, "60.00000", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_14.py",
-                "file_index": 14,
-                "file_totals": [0, 23, 13, 0, 10, "56.52174", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_02.py",
-                "file_index": 2,
-                "file_totals": [0, 13, 9, 0, 4, "69.23077", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_03.py",
-                "file_index": 3,
-                "file_totals": [0, 16, 8, 0, 8, "50.00000", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_04.py",
-                "file_index": 4,
-                "file_totals": [0, 10, 6, 0, 4, "60.00000", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_05.py",
-                "file_index": 5,
-                "file_totals": [0, 14, 10, 0, 4, "71.42857", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_06.py",
-                "file_index": 6,
-                "file_totals": [0, 9, 7, 1, 1, "77.77778", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_07.py",
-                "file_index": 7,
-                "file_totals": [0, 11, 9, 0, 2, "81.81818", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_08.py",
-                "file_index": 8,
-                "file_totals": [0, 11, 6, 0, 5, "54.54545", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_09.py",
-                "file_index": 9,
-                "file_totals": [0, 14, 10, 1, 3, "71.42857", 0, 0, 0, 0, 0, 0, 0],
-                "diff_totals": None,
-            },
-        ]
         storage_keys = mock_storage.storage["archive"].keys()
         assert any(map(lambda key: key.endswith("chunks.txt"), storage_keys))
 
@@ -3960,9 +3673,6 @@ class TestReportService(BaseTestCase):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(report_id=current_report_row.id_)
-        dbsession.add(report_details)
         dbsession.flush()
         report_service = ReportService({})
         report_service.save_report(commit, sample_report)
@@ -4154,10 +3864,8 @@ class TestReportService(BaseTestCase):
     ):
         parent_commit = CommitFactory()
         parent_commit_report = CommitReport(commit_id=parent_commit.id_)
-        parent_report_details = ReportDetails(report_id=parent_commit_report.id_)
         dbsession.add(parent_commit)
         dbsession.add(parent_commit_report)
-        dbsession.add(parent_report_details)
         dbsession.flush()
 
         commit = CommitFactory.create(

--- a/tasks/tests/unit/test_preprocess_upload.py
+++ b/tasks/tests/unit/test_preprocess_upload.py
@@ -1,6 +1,5 @@
 import pytest
 from redis.exceptions import LockError
-from shared.reports.types import ReportTotals
 
 from database.models.reports import Upload
 from database.tests.factories.core import (
@@ -65,49 +64,6 @@ class TestPreProcessUpload(object):
             commitid=commit.commitid,
             report_code=None,
         )
-        # assert that commit.report has carried forwarded flags sessions from its parent
-        assert commit.report.details.files_array == [
-            {
-                "filename": "file_1.go",
-                "file_index": 0,
-                "file_totals": ReportTotals(
-                    files=0,
-                    lines=8,
-                    hits=5,
-                    misses=3,
-                    partials=0,
-                    coverage="62.50000",
-                    branches=0,
-                    methods=0,
-                    messages=0,
-                    sessions=0,
-                    complexity=10,
-                    complexity_total=2,
-                    diff=0,
-                ),
-                "diff_totals": None,
-            },
-            {
-                "filename": "file_2.py",
-                "file_index": 1,
-                "file_totals": ReportTotals(
-                    files=0,
-                    lines=2,
-                    hits=1,
-                    misses=0,
-                    partials=1,
-                    coverage="50.00000",
-                    branches=1,
-                    methods=0,
-                    messages=0,
-                    sessions=0,
-                    complexity=0,
-                    complexity_total=0,
-                    diff=0,
-                ),
-                "diff_totals": None,
-            },
-        ]
         for sess_id in sample_report.sessions.keys():
             upload = (
                 dbsession.query(Upload)

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -11,7 +11,7 @@ from shared.torngit.exceptions import TorngitObjectNotFoundError
 from shared.upload.constants import UploadErrorCode
 from shared.yaml import UserYaml
 
-from database.models import CommitReport, ReportDetails, UploadError
+from database.models import CommitReport, UploadError
 from database.tests.factories import CommitFactory, UploadFactory
 from helpers.exceptions import (
     ReportEmptyError,
@@ -85,11 +85,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         result = UploadProcessorTask().run_impl(
             dbsession,
             {},
@@ -150,11 +145,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         result = UploadProcessorTask().run_impl(
             dbsession,
             {},
@@ -200,11 +190,6 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
         dbsession.flush()
         url = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
         upload = UploadFactory.create(
@@ -365,11 +350,6 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
         dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"
@@ -533,11 +513,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"
         )
@@ -624,11 +599,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"
         )
@@ -709,11 +679,6 @@ class TestUploadProcessorTask(object):
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
         dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
-        dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"
         )
@@ -751,11 +716,6 @@ class TestUploadProcessorTask(object):
         dbsession.flush()
         current_report_row = CommitReport(commit_id=commit.id_)
         dbsession.add(current_report_row)
-        dbsession.flush()
-        report_details = ReportDetails(
-            report_id=current_report_row.id_, _files_array=[]
-        )
-        dbsession.add(report_details)
         dbsession.flush()
         upload_1 = UploadFactory.create(
             report=current_report_row, state="started", storage_path="url"

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -166,7 +166,6 @@ class TestUploadTaskIntegration(object):
         assert commit.message == "dsidsahdsahdsa"
         assert commit.parent_commit_id is None
         assert commit.report is not None
-        assert commit.report.details is not None
         sessions = commit.report.uploads
         assert len(sessions) == 1
         first_session = (
@@ -904,7 +903,6 @@ class TestUploadTaskIntegration(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
         assert commit.report is not None
-        assert commit.report.details is not None
         sessions = commit.report.uploads
         assert len(sessions) == 2
         first_session = (
@@ -1004,7 +1002,6 @@ class TestUploadTaskIntegration(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
         assert commit.report is not None
-        assert commit.report.details is not None
         mocked_schedule_task.assert_called_with(
             mocker.ANY,
             commit,


### PR DESCRIPTION
This model was previously used for the ill-fated `report_builder` feature which was since removed.

Avoiding the table and in particular the `files_array` saves us from one GCS write per report, so should speed up the `UploadFinisher` ever so slightly.