### PR TITLE
fix: deadlock when inserting tests and rollups

### DIFF
--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -338,7 +338,7 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
         # Upsert Tests
         if len(test_data) > 0:
             test_insert = insert(Test.__table__).values(
-                sorted(list(test_data.values()), key=lambda x: str(x["flags_hash"]))
+                sorted(test_data.values(), key=lambda x: str(x["flags_hash"]))
             )
             insert_on_conflict_do_update = test_insert.on_conflict_do_update(
                 index_elements=["repoid", "name", "testsuite", "flags_hash"],
@@ -364,7 +364,7 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
         if len(daily_totals) > 0:
             rollup_table = DailyTestRollup.__table__
             stmt = insert(rollup_table).values(
-                sorted(list(daily_totals.values()), key=lambda x: str(x["test_id"]))
+                sorted(daily_totals.values(), key=lambda x: str(x["test_id"]))
             )
             stmt = stmt.on_conflict_do_update(
                 index_elements=[

--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -337,7 +337,9 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
 
         # Upsert Tests
         if len(test_data) > 0:
-            test_insert = insert(Test.__table__).values(list(test_data.values()))
+            test_insert = insert(Test.__table__).values(
+                sorted(list(test_data.values()), key=lambda x: str(x["flags_hash"]))
+            )
             insert_on_conflict_do_update = test_insert.on_conflict_do_update(
                 index_elements=["repoid", "name", "testsuite", "flags_hash"],
                 set_={

--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -363,7 +363,9 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
         # Upsert Daily Test Totals
         if len(daily_totals) > 0:
             rollup_table = DailyTestRollup.__table__
-            stmt = insert(rollup_table).values(list(daily_totals.values()))
+            stmt = insert(rollup_table).values(
+                sorted(list(daily_totals.values()), key=lambda x: str(x["test_id"]))
+            )
             stmt = stmt.on_conflict_do_update(
                 index_elements=[
                     "repoid",

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -684,16 +684,16 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
                 date.today(),
             ]
 
-            assert [r.fail_count for r in rollups] == [1, 0, 0, 1]
-            assert [r.pass_count for r in rollups] == [1, 1, 2, 0]
+            assert [r.fail_count for r in rollups] == [0, 1, 1, 0]
+            assert [r.pass_count for r in rollups] == [1, 1, 0, 2]
             assert [r.skip_count for r in rollups] == [0, 0, 0, 0]
-            assert [r.flaky_fail_count for r in rollups] == [0, 0, 0, 1]
+            assert [r.flaky_fail_count for r in rollups] == [0, 0, 1, 0]
 
             assert [r.commits_where_fail for r in rollups] == [
+                [],
                 ["cd76b0821854a780b60012aed85af0a8263004ad"],
-                [],
-                [],
                 ["bd76b0821854a780b60012aed85af0a8263004ad"],
+                [],
             ]
 
             assert [r.latest_run for r in rollups] == [
@@ -702,12 +702,17 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
                 datetime(1970, 1, 2, 0, 0),
                 datetime(1970, 1, 2, 0, 0),
             ]
-            assert [r.avg_duration_seconds for r in rollups] == [0.001, 7.2, 0.002, 3.6]
-            assert [r.last_duration_seconds for r in rollups] == [
-                0.001,
+            assert [r.avg_duration_seconds for r in rollups] == [
                 7.2,
-                0.002,
+                0.001,
                 3.6,
+                0.002,
+            ]
+            assert [r.last_duration_seconds for r in rollups] == [
+                7.2,
+                0.001,
+                3.6,
+                0.002,
             ]
 
     @pytest.mark.integration


### PR DESCRIPTION
we deadlock when inserting (on conflict do update is the part i think
causes this) tests possibly because each worker task is inserting tests
in a different order, this fixes that by making sure if tasks are inserting
the same tests they will insert them in the same order

does the same for the rollups batch insert on conflict do update