### PR TITLE
Account for `Repository.updatestamp` being nullable

### DIFF
--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -182,7 +182,7 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                 # of recently-active repositories
                 now = datetime.now(tz=timezone.utc)
                 threshold = now - timedelta(minutes=30)
-                if repository.updatestamp < threshold:
+                if not repository.updatestamp or repository.updatestamp < threshold:
                     repository.updatestamp = now
                     db_session.commit()
 


### PR DESCRIPTION
Fixes [WORKER-Q11](https://codecov.sentry.io/issues/6051507644/) which is a recent regression.