### PR TITLE
Store intermediate Reports in Redis

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -10,6 +10,8 @@ USE_LABEL_INDEX_IN_REPORT_PROCESSING_BY_REPO_ID = Feature(
     "use_label_index_in_report_processing"
 )
 
+INTERMEDIATE_REPORTS_IN_REDIS = Feature("intermediate_reports_in_redis")
+
 CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER = Feature("carryforward_base_search_range")
 
 SYNC_PULL_USE_MERGE_COMMIT_SHA = Feature("sync_pull_use_merge_commit_sha")

--- a/services/processing/intermediate.py
+++ b/services/processing/intermediate.py
@@ -7,9 +7,12 @@ from shared.reports.editable import EditableReport
 from shared.reports.resources import Report
 
 from services.archive import ArchiveService
+from services.redis import get_redis_connection
 
 from .metrics import INTERMEDIATE_REPORT_SIZE
 from .types import IntermediateReport
+
+REPORT_TTL = 24 * 60 * 60
 
 
 @sentry_sdk.trace
@@ -17,7 +20,31 @@ def load_intermediate_reports(
     archive_service: ArchiveService,
     commitsha: str,
     upload_ids: list[int],
+    intermediate_reports_in_redis=False,
 ) -> list[IntermediateReport]:
+    if intermediate_reports_in_redis:
+        redis = get_redis_connection()
+        dctx = zstandard.ZstdDecompressor()
+        intermediate_reports: list[IntermediateReport] = []
+
+        for upload_id in upload_ids:
+            key = intermediate_report_key(upload_id)
+            report_dict = redis.hgetall(key)
+            # NOTE: our redis client is configured to return `bytes` everywhere,
+            # so the dict keys are `bytes` as well.
+            chunks = dctx.decompress(report_dict[b"chunks"]).decode(errors="replace")
+            report_json = orjson.loads(dctx.decompress(report_dict[b"report_json"]))
+
+            report = EditableReport.from_chunks(
+                chunks=chunks,
+                files=report_json["files"],
+                sessions=report_json["sessions"],
+                totals=report_json.get("totals"),
+            )
+            intermediate_reports.append(IntermediateReport(upload_id, report))
+
+        return intermediate_reports
+
     @sentry_sdk.trace
     def load_report(upload_id: int) -> IntermediateReport:
         repo_hash = archive_service.storage_hash
@@ -51,11 +78,25 @@ def save_intermediate_report(
     commitsha: str,
     upload_id: int,
     report: Report,
+    intermediate_reports_in_redis=False,
 ):
     _totals, report_json = report.to_database()
     report_json = report_json.encode()
     chunks = report.to_archive().encode()
-    emit_size_metrics(report_json, chunks)
+    zstd_report_json, zstd_chunks = emit_size_metrics(report_json, chunks)
+
+    if intermediate_reports_in_redis:
+        report_key = intermediate_report_key(upload_id)
+        redis = get_redis_connection()
+        mapping = {
+            "report_json": zstd_report_json,
+            "chunks": zstd_chunks,
+        }
+        with redis.pipeline() as pipeline:
+            pipeline.hmset(report_key, mapping)
+            pipeline.expire(report_key, REPORT_TTL)
+            pipeline.execute()
+        return
 
     repo_hash = archive_service.storage_hash
     json_path, chunks_path = intermediate_report_paths(repo_hash, commitsha, upload_id)
@@ -69,14 +110,15 @@ def cleanup_intermediate_reports(
     archive_service: ArchiveService,
     commitsha: str,
     upload_ids: list[int],
+    intermediate_reports_in_redis=False,
 ):
-    """
-    Cleans up the files in storage that contain the "intermediate Report"s
-    from parallel processing, as well as the copy of the "master Report" used
-    for the "experiment" mode.
-    """
-    repo_hash = archive_service.storage_hash
+    if intermediate_reports_in_redis:
+        keys = [intermediate_report_key(upload_id) for upload_id in upload_ids]
+        redis = get_redis_connection()
+        redis.delete(*keys)
+        return
 
+    repo_hash = archive_service.storage_hash
     files_to_delete: list[str] = []
 
     for upload_id in upload_ids:
@@ -85,6 +127,10 @@ def cleanup_intermediate_reports(
         )
 
     archive_service.delete_files(files_to_delete)
