### PR TITLE
fix: Update bucket name for TA Stage result storage

### DIFF
--- a/django_scaffold/settings.py
+++ b/django_scaffold/settings.py
@@ -14,7 +14,7 @@ if "timeseries" in DATABASES:
 
 IS_DEV = os.getenv("RUN_ENV") == "DEV"
 
-GCS_BUCKET_NAME = get_config("services", "minio", "bucket")
+GCS_BUCKET_NAME = get_config("services", "minio", "bucket", default="codecov")
 
 # Application definition
 INSTALLED_APPS = [

--- a/django_scaffold/settings.py
+++ b/django_scaffold/settings.py
@@ -14,6 +14,8 @@ if "timeseries" in DATABASES:
 
 IS_DEV = os.getenv("RUN_ENV") == "DEV"
 
+GCS_BUCKET_NAME = get_config("services", "minio", "bucket")
+
 # Application definition
 INSTALLED_APPS = [
     "shared.django_apps.legacy_migrations",

--- a/tasks/cache_test_rollups.py
+++ b/tasks/cache_test_rollups.py
@@ -7,6 +7,7 @@ from shared.celery_config import cache_test_rollups_task_name
 from shared.config import get_config
 
 from app import celery_app
+from django_scaffold import settings
 from services.redis import get_redis_connection
 from services.storage import get_storage_client
 from tasks.base import BaseCodecovTask
@@ -164,7 +165,9 @@ class CacheTestRollupsTask(BaseCodecovTask, name=cache_test_rollups_task_name):
                 serialized_table = df.write_ipc(None)
                 serialized_table.seek(0)  # avoids Stream must be at beginning errors
 
-                storage_service.write_file("codecov", storage_key, serialized_table)
+                storage_service.write_file(
+                    settings.GCS_BUCKET_NAME, storage_key, serialized_table
+                )
 
         return
 

--- a/tasks/cache_test_rollups_redis.py
+++ b/tasks/cache_test_rollups_redis.py
@@ -5,6 +5,7 @@ from shared.celery_config import cache_test_rollups_redis_task_name
 from shared.storage.exceptions import FileNotInStorageError
 
 from app import celery_app
+from django_scaffold import settings
 from services.redis import get_redis_connection
 from services.storage import get_storage_client
 from tasks.base import BaseCodecovTask
@@ -44,7 +45,9 @@ class CacheTestRollupsRedisTask(
                 else f"test_results/rollups/{repoid}/{branch}/{interval_start}_{interval_end}"
             )
             try:
-                file: bytes = storage_service.read_file("codecov", storage_key)
+                file: bytes = storage_service.read_file(
+                    settings.GCS_BUCKET_NAME, storage_key
+                )
             except FileNotInStorageError:
                 pass
 


### PR DESCRIPTION
This PR updates the Test Result bucket for stage env to use the env variable, which should be codecov by default and codecov-staging on stage


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.