### PR TITLE
feat: add formatting to code blocks in PR comment

### DIFF
--- a/services/test_results.py
+++ b/services/test_results.py
@@ -162,14 +162,14 @@ def properly_backtick(content: str) -> str:
             max_backtick_count = curr_backtick_count
 
     backticks = "`" * (max_backtick_count + 1)
-    return f"{backticks}\n{content}\n{backticks}"
+    return f"{backticks}python\n{content}\n{backticks}"
 
 
 def wrap_in_code(content: str) -> str:
     if "```" in content:
         return properly_backtick(content)
     else:
-        return f"\n```\n{content}\n```\n"
+        return f"\n```python\n{content}\n```\n"
 
 
 def display_duration(f: float) -> str:

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -86,7 +86,7 @@ def test_generate_failure_info():
     assert (
         res
         == """
-```
+```python
 hello world
 ```
 
@@ -119,14 +119,14 @@ def test_build_message():
 <details><summary>View the top 1 failed tests by shortest run time</summary>
 
 > 
-> ```
+> ```python
 > testname
 > ```
 > 
 > <details><summary>Stack Traces | 1s run time</summary>
 > 
 > > 
-> > ```
+> > ```python
 > > hello world
 > > ```
 > > 
@@ -169,7 +169,7 @@ def test_build_message_with_flake():
 <details><summary>View the full list of 1 :snowflake: flaky tests</summary>
 
 > 
-> ```
+> ```python
 > testname
 > ```
 > 
@@ -177,7 +177,7 @@ def test_build_message_with_flake():
 > <details><summary>Stack Traces | 1s run time</summary>
 > 
 > > 
-> > ```
+> > ```python
 > > hello world
 > > ```
 > > 

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -381,13 +381,13 @@ class TestUploadTestFinisherTask(object):
 <details><summary>View the top 3 failed tests by shortest run time</summary>
 
 > 
-> ```
+> ```python
 > test_name1
 > ```
 > 
 > <details><summary>Stack Traces | 2s run time</summary>
 > 
-> > `````````
+> > `````````python
 > > Shared 
 > > 
 > > 
@@ -403,13 +403,13 @@ class TestUploadTestFinisherTask(object):
 
 
 > 
-> ```
+> ```python
 > Other Class Name test_name2
 > ```
 > 
 > <details><summary>Stack Traces | 3s run time</summary>
 > 
-> > `````````
+> > `````````python
 > > Shared 
 > > 
 > > 
@@ -426,14 +426,14 @@ class TestUploadTestFinisherTask(object):
 
 
 > 
-> ```
+> ```python
 > Class Name test_name0
 > ```
 > 
 > <details><summary>Stack Traces | 4s run time</summary>
 > 
 > > 
-> > ```
+> > ```python
 > > <pre>Fourth 
 > > 
 > > </pre> | test  | instance |
@@ -708,13 +708,13 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 <details><summary>View the top 3 failed tests by shortest run time</summary>
 
 > 
-> ```
+> ```python
 > test_name1
 > ```
 > 
 > <details><summary>Stack Traces | 2s run time</summary>
 > 
-> > `````````
+> > `````````python
 > > Shared 
 > > 
 > > 
@@ -730,13 +730,13 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 
 
 > 
-> ```
+> ```python
 > Other Class Name test_name2
 > ```
 > 
 > <details><summary>Stack Traces | 3s run time</summary>
 > 
-> > `````````
+> > `````````python
 > > Shared 
 > > 
 > > 
@@ -753,14 +753,14 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 
 
 > 
-> ```
+> ```python
 > Class Name test_name0
 > ```
 > 
 > <details><summary>Stack Traces | 4s run time</summary>
 > 
 > > 
-> > ```
+> > ```python
 > > <pre>Fourth 
 > > 
 > > </pre> | test  | instance |
@@ -916,13 +916,13 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 <details><summary>{"View the top 1 failed tests by shortest run time" if (count - fail_count) == recent_passes_count else "View the full list of 1 :snowflake: flaky tests"}</summary>
 
 > 
-> ```
+> ```python
 > Other Class Name test_name2
 > ```
 > {f"\n> **Flake rate in main:** 33.33% (Passed {count - fail_count} times, Failed {fail_count} times)" if (count - fail_count) != recent_passes_count else ""}
 > <details><summary>Stack Traces | 3s run time</summary>
 > 
-> > `````````
+> > `````````python
 > > Shared 
 > > 
 > > 
@@ -1069,13 +1069,13 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 <details><summary>View the top 3 failed tests by shortest run time</summary>
 
 > 
-> ```
+> ```python
 > hello_test_name1
 > ```
 > 
 > <details><summary>Stack Traces | 2s run time</summary>
 > 
-> > `````````
+> > `````````python
 > > Shared 
 > > 
 > > 
@@ -1091,13 +1091,13 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 
 
 > 
-> ```
+> ```python
 > hello_Other Class Name test_name2
 > ```
 > 
 > <details><summary>Stack Traces | 3s run time</summary>
 > 
-> > `````````
+> > `````````python
 > > Shared 
 > > 
 > > 
@@ -1114,14 +1114,14 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
 
 
 > 
-> ```
+> ```python
 > hello_Class Name test_name0
 > ```
 > 
 > <details><summary>Stack Traces | 4s run time</summary>
 > 
 > > 
-> > ```
+> > ```python
 > > <pre>Fourth 
 > > 
 > > </pre> | test  | instance |


### PR DESCRIPTION
we want to add python codee formatting to the code blocks in the TA PR comment so that the code blocks have some highlighting even though it's not completely accurate to the content of the code block