### PR TITLE
fix: polars schema inference issue

### DIFF
--- a/tasks/cache_test_rollups.py
+++ b/tasks/cache_test_rollups.py
@@ -134,7 +134,7 @@ class CacheTestRollupsTask(BaseCodecovTask, name=cache_test_rollups_task_name):
                     [
                         "name",
                         "testsuite",
-                        "flags",
+                        ("flags", pl.List(pl.String)),
                         "test_id",
                         "failure_rate",
                         "flake_rate",


### PR DESCRIPTION
polars is having trouble inferring the schema for flags, i'm guessing that it's because at the start of the data that we're reading from, there's a bunch of null values for the flags, so i'm manually making it so the schema expects a list of strings