### PR TITLE
Only update the `Upload` once in `UploadFinisher`

### DIFF
--- a/services/processing/processing.py
+++ b/services/processing/processing.py
@@ -29,7 +29,7 @@ def process_upload(
     commit_yaml: UserYaml,
     arguments: UploadArguments,
     intermediate_reports_in_redis=False,
-) -> dict:
+) -> ProcessingResult:
     upload_id = arguments["upload_id"]
 
     commit = (
@@ -66,8 +66,7 @@ def process_upload(
             result["successful"] = True
         log.info("Finished processing upload", extra={"result": result})
 
-        report_service.update_upload_with_processing_result(upload, processing_result)
-        # TODO(swatinem): do not save empty reports
+        # TODO(swatinem): only save the intermediate report on success
         save_intermediate_report(
             archive_service,
             commit_sha,

--- a/services/processing/types.py
+++ b/services/processing/types.py
@@ -3,6 +3,8 @@ from typing import NotRequired, TypedDict
 
 from shared.reports.editable import EditableReport
 
+from services.report import ProcessingErrorDict
+
 
 class UploadArguments(TypedDict):
     upload_id: int
@@ -15,7 +17,7 @@ class ProcessingResult(TypedDict):
     upload_id: int
     arguments: UploadArguments
     successful: bool
-    error: NotRequired[dict]
+    error: NotRequired[ProcessingErrorDict]
 
 
 @dataclass


### PR DESCRIPTION
This avoids updating the `Upload` state in the first `UploadProcessor` job, deferring that work to the final `UploadFinisher`, which was doing the same anyway.

This way, it is also possible to run the `UPDATE`, as well as all the `INSERT`s for either `UploadError` or `UploadLevelTotals` (which we should start removing) in bulk.