### PR TITLE
fix: MIME type for HTML emails

### DIFF
--- a/helpers/email.py
+++ b/helpers/email.py
@@ -11,4 +11,4 @@ class Email:
         self.message["Subject"] = subject
         self.message.set_content(text)
         if html:
-            self.message.add_alternative(html, "text/html")
+            self.message.add_alternative(html, "html")

--- a/tasks/send_email.py
+++ b/tasks/send_email.py
@@ -20,7 +20,10 @@ class SendEmailTask(BaseCodecovTask, name=send_email_task_name):
         with metrics.timer("worker.tasks.send_email"):
             if from_addr is None:
                 from_addr = get_config(
-                    "services", "smtp", "from_address", default="Codecov <noreply@codecov.io>"
+                    "services",
+                    "smtp",
+                    "from_address",
+                    default="Codecov <noreply@codecov.io>",
                 )
 
             log_extra_dict = {

--- a/tasks/send_email.py
+++ b/tasks/send_email.py
@@ -20,7 +20,7 @@ class SendEmailTask(BaseCodecovTask, name=send_email_task_name):
         with metrics.timer("worker.tasks.send_email"):
             if from_addr is None:
                 from_addr = get_config(
-                    "services", "smtp", "from_address", default="noreply@codecov.io"
+                    "services", "smtp", "from_address", default="Codecov <noreply@codecov.io>"
                 )
 
             log_extra_dict = {

--- a/tasks/tests/integration/test_send_email_task.py
+++ b/tasks/tests/integration/test_send_email_task.py
@@ -79,7 +79,7 @@ class TestSendEmailTask:
             "",
         ]
         assert mail_body[7:-1] == [
-            'Content-Type: text/text/html; charset="utf-8"',
+            'Content-Type: text/html; charset="utf-8"',
             "Content-Transfer-Encoding: 7bit",
             "MIME-Version: 1.0",
             "",


### PR DESCRIPTION
Our emails were adding an extra `text/` to the `text/html` MIME type on our emails, causing only the text content to display in gmail web client (though mailhog handled this fine interestingly).

Also adds "Codecov" as the display name for our emails.
