### PR TITLE
Make `process_raw_upload` return the `Report` directly

### DIFF
--- a/services/processing/processing.py
+++ b/services/processing/processing.py
@@ -54,10 +54,9 @@ def process_upload(
     )
 
     try:
-        report = Report()
         report_info = RawReportInfo()
         processing_result = report_service.build_report_from_raw_content(
-            report, report_info, upload
+            report_info, upload
         )
 
         if error := processing_result.error:
@@ -68,11 +67,12 @@ def process_upload(
         log.info("Finished processing upload", extra={"result": result})
 
         report_service.update_upload_with_processing_result(upload, processing_result)
+        # TODO(swatinem): do not save empty reports
         save_intermediate_report(
             archive_service,
             commit_sha,
             upload_id,
-            report,
+            processing_result.report or Report(),
             intermediate_reports_in_redis,
         )
         state.mark_upload_as_processed(upload_id)

--- a/services/tests/test_report.py
+++ b/services/tests/test_report.py
@@ -3764,10 +3764,7 @@ class TestReportService(BaseTestCase):
         dbsession.add(upload_obj)
         dbsession.flush()
         assert len(upload_obj.errors) == 0
-        processing_result = ProcessingResult(
-            session=Session(),
-            session_adjustment=SessionAdjustmentResult([], []),
-        )
+        processing_result = ProcessingResult(session=Session())
         ReportService({}).update_upload_with_processing_result(
             upload_obj, processing_result
         )

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -23,10 +23,6 @@ from services.archive import ArchiveService
 from services.processing.processing import process_upload
 from services.report import ProcessingError, RawReportInfo, ReportService
 from services.report.parser.legacy import LegacyReportParser
-from services.report.raw_upload_processor import (
-    SessionAdjustmentResult,
-    UploadProcessingResult,
-)
 from tasks.upload_processor import (
     UploadProcessorTask,
     load_commit_diff,
@@ -325,9 +321,7 @@ class TestUploadProcessorTask(object):
         false_report_file.append(18, ReportLine.create(1, []))
         false_report.append(false_report_file)
         mocked_2.side_effect = [
-            UploadProcessingResult(
-                report=false_report, session_adjustment=SessionAdjustmentResult([], [])
-            ),
+            false_report,
             ReportExpiredException(),
         ]
         # Mocking retry to also raise the exception so we can see how it is called
@@ -492,9 +486,7 @@ class TestUploadProcessorTask(object):
         false_report_file.append(18, ReportLine.create(1, []))
         false_report.append(false_report_file)
         mocked_2.side_effect = [
-            UploadProcessingResult(
-                report=false_report, session_adjustment=SessionAdjustmentResult([], [])
-            ),
+            false_report,
             ReportEmptyError(),
         ]
         mocker.patch.object(UploadProcessorTask, "app", celery_app)


### PR DESCRIPTION
The `process_raw_upload` function would previously get a partial `report` as one of its arguments, to merge the processed upload into.

As this has changed fundamentally with parallel upload processing, we can just return the processed `Report` directly.