### PR TITLE
Less repo timestamp updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,9 @@ push.self-hosted-rolling:
 	docker push ${DOCKERHUB_REPO}:rolling_no_dependencies
 	docker push ${DOCKERHUB_REPO}:rolling
 
+shell:
+	docker-compose exec worker bash
+
 test_env.up:
 	env | grep GITHUB > .testenv; true
 	TIMESERIES_ENABLED=${TIMESERIES_ENABLED} docker-compose up -d
@@ -213,6 +216,7 @@ test_env.install_cli:
 	pip install --no-cache-dir codecov-cli==$(CODECOV_CLI_VERSION)
 
 test_env.container_prepare:
+	apt-get update
 	apt-get install -y git build-essential netcat-traditional
 	make test_env.install_cli
 	git config --global --add safe.directory /worker

--- a/tasks/sync_repos.py
+++ b/tasks/sync_repos.py
@@ -524,11 +524,21 @@ class SyncReposTask(BaseCodecovTask, name=sync_repos_task_name):
 
         if repo:
             # Found the exact repo. Let's just update
-            repo.private = repo_data["private"]
-            repo.language = repo_data["language"]
-            repo.name = repo_data["name"]
-            repo.deleted = False
-            repo.updatestamp = datetime.now()
+            has_changes = False
+            if repo.private != repo_data["private"]:
+                repo.private = repo_data["private"]
+                has_changes = True
+            if repo.language != repo_data["language"]:
+                repo.language = repo_data["language"]
+                has_changes = True
+            if repo.name != repo_data["name"]:
+                repo.name = repo_data["name"]
+                has_changes = True
+            if repo.deleted is not False:
+                repo.deleted = False
+                has_changes = True
+            if has_changes:
+                repo.updatestamp = datetime.now()
             repo_id = repo.repoid
             return repo_id
         # repo was not found, could be a different owner


### PR DESCRIPTION
<!-- Describe your PR here. -->

Only update the timestamp IF other fields change. This will help immensely with DB lock contention.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.