### PR TITLE
Do not update `Commit.notified`

### DIFF
--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -437,8 +437,6 @@ class NotifyTask(BaseCodecovTask, name=notify_task_name):
                 ),
             )
             db_session.commit()
-            commit.notified = True
-            db_session.commit()
             return {"notified": True, "notifications": notifications}
         else:
             log.info(

--- a/tasks/tests/unit/test_notify_task.py
+++ b/tasks/tests/unit/test_notify_task.py
@@ -616,9 +616,6 @@ class TestNotifyTask(object):
         assert result["notifications"][0] == expected_result["notifications"][0]
         assert result["notifications"] == expected_result["notifications"]
         assert result == expected_result
-        dbsession.flush()
-        dbsession.refresh(commit)
-        assert commit.notified is True
 
         calls = [
             call(
@@ -667,9 +664,6 @@ class TestNotifyTask(object):
             "notified": True,
             "notifications": mocked_submit_third_party_notifications.return_value,
         }
-        dbsession.flush()
-        dbsession.refresh(commit)
-        assert commit.notified is True
 
     def test_simple_call_should_delay(
         self, dbsession, mocker, mock_storage, mock_configuration

--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -126,7 +126,6 @@ class TestUploadFinisherTask(object):
             commit_yaml={},
             **kwargs,
         )
-        assert commit.notified is False
         expected_result = {"notifications_called": True}
         assert expected_result == result
         dbsession.refresh(commit)

--- a/tasks/tests/unit/test_upload_finisher_task.py
+++ b/tasks/tests/unit/test_upload_finisher_task.py
@@ -6,16 +6,19 @@ import pytest
 from celery.exceptions import Retry
 from redis.exceptions import LockError
 from shared.celery_config import timeseries_save_commit_measurements_task_name
+from shared.torngit.exceptions import TorngitObjectNotFoundError
 from shared.yaml import UserYaml
 
 from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
 from helpers.checkpoint_logger import CheckpointLogger, _kwargs_key
 from helpers.checkpoint_logger.flows import UploadFlow
+from helpers.exceptions import RepositoryWithoutValidBotError
 from tasks.upload_finisher import (
     ReportService,
     ShouldCallNotifyResult,
     UploadFinisherTask,
     get_processing_results,
+    load_commit_diff,
 )
 
 here = Path(__file__)
@@ -72,6 +75,29 @@ def test_results_arg_new():
     assert results == [
         {"upload_id": 123, "arguments": {"foo": "bar"}, "successful": True}
     ]
+
+
+def test_load_commit_diff_no_diff(mock_configuration, dbsession, mock_repo_provider):
+    commit = CommitFactory.create()
+    dbsession.add(commit)
+    dbsession.flush()
+    mock_repo_provider.get_commit_diff.side_effect = TorngitObjectNotFoundError(
+        "response", "message"
+    )
+    diff = load_commit_diff(commit)
+    assert diff is None
+
+
+def test_load_commit_diff_no_bot(mocker, mock_configuration, dbsession):
+    commit = CommitFactory.create()
+    dbsession.add(commit)
+    dbsession.flush()
+    mock_get_repo_service = mocker.patch(
+        "tasks.upload_finisher.get_repo_provider_service"
+    )
+    mock_get_repo_service.side_effect = RepositoryWithoutValidBotError()
+    diff = load_commit_diff(commit)
+    assert diff is None
 
 
 class TestUploadFinisherTask(object):

--- a/tasks/tests/utils.py
+++ b/tasks/tests/utils.py
@@ -33,11 +33,11 @@ def hook_session(mocker, dbsession: Session):
 
 
 GLOBALS_USING_REPO_PROVIDER = [
+    "services.comparison.get_repo_provider_service",
     "services.report.get_repo_provider_service",
     "tasks.notify.get_repo_provider_service",
-    "tasks.upload_processor.get_repo_provider_service",
+    "tasks.upload_finisher.get_repo_provider_service",
     "tasks.upload.get_repo_provider_service",
-    "services.comparison.get_repo_provider_service",
 ]
 
 

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 
 import sentry_sdk
+from asgiref.sync import async_to_sync
 from redis.exceptions import LockError
 from redis.lock import Lock
 from shared.celery_config import (
@@ -15,14 +16,21 @@ from shared.celery_config import (
     upload_finisher_task_name,
 )
 from shared.reports.resources import Report
+from shared.torngit.exceptions import TorngitError
 from shared.yaml import UserYaml
 
 from app import celery_app
 from celery_config import notify_error_task_name
+from database.enums import CommitErrorTypes
 from database.models import Commit, Pull
+from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME
+from helpers.cache import cache
 from helpers.checkpoint_logger import _kwargs_key
 from helpers.checkpoint_logger import from_kwargs as checkpoints_from_kwargs
 from helpers.checkpoint_logger.flows import UploadFlow
+from helpers.exceptions import RepositoryWithoutValidBotError
+from helpers.github_installation import get_installation_name_for_owner_for_task
+from helpers.save_commit_error import save_commit_error
 from services.archive import ArchiveService
 from services.comparison import get_or_create_comparison
 from services.processing.intermediate import (
@@ -35,15 +43,11 @@ from services.processing.state import ProcessingState, should_trigger_postproces
 from services.processing.types import ProcessingResult
 from services.redis import get_redis_connection
 from services.report import ReportService
+from services.repository import get_repo_provider_service
 from services.yaml import read_yaml_field
 from tasks.base import BaseCodecovTask
 from tasks.upload_clean_labels_index import task_name as clean_labels_index_task_name
-from tasks.upload_processor import (
-    MAX_RETRIES,
-    UPLOAD_PROCESSING_LOCK_NAME,
-    load_commit_diff,
-    save_report_results,
-)
+from tasks.upload_processor import MAX_RETRIES, UPLOAD_PROCESSING_LOCK_NAME
 
 log = logging.getLogger(__name__)
 
@@ -110,8 +114,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
 
         processing_results = get_processing_results(processing_results)
         upload_ids = [upload["upload_id"] for upload in processing_results]
-        pr = processing_results[0]["arguments"].get("pr")
-        diff = load_commit_diff(commit, pr, self.name)
+        diff = load_commit_diff(commit, self.name)
 
         try:
             with get_report_lock(repoid, commitid, self.hard_time_limit_task):
@@ -128,17 +131,14 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
 
                 log.info(
                     "Saving combined report",
-                    extra=dict(
-                        repoid=repoid,
-                        commit=commitid,
-                        processing_results=processing_results,
-                        parent_task=self.request.parent_id,
-                    ),
+                    extra=dict(processing_results=processing_results),
                 )
 
-                save_report_results(
-                    report_service, commit, report, diff, pr, report_code
-                )
+                if diff:
+                    report.apply_diff(diff)
+                report_service.save_report(commit, report, report_code)
+
+                db_session.commit()
                 state.mark_uploads_as_merged(upload_ids)
 
         except LockError:
@@ -487,3 +487,43 @@ def get_processing_results(processing_results: list) -> list[ProcessingResult]:
             results.append(input_result)
 
     return results
+
+
+@sentry_sdk.trace
+@cache.cache_function(ttl=60 * 60)  # the commit diff is immutable
+def load_commit_diff(commit: Commit, task_name: str | None = None) -> dict | None:
+    repository = commit.repository
+    commitid = commit.commitid
+    try:
+        installation_name_to_use = (
+            get_installation_name_for_owner_for_task(task_name, repository.owner)
+            if task_name
+            else GITHUB_APP_INSTALLATION_DEFAULT_NAME
+        )
+        repository_service = get_repo_provider_service(
+            repository, installation_name_to_use=installation_name_to_use
+        )
+        return async_to_sync(repository_service.get_commit_diff)(commitid)
+
+    # TODO(swatinem): can we maybe get rid of all this logging?
+    except TorngitError:
+        # When this happens, we have that commit.totals["diff"] is not available.
+        # Since there is no way to calculate such diff without the git commit,
+        # then we assume having the rest of the report saved there is better than the
+        # alternative of refusing an otherwise "good" report because of the lack of diff
+        log.warning(
+            "Could not apply diff to report because there was an error fetching diff from provider",
+            exc_info=True,
+        )
+    except RepositoryWithoutValidBotError:
+        save_commit_error(
+            commit,
+            error_code=CommitErrorTypes.REPO_BOT_INVALID.value,
+        )
+
+        log.warning(
+            "Could not apply diff to report because there is no valid bot found for that repo",
+            exc_info=True,
+        )
+
+    return None

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -171,8 +171,6 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
         try:
             with redis_connection.lock(lock_name, timeout=60 * 5, blocking_timeout=5):
                 commit_yaml = UserYaml(commit_yaml)
-                commit.notified = False
-                db_session.commit()
                 result = self.finish_reports_processing(
                     db_session,
                     commit,

--- a/tasks/upload_processor.py
+++ b/tasks/upload_processor.py
@@ -1,24 +1,13 @@
 import logging
 
-import sentry_sdk
-from asgiref.sync import async_to_sync
 from shared.celery_config import upload_processor_task_name
 from shared.config import get_config
-from shared.torngit.exceptions import TorngitError
 from shared.yaml import UserYaml
 from sqlalchemy.orm import Session as DbSession
 
 from app import celery_app
-from database.enums import CommitErrorTypes
-from database.models import Commit
-from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME, Pull
-from helpers.cache import cache
-from helpers.exceptions import RepositoryWithoutValidBotError
-from helpers.github_installation import get_installation_name_for_owner_for_task
-from helpers.save_commit_error import save_commit_error
 from services.processing.processing import UploadArguments, process_upload
-from services.report import ProcessingError, Report, ReportService
-from services.repository import get_repo_provider_service
+from services.report import ProcessingError
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
@@ -97,93 +86,3 @@ class UploadProcessorTask(BaseCodecovTask, name=upload_processor_task_name):
 
 RegisteredUploadTask = celery_app.register_task(UploadProcessorTask())
 upload_processor_task = celery_app.tasks[RegisteredUploadTask.name]
-
-
-@sentry_sdk.trace
-@cache.cache_function(ttl=60 * 60)  # the commit diff is immutable
-def load_commit_diff(
-    commit: Commit, pr: Pull | None, task_name: str | None
-) -> dict | None:
-    repository = commit.repository
-    commitid = commit.commitid
-    try:
-        installation_name_to_use = (
-            get_installation_name_for_owner_for_task(task_name, repository.owner)
-            if task_name
-            else GITHUB_APP_INSTALLATION_DEFAULT_NAME
-        )
-        repository_service = get_repo_provider_service(
-            repository, installation_name_to_use=installation_name_to_use
-        )
-        return async_to_sync(repository_service.get_commit_diff)(commitid)
-
-    # TODO: can we maybe get rid of all this logging?
-    except TorngitError:
-        # When this happens, we have that commit.totals["diff"] is not available.
-        # Since there is no way to calculate such diff without the git commit,
-        # then we assume having the rest of the report saved there is better than the
-        # alternative of refusing an otherwise "good" report because of the lack of diff
-        log.warning(
-            "Could not apply diff to report because there was an error fetching diff from provider",
-            extra=dict(
-                repoid=commit.repoid,
-                commit=commit.commitid,
-            ),
-            exc_info=True,
-        )
-    except RepositoryWithoutValidBotError:
-        save_commit_error(
-            commit,
-            error_code=CommitErrorTypes.REPO_BOT_INVALID.value,
-            error_params=dict(
-                repoid=commit.repoid,
-                pr=pr,
-            ),
-        )
-
-        log.warning(
-            "Could not apply diff to report because there is no valid bot found for that repo",
-            extra=dict(
-                repoid=commit.repoid,
-                commit=commit.commitid,
-            ),
-            exc_info=True,
-        )
-
-    return None
-
-
-@sentry_sdk.trace
-def save_report_results(
-    report_service: ReportService,
-    commit: Commit,
-    report: Report,
-    diff: dict | None,
-    # TODO: maybe remove this parameter, as its only used to update `commit`:
-    pr: Pull | None,
-    report_code=None,
-):
-    """Saves the result of `report` to the commit database and chunks archive
-
-    This method only takes care of getting a processed Report to the database and archive.
-
-    It also tries to calculate the diff of the report (which uses commit info
-        from th git provider), but it it fails to do so, it just moves on without such diff
-    """
-    log.debug("In save_report_results for commit: %s" % commit)
-
-    if diff:
-        report.apply_diff(diff)
-
-    if pr is not None:
-        try:
-            commit.pullid = int(pr)
-        except (ValueError, TypeError):
-            log.warning(
-                "Cannot set PR value on commit",
-                extra=dict(repoid=commit.repoid, commit=commit.commitid, pr_value=pr),
-            )
-
-    res = report_service.save_report(commit, report, report_code)
-    commit.get_db_session().commit()
-    return res


### PR DESCRIPTION
This field is constantly being updated/touched in both `UploadFinisher` and `Notify`.

But I couldn’t find any piece of code that actually reads this field across the whole codebase.

---

Moves and debounces the update to `Repository.updatestamp`, fixes https://github.com/codecov/internal-issues/issues/1043

---

Stops setting `Commit.pullid` in `UploadFinisher`.

This already happens as part of `{PreProcess,}Upload`, so it is not needed to set this field once again.

This also cleans up the code quite a bit.

---

Part of https://github.com/codecov/engineering-team/issues/2824