### PR TITLE
fix: Update the PR comment footer copy

### DIFF
--- a/services/test_results.py
+++ b/services/test_results.py
@@ -198,7 +198,7 @@ def generate_failure_info(
 def generate_view_test_analytics_line(commit: Commit) -> str:
     repo = commit.repository
     test_analytics_url = get_test_analytics_url(repo, commit)
-    return f"\nTo view individual test run time comparison to the main branch, go to the [Test Analytics Dashboard]({test_analytics_url})"
+    return f"\nTo view more test analytics go to the [Test Analytics Dashboard]({test_analytics_url})\nGot feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)"
 
 
 def messagify_failure(

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -198,7 +198,7 @@ def generate_failure_info(
 def generate_view_test_analytics_line(commit: Commit) -> str:
     repo = commit.repository
     test_analytics_url = get_test_analytics_url(repo, commit)
-    return f"\nTo view more test analytics go to the [Test Analytics Dashboard]({test_analytics_url})\nGot feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)"
+    return f"\nTo view more test analytics, go to the [Test Analytics Dashboard]({test_analytics_url})\nGot feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)"
 
 
 def messagify_failure(

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -136,7 +136,7 @@ def test_build_message():
 
 </details>
 
-To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/thing%2Fthing)
+To view more test analytics, go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/thing%2Fthing)
 Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)"""
     )
 
@@ -187,7 +187,7 @@ def test_build_message_with_flake():
 
 </details>
 
-To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/{commit.branch})
+To view more test analytics, go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/{commit.branch})
 Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)"""
     )
 

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -136,7 +136,8 @@ def test_build_message():
 
 </details>
 
-To view individual test run time comparison to the main branch, go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/thing%2Fthing)"""
+To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/thing%2Fthing)
+Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)"""
     )
 
 
@@ -186,7 +187,8 @@ def test_build_message_with_flake():
 
 </details>
 
-To view individual test run time comparison to the main branch, go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/{commit.branch})"""
+To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/{commit.branch})
+Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)"""
     )
 
 

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -433,7 +433,7 @@ class TestUploadTestFinisherTask(object):
 
 </details>
 
-To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
+To view more test analytics, go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
 Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)""",
         )
 
@@ -720,7 +720,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 
 </details>
 
-To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
+To view more test analytics, go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
 Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)""",
         )
 
@@ -867,7 +867,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 
 </details>
 
-To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
+To view more test analytics, go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
 Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)""",
         )
 
@@ -1052,6 +1052,6 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 
 </details>
 
-To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
+To view more test analytics, go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
 Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)""",
         )

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -433,7 +433,8 @@ class TestUploadTestFinisherTask(object):
 
 </details>
 
-To view individual test run time comparison to the main branch, go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)""",
+To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
+Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)""",
         )
 
     @pytest.mark.integration
@@ -719,7 +720,8 @@ To view individual test run time comparison to the main branch, go to the [Test 
 
 </details>
 
-To view individual test run time comparison to the main branch, go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)""",
+To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
+Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)""",
         )
 
         assert expected_result == result
@@ -865,7 +867,8 @@ To view individual test run time comparison to the main branch, go to the [Test 
 
 </details>
 
-To view individual test run time comparison to the main branch, go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)""",
+To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
+Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)""",
         )
 
     @pytest.mark.integration
@@ -1049,5 +1052,6 @@ To view individual test run time comparison to the main branch, go to the [Test 
 
 </details>
 
-To view individual test run time comparison to the main branch, go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)""",
+To view more test analytics go to the [Test Analytics Dashboard](https://app.codecov.io/gh/test-username/test-repo-name/tests/main)
+Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues)""",
         )


### PR DESCRIPTION
<!-- Describe your PR here. -->
Updating the PR comment as described in [#2711](https://github.com/codecov/engineering-team/issues/2711) 

<img width="620" alt="Screenshot 2024-11-06 at 10 57 07 AM" src="https://github.com/user-attachments/assets/a0f926e0-5410-4e11-8f51-50b1f4c96945">




<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.