### PR TITLE
Fix notifiers assuming a `Report` exists

### DIFF
--- a/services/comparison/types.py
+++ b/services/comparison/types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Optional, TypedDict
 
-from shared.reports.resources import Report
+from shared.reports.readonly import ReadOnlyReport
 from shared.yaml import UserYaml
 
 from database.models import Commit
@@ -11,7 +11,7 @@ from services.repository import EnrichedPull
 @dataclass
 class FullCommit(object):
     commit: Commit
-    report: Report
+    report: ReadOnlyReport
 
 
 class ReportUploadedCount(TypedDict):
@@ -38,6 +38,11 @@ class Comparison(object):
 
     enriched_pull: EnrichedPull
     current_yaml: Optional[UserYaml] = None
+
+    # FIXME: The functions down below do not make sense given that we assume
+    # a `FullCommit` and its `report` to always exist.
+    # Similarly, we also expect an `EnrichedPull` to exist, which does not match
+    # the reality.
 
     def has_project_coverage_base_report(self):
         return bool(

--- a/services/notification/notifiers/codecov_slack_app.py
+++ b/services/notification/notifiers/codecov_slack_app.py
@@ -59,13 +59,12 @@ class CodecovSlackAppNotifier(AbstractBaseNotifier):
         head_full_commit = comparison.head
         base_full_commit = comparison.project_coverage_base
         if comparison.has_project_coverage_base_report():
-            difference = None
-            head_report_coverage = head_full_commit.report.totals.coverage
-            base_report_coverage = base_full_commit.report.totals.coverage
-            if head_report_coverage is not None and base_report_coverage is not None:
-                difference = Decimal(head_full_commit.report.totals.coverage) - Decimal(
-                    base_full_commit.report.totals.coverage
-                )
+            difference = Decimal(0)
+            head_coverage = head_full_commit.report.totals.coverage
+            base_coverage = base_full_commit.report.totals.coverage
+            if head_coverage is not None and base_coverage is not None:
+                difference = Decimal(head_coverage) - Decimal(base_coverage)
+
             message = (
                 "no change"
                 if difference == 0

--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -341,6 +341,7 @@ class StatusNotifier(AbstractBaseNotifier):
 
         try:
             _set_commit_status = async_to_sync(repository_service.set_commit_status)
+            head_coverage = head_report and head_report.totals.coverage
             all_results = [
                 _set_commit_status(
                     commitid,
@@ -348,7 +349,7 @@ class StatusNotifier(AbstractBaseNotifier):
                     title,
                     description=message,
                     url=url,
-                    coverage=(float(head_report.totals.coverage) if head_report else 0),
+                    coverage=(float(head_coverage) if head_coverage else 0),
                 )
                 for commitid in all_shas_to_notify
             ]

--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -307,11 +307,11 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
         return ComparisonProxy(
             Comparison(
                 head=FullCommit(commit=compare_commit, report=compare_report),
-                enriched_pull=None,
                 project_coverage_base=FullCommit(
                     commit=base_commit, report=base_report
                 ),
                 patch_coverage_base_commitid=patch_coverage_base_commitid,
+                enriched_pull=None,
             ),
             context=ComparisonContext(
                 gh_app_installation_name=installation_name_to_use

--- a/tasks/save_report_results.py
+++ b/tasks/save_report_results.py
@@ -69,11 +69,11 @@ class SaveReportResultsTask(
         comparison = ComparisonProxy(
             Comparison(
                 head=FullCommit(commit=commit, report=head_report),
-                enriched_pull=enriched_pull,
                 project_coverage_base=FullCommit(
                     commit=base_commit, report=base_report
                 ),
                 patch_coverage_base_commitid=patch_coverage_base_commitid,
+                enriched_pull=enriched_pull,
             ),
             ComparisonContext(repository_service=repository_service),
         )

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -2,7 +2,7 @@ from decimal import Decimal
 from unittest.mock import patch
 
 import pytest
-from mock import AsyncMock, PropertyMock
+from mock import ANY, AsyncMock, PropertyMock
 from shared.validation.types import CoverageCommentRequiredChanges
 
 from database.models import Pull
@@ -87,7 +87,8 @@ class TestNotifyTask(object):
         result = task.run_impl(
             dbsession, repoid=commit.repoid, commitid=commit.commitid, current_yaml={}
         )
-        expected_result = {
+
+        assert result == {
             "notified": True,
             "notifications": [
                 {
@@ -101,9 +102,9 @@ class TestNotifyTask(object):
                             "repository": "example-python",
                             "owner": "ThiagoCodecov",
                             "comparison": {
-                                "url": None,
-                                "message": "unknown",
-                                "coverage": None,
+                                "url": ANY,
+                                "message": "no change",
+                                "coverage": "0.00",
                                 "notation": "",
                                 "head_commit": {
                                     "commitid": "649eaaf2924e92dc7fd8d370ddb857033231e67a",
@@ -152,7 +153,6 @@ class TestNotifyTask(object):
                 }
             ],
         }
-        assert result == expected_result
 
     @patch("requests.post")
     def test_simple_call_only_status_notifiers(


### PR DESCRIPTION
The various Notifier classes assume that a `Report` always exists, which was not the case previously, and they would fail in various ways due to `report` being `None`.

Instead of actually fixing all of the usages deep within the notifier code, this just makes sure that an (empty) `Report` indeed exists.

This is suboptimal, as we should really fix the wrong assumptions in the code. However doing so would be quite some work, and this seems like a quicker quickfix.

---

fixes [WORKER-5ZB](https://codecov.sentry.io/issues/4370613101/)
fixes [WORKER-PNW](https://codecov.sentry.io/issues/6017331725/)
should help with https://github.com/codecov/engineering-team/issues/2365