### PR TITLE
Clean up `Upload{Processor,Finisher}` task args and return values

### DIFF
--- a/services/processing/processing.py
+++ b/services/processing/processing.py
@@ -29,7 +29,7 @@ def process_upload(
     commit_yaml: UserYaml,
     arguments: UploadArguments,
 ) -> dict:
-    upload_id = arguments["upload_pk"]
+    upload_id = arguments["upload_id"]
 
     commit = (
         db_session.query(Commit)
@@ -85,11 +85,7 @@ def process_upload(
         # or retries are not blocking later merge/notify stages
         state.clear_in_progress_uploads([upload_id])
 
-    # TODO(swatinem): migrate this to just `return result`:
-    return {
-        "processings_so_far": [result],
-        "parallel_incremental_result": {"upload_pk": upload_id},
-    }
+    return result
 
 
 def rewrite_or_delete_upload(

--- a/services/processing/types.py
+++ b/services/processing/types.py
@@ -5,6 +5,8 @@ from shared.reports.editable import EditableReport
 
 
 class UploadArguments(TypedDict):
+    upload_id: int
+
     # TODO(swatinem): migrate this over to `upload_id`
     upload_pk: int
 

--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -678,7 +678,6 @@ class TestUploadFinisherTask(object):
                 repoid=commit.repoid,
                 commitid=commit.commitid,
                 commit_yaml={},
-                run_fully_parallel=True,
             )
 
 


### PR DESCRIPTION
The `UploadFinisher` was made forward compatible to accept a new shape of arguments, which itself is the return value of the `UploadProcessor`.

Both tasks are also cleaned up of some old obsolete task arguments which are not being used anymore.