+
+
+def intermediate_report_key(upload_id: int):
+    return f"intermediate_report/{upload_id}"
 
 
 def intermediate_report_paths(
@@ -97,16 +143,22 @@ def intermediate_report_paths(
     return json_path, chunks_path
 
 
-def emit_size_metrics(report_json: bytes, chunks: bytes):
+def emit_size_metrics(report_json: bytes, chunks: bytes) -> tuple[bytes, bytes]:
     INTERMEDIATE_REPORT_SIZE.labels(type="report_json", compression="none").observe(
         len(report_json)
     )
     INTERMEDIATE_REPORT_SIZE.labels(type="chunks", compression="none").observe(
         len(chunks)
     )
+
+    zstd_report_json = zstandard.compress(report_json)
+    zstd_chunks = zstandard.compress(chunks)
+
     INTERMEDIATE_REPORT_SIZE.labels(type="report_json", compression="zstd").observe(
-        len(zstandard.compress(report_json))
+        len(zstd_report_json)
     )
     INTERMEDIATE_REPORT_SIZE.labels(type="chunks", compression="zstd").observe(
-        len(zstandard.compress(chunks))
+        len(zstd_chunks)
     )
+
+    return zstd_report_json, zstd_chunks

--- a/services/processing/intermediate.py
+++ b/services/processing/intermediate.py
@@ -130,7 +130,7 @@ def cleanup_intermediate_reports(
 
 
 def intermediate_report_key(upload_id: int):
-    return f"intermediate_report/{upload_id}"
+    return f"intermediate-report/{upload_id}"
 
 
 def intermediate_report_paths(

--- a/services/processing/processing.py
+++ b/services/processing/processing.py
@@ -28,6 +28,7 @@ def process_upload(
     commit_sha: str,
     commit_yaml: UserYaml,
     arguments: UploadArguments,
+    intermediate_reports_in_redis=False,
 ) -> dict:
     upload_id = arguments["upload_id"]
 
@@ -67,7 +68,13 @@ def process_upload(
         log.info("Finished processing upload", extra={"result": result})
 
         report_service.update_upload_with_processing_result(upload, processing_result)
-        save_intermediate_report(archive_service, commit_sha, upload_id, report)
+        save_intermediate_report(
+            archive_service,
+            commit_sha,
+            upload_id,
+            report,
+            intermediate_reports_in_redis,
+        )
         state.mark_upload_as_processed(upload_id)
 
         rewrite_or_delete_upload(archive_service, commit_yaml, report_info)

--- a/tasks/tests/integration/test_upload_e2e.py
+++ b/tasks/tests/integration/test_upload_e2e.py
@@ -16,6 +16,7 @@ from database.models.core import Commit, CompareCommit, Repository
 from database.models.reports import Upload
 from database.tests.factories import CommitFactory, RepositoryFactory
 from database.tests.factories.core import PullFactory
+from rollouts import INTERMEDIATE_REPORTS_IN_REDIS
 from services.archive import ArchiveService
 from services.redis import get_redis_connection
 from services.report import ReportService
@@ -159,14 +160,22 @@ def setup_mocks(
 
 @pytest.mark.integration
 @pytest.mark.django_db
+@pytest.mark.parametrize("redis_storage", [True, False])
 def test_full_upload(
     dbsession: DbSession,
+    redis_storage: bool,
     mocker,
     mock_repo_provider,
     mock_storage,
     mock_configuration,
 ):
     setup_mocks(mocker, dbsession, mock_configuration, mock_repo_provider)
+
+    mocker.patch.object(
+        INTERMEDIATE_REPORTS_IN_REDIS,
+        "check_value",
+        return_value=redis_storage,
+    )
 
     repository = RepositoryFactory.create()
     dbsession.add(repository)
@@ -356,8 +365,10 @@ end_of_record
 
 @pytest.mark.integration
 @pytest.mark.django_db()
+@pytest.mark.parametrize("redis_storage", [True, False])
 def test_full_carryforward(
     dbsession: DbSession,
+    redis_storage: bool,
     mocker,
     mock_repo_provider,
     mock_storage,
@@ -368,6 +379,12 @@ def test_full_carryforward(
         mocker, dbsession, mock_configuration, mock_repo_provider, user_yaml=user_yaml
     )
     mocker.patch("tasks.compute_comparison.ComputeComparisonTask.run_impl")
+
+    mocker.patch.object(
+        INTERMEDIATE_REPORTS_IN_REDIS,
+        "check_value",
+        return_value=redis_storage,
+    )
 
     repository = RepositoryFactory.create()
     dbsession.add(repository)

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -183,12 +183,14 @@ class TestUploadTaskIntegration(object):
                 "upload_id": first_session.id,
                 "upload_pk": first_session.id,
             },
+            intermediate_reports_in_redis=False,
         )
         kwargs = dict(
             repoid=commit.repoid,
             commitid="abf6d4df662c47e32460020ab14abf9303581429",
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},
             report_code=None,
+            intermediate_reports_in_redis=False,
         )
         kwargs[_kwargs_key(UploadFlow)] = mocker.ANY
         finisher = upload_finisher_task.signature(kwargs=kwargs)
@@ -651,6 +653,7 @@ class TestUploadTaskIntegration(object):
                     "upload_id": mocker.ANY,
                     "upload_pk": mocker.ANY,
                 },
+                intermediate_reports_in_redis=False,
             )
             for arguments in redis_queue
         ]
@@ -660,6 +663,7 @@ class TestUploadTaskIntegration(object):
             commitid="abf6d4df662c47e32460020ab14abf9303581429",
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},
             report_code=None,
