### PR TITLE
fix: cache rollup task serialization

### DIFF
--- a/tasks/cache_test_rollups.py
+++ b/tasks/cache_test_rollups.py
@@ -156,6 +156,7 @@ class CacheTestRollupsTask(BaseCodecovTask, name=cache_test_rollups_task_name):
                 )
 
                 serialized_table = df.write_ipc(None)
+                serialized_table.seek(0)  # avoids Stream must be at beginning errors
 
                 storage_service.write_file("codecov", storage_key, serialized_table)
 


### PR DESCRIPTION
there's an error where the cursor of the serialized table BytesIO is not at the start which causes it to fail writing to GCP, this fixes that
