### PR TITLE
fix: cache tasks args

### DIFF
--- a/tasks/cache_test_rollups.py
+++ b/tasks/cache_test_rollups.py
@@ -90,7 +90,7 @@ left join flags_cte using (test_id)
 
 
 class CacheTestRollupsTask(BaseCodecovTask, name=cache_test_rollups_task_name):
-    def run_impl(self, *, repoid, branch, **kwargs):
+    def run_impl(self, _db_session, repoid: int, branch: str, **kwargs):
         redis_conn = get_redis_connection()
         try:
             with redis_conn.lock(

--- a/tasks/cache_test_rollups_redis.py
+++ b/tasks/cache_test_rollups_redis.py
@@ -13,7 +13,9 @@ from tasks.base import BaseCodecovTask
 class CacheTestRollupsRedisTask(
     BaseCodecovTask, name=cache_test_rollups_redis_task_name
 ):
-    def run_impl(self, *, repoid: int, branch: str, **kwargs) -> dict[str, bool]:
+    def run_impl(
+        self, _db_session, repoid: int, branch: str, **kwargs
+    ) -> dict[str, bool]:
         redis_conn = get_redis_connection()
         try:
             with redis_conn.lock(


### PR DESCRIPTION
this fixes an error where the cache tasks only expect one arg instead of all the actual args