### PR TITLE
fix: Cancel Stripe sub when user purchases via GHM

### DIFF
--- a/tasks/github_marketplace.py
+++ b/tasks/github_marketplace.py
@@ -187,7 +187,10 @@ class SyncPlansTask(BaseCodecovTask, name=ghm_sync_plans_task_name):
         Create or update plan from GitHub marketplace purchase info. Cancel Stripe
         subscription if owner currently has one.
         """
-        log.info("Create or update plan", extra=dict(service_id=service_id))
+        log.info(
+            "Github Marketplace - Create or update plan",
+            extra=dict(service_id=service_id),
+        )
 
         owner = (
             db_session.query(Owner)
@@ -203,8 +206,11 @@ class SyncPlansTask(BaseCodecovTask, name=ghm_sync_plans_task_name):
             owner.plan_user_count = purchase_object["unit_count"]
 
             if owner.stripe_customer_id and owner.stripe_subscription_id:
-                # cancel strip subscription
-                stripe.Subscription.delete(owner.stripe_subscription_id)
+                # cancel stripe subscription immediately
+                stripe.Subscription.cancel(
+                    owner.stripe_subscription_id,
+                    prorate=True,
+                )
                 owner.stripe_subscription_id = None
         else:
             # create the user

--- a/tasks/tests/unit/test_ghm_sync_plans.py
+++ b/tasks/tests/unit/test_ghm_sync_plans.py
@@ -88,7 +88,7 @@ class TestGHMarketplaceSyncPlansTaskUnit(object):
         dbsession.flush()
 
         stripe_mock = mocker.patch(
-            "tasks.github_marketplace.stripe.Subscription.delete"
+            "tasks.github_marketplace.stripe.Subscription.cancel"
         )
         ghm_service = mocker.MagicMock(get_user=mocker.MagicMock())
         SyncPlansTask().create_or_update_plan(
@@ -102,8 +102,8 @@ class TestGHMarketplaceSyncPlansTaskUnit(object):
         assert owner.plan_activated_users is None
         assert owner.plan_user_count == 5
 
-        # stripe subscription should be deleted but not customer id
-        stripe_mock.assert_called_with("sub_123")
+        # stripe subscription should be canceled but not customer id
+        stripe_mock.assert_called_with("sub_123", prorate=True)
         assert owner.stripe_subscription_id is None
         assert owner.stripe_customer_id == "cus_123"
 
@@ -124,7 +124,7 @@ class TestGHMarketplaceSyncPlansTaskUnit(object):
         dbsession.flush()
 
         stripe_mock = mocker.patch(
-            "tasks.github_marketplace.stripe.Subscription.delete"
+            "tasks.github_marketplace.stripe.Subscription.cancel"
         )
         ghm_service = mocker.MagicMock(get_user=mocker.MagicMock())
         SyncPlansTask().create_or_update_plan(


### PR DESCRIPTION
This PR aims to update the stripe call from a .delete() to a .cancel() when the user purchases Codecov via the Github Marketplace and already has an existing stripe subscription.

Delete doesn't actually cancel the stripe subscription, and shouldn't be called at all [looking at the Stripe documentation](https://docs.stripe.com/api#cancel_subscription)

Closes https://github.com/codecov/internal-issues/issues/1033

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.