### PR TITLE
Fix some flakey tests

### DIFF
--- a/tasks/tests/integration/test_upload_e2e.py
+++ b/tasks/tests/integration/test_upload_e2e.py
@@ -187,6 +187,8 @@ def test_full_upload(
         repository=repository, commitid=commitid, pullid=12, _report_json=None
     )
     dbsession.add(pull)
+    dbsession.flush()
+
     dbsession.add(commit)
     dbsession.flush()
 

--- a/tasks/tests/integration/test_upload_e2e.py
+++ b/tasks/tests/integration/test_upload_e2e.py
@@ -177,20 +177,19 @@ def test_full_upload(
 
     repoid = repository.repoid
     commitid = uuid4().hex
-    commit = CommitFactory.create(
-        repository=repository, commitid=commitid, pullid=12, _report_json=None
-    )
-    dbsession.add(commit)
-    dbsession.flush()
-
     # BASE and HEAD are connected in a PR
     pull = PullFactory(
         pullid=12,
         repository=repository,
         compared_to=base_commit.commitid,
     )
+    commit = CommitFactory.create(
+        repository=repository, commitid=commitid, pullid=12, _report_json=None
+    )
     dbsession.add(pull)
+    dbsession.add(commit)
     dbsession.flush()
+
     setup_mock_get_compare(base_commit, commit, mock_repo_provider)
 
     archive_service = ArchiveService(repository)

--- a/tasks/tests/unit/test_manual_trigger.py
+++ b/tasks/tests/unit/test_manual_trigger.py
@@ -26,16 +26,20 @@ class TestUploadCompletionTask(object):
                 "app.tasks.compute_comparison.ComputeComparison": mocker.MagicMock(),
             },
         )
-        commit = CommitFactory.create()
+        commit = CommitFactory.create(pullid=None)
         pull = PullFactory.create(repository=commit.repository, head=commit.commitid)
         commit.pullid = pull.pullid
+        dbsession.add(pull)
+        dbsession.add(commit)
+        dbsession.flush()
+
         upload = UploadFactory.create(report__commit=commit)
         compared_to = CommitFactory.create(repository=commit.repository)
         pull.compared_to = compared_to.commitid
-        dbsession.add(commit)
+
         dbsession.add(upload)
-        dbsession.add(pull)
         dbsession.add(compared_to)
+        dbsession.add(pull)
         dbsession.flush()
         result = ManualTriggerTask().run_impl(
             dbsession,

--- a/tasks/tests/unit/test_manual_trigger.py
+++ b/tasks/tests/unit/test_manual_trigger.py
@@ -26,11 +26,9 @@ class TestUploadCompletionTask(object):
                 "app.tasks.compute_comparison.ComputeComparison": mocker.MagicMock(),
             },
         )
-
-        commit = CommitFactory.create(pullid=10)
-        pull = PullFactory.create(
-            repository=commit.repository, head=commit.commitid, pullid=commit.pullid
-        )
+        commit = CommitFactory.create()
+        pull = PullFactory.create(repository=commit.repository, head=commit.commitid)
+        commit.pullid = pull.pullid
         upload = UploadFactory.create(report__commit=commit)
         compared_to = CommitFactory.create(repository=commit.repository)
         pull.compared_to = compared_to.commitid

--- a/tasks/tests/unit/test_manual_trigger.py
+++ b/tasks/tests/unit/test_manual_trigger.py
@@ -30,8 +30,9 @@ class TestUploadCompletionTask(object):
         pull = PullFactory.create(repository=commit.repository, head=commit.commitid)
         commit.pullid = pull.pullid
         dbsession.add(pull)
-        dbsession.add(commit)
         dbsession.flush()
+
+        dbsession.add(commit)
 
         upload = UploadFactory.create(report__commit=commit)
         compared_to = CommitFactory.create(repository=commit.repository)

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -525,12 +525,9 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
 
         test_flag_bridges = dbsession.query(TestFlagBridge).all()
 
-        assert [bridge.test_id for bridge in test_flag_bridges] == [
-            tests[1].id,
-            tests[2].id,
-            tests[3].id,
-            tests[4].id,
-        ]
+        assert set(bridge.test_id for bridge in test_flag_bridges) == set(
+            instance.test_id for instance in test_instances
+        )
         for bridge in test_flag_bridges:
             assert bridge.flag == repo_flag
 

--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -459,9 +459,12 @@ class TestUploadFinisherTask(object):
             owner__username="ThiagoCodecov",
             yaml=commit_yaml,
         )
-        dbsession.add(repository)
-        dbsession.flush()
         pull = PullFactory.create(repository=repository)
+
+        dbsession.add(repository)
+        dbsession.add(pull)
+        dbsession.flush()
+
         compared_to = CommitFactory.create(repository=repository)
         pull.compared_to = compared_to.commitid
         commit = CommitFactory.create(
@@ -472,7 +475,6 @@ class TestUploadFinisherTask(object):
         )
         dbsession.add(commit)
         dbsession.add(compared_to)
-        dbsession.add(pull)
         dbsession.flush()
 
         checkpoints = _create_checkpoint_logger(mocker)


### PR DESCRIPTION
Extracted this from https://github.com/codecov/worker/pull/729

A few of the tests become flaky when migrating to the Django models because of some unique references that's defined in Django, but not SQLAlchemy. 

In particular, the way that FactoryBoy creates references can be flakey (i.e. Commits referencing Pulls. If the original `pull` is not flushed, there is a chance that the `commit` gets created first, which inadvertently creates a separate pull with the `id` of the one that you specified to create). So, doing an explicit flush will of `pull` before creating the `commit` will fix this. 

Also fixed a test where DB returned results are not necessarily ordered.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.