### PR TITLE
Fix `joined=False` functionality

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -644,9 +644,7 @@ class ReportService(BaseReportService):
 
         log.debug("Retrieved report for processing from url %s", archive_url)
         try:
-            result.report = process_raw_upload(
-                self.current_yaml, raw_report, flags, session
-            )
+            result.report = process_raw_upload(self.current_yaml, raw_report, session)
 
             log.info(
                 "Successfully processed report",

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -517,8 +517,8 @@ class TestUploadProcessorTask(object):
         mocked_1 = mocker.patch.object(ArchiveService, "read_chunks")
         mocked_1.return_value = None
         mocked_2 = mocker.patch("services.report.process_raw_upload")
-        mocker.patch.object(ArchiveService, "read_file", return_value=b"")
         mocked_2.side_effect = [ReportEmptyError(), ReportExpiredException()]
+        mocker.patch.object(ArchiveService, "read_file", return_value=b"")
         # Mocking retry to also raise the exception so we can see how it is called
         mocker.patch.object(UploadProcessorTask, "app", celery_app)
         commit = CommitFactory.create(


### PR DESCRIPTION
This functionality was temporarily broken due to parallel processing, and this restores that functionality.

Additionally, this also logs any time this flag is triggered to Sentry to assist in figuring out who is actually using this.