### PR TITLE
Optimize repeated path-fixing and calls to `supports_labels`

### DIFF
--- a/services/path_fixer/__init__.py
+++ b/services/path_fixer/__init__.py
@@ -119,6 +119,7 @@ class PathFixer(object):
 
 class BasePathAwarePathFixer(PathFixer):
     def __init__(self, original_path_fixer, base_path) -> None:
+        self._resolved_paths: dict[tuple[str, list[str]], str | None] = {}
         self.original_path_fixer = original_path_fixer
 
         # base_path argument is the file path after the "# path=" in the report containing report location, if provided.
@@ -126,7 +127,7 @@ class BasePathAwarePathFixer(PathFixer):
         # e.g.: "path/to/coverage.xml" --> "path/to/"
         self.base_path = [PurePath(base_path).parent] if base_path is not None else []
 
-    def __call__(self, path: str, bases_to_try: list[str] | None = None) -> str | None:
+    def _try_fix_path(self, path: str, bases_to_try: list[str]) -> str | None:
         original_path_fixer_result = self.original_path_fixer(path)
         if (
             original_path_fixer_result is not None
@@ -136,9 +137,10 @@ class BasePathAwarePathFixer(PathFixer):
             return original_path_fixer_result
 
         if not os.path.isabs(path):
-            all_base_paths_to_try = self.base_path + (
-                bases_to_try if bases_to_try is not None else []
+            all_base_paths_to_try = (
+                self.base_path + bases_to_try if bases_to_try else self.base_path
             )
+
             for base_path in all_base_paths_to_try:
                 adjusted_path = os.path.join(base_path, path)
                 base_path_aware_result = self.original_path_fixer(adjusted_path)
@@ -146,3 +148,12 @@ class BasePathAwarePathFixer(PathFixer):
                     return base_path_aware_result
 
         return original_path_fixer_result
+
+    def __call__(self, path: str, bases_to_try: list[str] | None = None) -> str | None:
+        bases_to_try = bases_to_try or []
+        key = (path, bases_to_try)
+
+        if key not in self._resolved_paths:
+            self._resolved_paths[key] = self._try_fix_path(path, bases_to_try)
+
+        return self._resolved_paths[key]

--- a/services/path_fixer/tests/unit/test_path_fixer.py
+++ b/services/path_fixer/tests/unit/test_path_fixer.py
@@ -124,7 +124,7 @@ class TestBasePathAwarePathFixer(object):
         assert pf("__init__.py") is None
         assert base_aware_pf("__init__.py") is None
         assert (
-            base_aware_pf("__init__.py", bases_to_try=["/home/travis/build/project"])
+            base_aware_pf("__init__.py", bases_to_try=("/home/travis/build/project",))
             == "project/__init__.py"
         )
 
@@ -136,7 +136,7 @@ def test_ambiguous_paths():
     ]
     base_path = "/home/runner/work/owner/repo/foobar/build/coverage/coverage.xml"
     #                                         ~~~~~~
-    bases_to_try = ["/app"]
+    bases_to_try = ("/app",)
     # The problem here is that the given `file_name` is ambiguous, and neither the
     # `base_path` nor the `bases_to_try` is helping us narrow this down.
     # The `base_path` does include one of the relevant parent directories,

--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -1,6 +1,6 @@
 import logging
 import re
-from typing import List
+from typing import Sequence
 from xml.etree.ElementTree import Element
 
 import sentry_sdk
@@ -31,9 +31,9 @@ def Int(value):
         return int(float(value))
 
 
-def get_sources_to_attempt(xml) -> List[str]:
-    sources = [source.text for source in xml.iter("source")]
-    return [s for s in sources if isinstance(s, str) and s.startswith("/")]
+def get_sources_to_attempt(xml) -> Sequence[str]:
+    sources = (source.text for source in xml.iter("source"))
+    return tuple(s for s in sources if isinstance(s, str) and s.startswith("/"))
 
 
 def from_xml(xml: Element, report_builder_session: ReportBuilderSession) -> None:

--- a/services/report/languages/helpers.py
+++ b/services/report/languages/helpers.py
@@ -5,7 +5,7 @@ from xml.etree.ElementTree import Element
 def remove_non_ascii(string: str) -> str:
     # ASCII control characters <=31, 127
     # Extended ASCII characters: >=128
-    return "".join([c if 31 < ord(c) < 127 else "" for c in string])
+    return "".join(c if 31 < ord(c) < 127 else "" for c in string)
 
 
 def child_text(parent: Element, element: str) -> str:

--- a/services/report/report_builder.py
+++ b/services/report/report_builder.py
@@ -190,7 +190,7 @@ class ReportBuilderSession(object):
                 for label_ids in (labels_list_of_lists or [])
                 if label_ids
             ]
-            if self._report_builder.supports_labels()
+            if self._report_builder._supports_labels
             else None
         )
         return ReportLine.create(
@@ -224,6 +224,7 @@ class ReportBuilder(object):
         self.sessionid = sessionid
         self.ignored_lines = ignored_lines
         self.path_fixer = path_fixer
+        self._supports_labels = self.supports_labels()
 
     def create_report_builder_session(self, filepath) -> ReportBuilderSession:
         return ReportBuilderSession(self, filepath)


### PR DESCRIPTION
Calls to the PathFixer are very hot in report processing. I have the suspicion that some formats might call the path fixer multiple times for the same file. So it might be beneficial to go through a small cache in that case.

Previously, each call to `create_coverage_line` would call `supports_labels` which goes through all of the flags in the yaml config. As this result never changes, this will now cache the result for the whole processor.