### PR TITLE
Optimize Report merging

### DIFF
--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -108,7 +108,17 @@ def process_raw_upload(
             r.filename = current_filename
             raise
 
-        if report_from_file:
+        if not report_from_file:
+            continue
+        if report.is_empty():
+            # if the initial report is empty, we can avoid a costly merge operation
+            report = report_from_file
+        else:
+            # merging the smaller report into the larger one is faster,
+            # so swap the two reports in that case.
+            if len(report_from_file._files) > len(report._files):
+                report_from_file, report = report, report_from_file
+
             report.merge(report_from_file, joined=True)
 
     if not report:

--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -66,9 +66,8 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
 
         # At this point we can calculate the patch coverage
         # Because we have a HEAD report and a base commit to get the diff from
-        if comparison.patch_totals is None:
-            patch_totals = comparison_proxy.get_patch_totals()
-            comparison.patch_totals = minimal_totals(patch_totals)
+        patch_totals = comparison_proxy.get_patch_totals()
+        comparison.patch_totals = minimal_totals(patch_totals)
 
         if not comparison_proxy.has_project_coverage_base_report():
             comparison.error = CompareCommitError.missing_base_report.value

--- a/tasks/tests/integration/test_upload_e2e.py
+++ b/tasks/tests/integration/test_upload_e2e.py
@@ -238,6 +238,14 @@ end_of_record
         f"UPDATE reports_upload SET id={upload_id} WHERE id={first_upload.id}"
     )
 
+    with run_tasks():
+        upload_task.apply_async(
+            kwargs={
+                "repoid": repoid,
+                "commitid": commitid,
+            }
+        )
+
     do_upload(
         b"""
 a.rs

--- a/tasks/tests/integration/test_upload_e2e.py
+++ b/tasks/tests/integration/test_upload_e2e.py
@@ -141,9 +141,14 @@ def setup_mocks(
         "tasks.upload.fetch_commit_yaml_and_possibly_store",
         return_value=UserYaml(user_yaml or {}),
     )
+    mocker.patch(
+        "tasks.compute_comparison.get_current_yaml",
+        return_value=UserYaml(user_yaml or {}),
+    )
     # disable all the tasks being emitted from `UploadFinisher`.
     # ideally, we would really want to test their outcomes as well.
     mocker.patch("tasks.notify.NotifyTask.run_impl")
+    mocker.patch("tasks.sync_pull.PullSyncTask.run_impl")
     mocker.patch("tasks.save_commit_measurements.SaveCommitMeasurementsTask.run_impl")
 
     # force `report_json` to be written out to storage

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -423,7 +423,9 @@ def perform_report_merging(
         archive_service, commit.commitid, upload_ids, intermediate_reports_in_redis
     )
 
-    merge_result = merge_reports(commit_yaml, master_report, intermediate_reports)
+    master_report, merge_result = merge_reports(
+        commit_yaml, master_report, intermediate_reports
+    )
 
     # Update the `Upload` in the database with the final session_id
     # (aka `order_number`) and other statuses


### PR DESCRIPTION
This change tries to optimize the slow `Report.merge` operation.

When merging report `B` into an existing report `A`, we can just use `B` in case `A` is empty. Also, the speed of merging depends on the size of the right hand size Report (`B` in this example). By swapping the reports, we can make sure to always merge the smaller Report into the larger one.