### PR TITLE
fix: rewriting of test result reports

### DIFF
--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -495,7 +495,7 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
 
             readable_report = self.rewrite_readable(network, report_contents)
 
-            archive_service.write_file(upload.storage_path, readable_report.getvalue())
+        archive_service.write_file(upload.storage_path, readable_report.getvalue())
 
         return TestResultsProcessingResult(
             network_files=network, parsing_results=parsing_results

--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -493,8 +493,7 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
                     ),
                 )
 
-            readable_report = self.rewrite_readable(network, report_contents)
-
+        readable_report = self.rewrite_readable(network, report_contents)
         archive_service.write_file(upload.storage_path, readable_report.getvalue())
 
         return TestResultsProcessingResult(


### PR DESCRIPTION
the rewrite_readable and writing of the storage file should've been outside the loop, having them inside the loop was:
1. doing extra useless work by calling rewrite_readable a bunch of times
2. causing rate limit errors in GCS due to trying to write to the same object so often, resulting in the task failing