### PR TITLE
Optimize `update_commit_from_provider_info`

### DIFF
--- a/services/repository.py
+++ b/services/repository.py
@@ -92,7 +92,7 @@ def _get_repo_provider_service_instance(service: str, adapter_params: dict):
 
 @sentry_sdk.trace
 async def fetch_appropriate_parent_for_commit(
-    repository_service, commit: Commit, git_commit=None
+    repository_service: TorngitBaseAdapter, commit: Commit, git_commit=None
 ) -> str | None:
     closest_parent_without_message = None
     db_session = commit.get_db_session()

--- a/tasks/commit_update.py
+++ b/tasks/commit_update.py
@@ -1,6 +1,5 @@
 import logging
 
-from asgiref.sync import async_to_sync
 from shared.celery_config import commit_update_task_name
 from shared.torngit.exceptions import TorngitClientError, TorngitRepoNotFoundError
 
@@ -41,7 +40,7 @@ class CommitUpdateTask(BaseCodecovTask, name=commit_update_task_name):
             repository_service = get_repo_provider_service(
                 repository, installation_name_to_use=installation_name_to_use
             )
-            was_updated = async_to_sync(possibly_update_commit_from_provider_info)(
+            was_updated = possibly_update_commit_from_provider_info(
                 commit, repository_service
             )
         except RepositoryWithoutValidBotError:

--- a/tasks/preprocess_upload.py
+++ b/tasks/preprocess_upload.py
@@ -1,7 +1,6 @@
 import logging
 from typing import Optional
 
-from asgiref.sync import async_to_sync
 from redis.exceptions import LockError
 from shared.torngit.base import TorngitBaseAdapter
 
@@ -106,7 +105,7 @@ class PreProcessUpload(BaseCodecovTask, name="app.tasks.upload.PreProcessUpload"
             }
         # Makes sure that we can properly carry forward reports
         # By populating the commit info (if needed)
-        updated_commit = async_to_sync(possibly_update_commit_from_provider_info)(
+        updated_commit = possibly_update_commit_from_provider_info(
             commit=commit, repository_service=repository_service
         )
         commit_yaml = fetch_commit_yaml_and_possibly_store(commit, repository_service)

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -954,7 +954,7 @@ class TestUploadTaskIntegration(object):
         mock_storage,
     ):
         mocked_schedule_task = mocker.patch.object(UploadTask, "schedule_task")
-        mock_possibly_update_commit_from_provider_info = mocker.patch(
+        mocker.patch(
             "tasks.upload.possibly_update_commit_from_provider_info", return_value=True
         )
         mock_create_upload = mocker.patch.object(ReportService, "create_report_upload")

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -424,7 +424,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             repository_service = get_repo_provider_service(
                 repository, installation_name_to_use=installation_name_to_use
             )
-            was_updated = async_to_sync(possibly_update_commit_from_provider_info)(
+            was_updated = possibly_update_commit_from_provider_info(
                 commit, repository_service
             )
             was_setup = self.possibly_setup_webhooks(commit, repository_service)


### PR DESCRIPTION
This makes the `possibly_` variant of this function sync, to avoid an unnecessary `async_to_sync` call.

The main function is changed in such a way that:
- It early-returns when no commit was found, de-indenting the rest of the block
- Most importantly, it moves some of the field writes around, and adds an explicit `flush` at the end. That way, it avoids splitting the `UPDATE` into two different queries, and rather does one update at the end.
- A query indirection doing a `COUNT` before the actual query is removed by just doing the filtering on the Python side
- It might avoid a second provider request for a bitbucket edgecase.

---

Part of https://github.com/codecov/engineering-team/issues/2824