+            intermediate_reports_in_redis=False,
         )
         kwargs[_kwargs_key(UploadFlow)] = mocker.ANY
         t_final = upload_finisher_task.signature(kwargs=kwargs)
@@ -1166,6 +1170,7 @@ class TestUploadTaskUnit(object):
             commitid=commit.commitid,
             commit_yaml=commit_yaml,
             arguments={"upload_id": 1, "upload_pk": 1},
+            intermediate_reports_in_redis=False,
         )
         finisher = upload_finisher_task.signature(
             kwargs={
@@ -1173,6 +1178,7 @@ class TestUploadTaskUnit(object):
                 "commitid": commit.commitid,
                 "commit_yaml": commit_yaml,
                 "report_code": None,
+                "intermediate_reports_in_redis": False,
                 _kwargs_key(UploadFlow): mocker.ANY,
             }
         )

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -29,6 +29,7 @@ from helpers.checkpoint_logger.flows import TestResultsFlow, UploadFlow
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
 from helpers.save_commit_error import save_commit_error
+from rollouts import INTERMEDIATE_REPORTS_IN_REDIS
 from services.archive import ArchiveService
 from services.bundle_analysis.report import BundleAnalysisReportService
 from services.processing.state import ProcessingState
@@ -596,12 +597,17 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             [int(upload["upload_id"]) for upload in argument_list]
         )
 
+        intermediate_reports_in_redis = INTERMEDIATE_REPORTS_IN_REDIS.check_value(
+            commit.repoid
+        )
+
         parallel_processing_tasks = [
             upload_processor_task.s(
                 repoid=commit.repoid,
                 commitid=commit.commitid,
                 commit_yaml=commit_yaml,
                 arguments=arguments,
+                intermediate_reports_in_redis=intermediate_reports_in_redis,
             )
             for arguments in argument_list
         ]
@@ -612,6 +618,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
                 "commitid": commit.commitid,
                 "commit_yaml": commit_yaml,
                 "report_code": commit_report.code,
+                "intermediate_reports_in_redis": intermediate_reports_in_redis,
                 _kwargs_key(UploadFlow): checkpoints.data,
             },
         )

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -67,6 +67,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
         commitid: str,
         commit_yaml: dict,
         arguments: UploadArguments,
+        intermediate_reports_in_redis=False,
         **kwargs,
     ):
         log.info(
@@ -90,6 +91,7 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
             commitid,
             UserYaml(commit_yaml),
             arguments,
+            intermediate_reports_in_redis,
         )
 
 


### PR DESCRIPTION
This adds a new feature flag to store intermediate reports in Redis rather than in GCS.

Doing so will remove very slow GCS write/delete operations from the processing/merging flow respectively. It also switches from `gzip` to `zstd` compression for those reports, which should also be slightly faster.
