### PR TITLE
fix type annotation mistake that caused a security detector to misfire

### DIFF
--- a/services/report/languages/bullseye.py
+++ b/services/report/languages/bullseye.py
@@ -1,6 +1,5 @@
-from xml.etree.ElementTree import Element
-
 import sentry_sdk
+from lxml.etree import Element
 from timestring import Date
 
 from helpers.exceptions import ReportExpiredException

--- a/services/report/languages/clover.py
+++ b/services/report/languages/clover.py
@@ -1,6 +1,5 @@
-from xml.etree.ElementTree import Element
-
 import sentry_sdk
+from lxml.etree import Element
 from timestring import Date
 
 from helpers.exceptions import ReportExpiredException

--- a/services/report/languages/cobertura.py
+++ b/services/report/languages/cobertura.py
@@ -1,9 +1,9 @@
 import logging
 import re
 from typing import Sequence
-from xml.etree.ElementTree import Element
 
 import sentry_sdk
+from lxml.etree import Element
 from timestring import Date, TimestringInvalid
 
 from helpers.exceptions import ReportExpiredException

--- a/services/report/languages/csharp.py
+++ b/services/report/languages/csharp.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
 from itertools import repeat
-from xml.etree.ElementTree import Element
 
 import sentry_sdk
+from lxml.etree import Element
 from shared.reports.resources import ReportFile
 
 from services.report.languages.base import BaseLanguageProcessor

--- a/services/report/languages/helpers.py
+++ b/services/report/languages/helpers.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from xml.etree.ElementTree import Element
+
+from lxml.etree import Element
 
 
 def remove_non_ascii(string: str) -> str:

--- a/services/report/languages/jacoco.py
+++ b/services/report/languages/jacoco.py
@@ -1,8 +1,8 @@
 import logging
 from collections import defaultdict
-from xml.etree.ElementTree import Element
 
 import sentry_sdk
+from lxml.etree import Element
 from shared.utils.merge import LineType, branch_type
 from timestring import Date
 

--- a/services/report/languages/jetbrainsxml.py
+++ b/services/report/languages/jetbrainsxml.py
@@ -1,6 +1,5 @@
-from xml.etree.ElementTree import Element
-
 import sentry_sdk
+from lxml.etree import Element
 from shared.reports.resources import ReportFile
 
 from services.report.languages.base import BaseLanguageProcessor

--- a/services/report/languages/mono.py
+++ b/services/report/languages/mono.py
@@ -1,6 +1,5 @@
-from xml.etree.ElementTree import Element
-
 import sentry_sdk
+from lxml.etree import Element
 from shared.reports.resources import ReportFile
 
 from services.report.languages.base import BaseLanguageProcessor

--- a/services/report/languages/scoverage.py
+++ b/services/report/languages/scoverage.py
@@ -1,6 +1,5 @@
-from xml.etree.ElementTree import Element
-
 import sentry_sdk
+from lxml.etree import Element
 from shared.helpers.numeric import maxint
 from shared.reports.resources import ReportFile
 

--- a/services/report/languages/vb.py
+++ b/services/report/languages/vb.py
@@ -1,6 +1,5 @@
-from xml.etree.ElementTree import Element
-
 import sentry_sdk
+from lxml.etree import Element
 from shared.reports.resources import ReportFile
 
 from services.report.languages.base import BaseLanguageProcessor

--- a/services/report/languages/vb2.py
+++ b/services/report/languages/vb2.py
@@ -1,6 +1,5 @@
-from xml.etree.ElementTree import Element
-
 import sentry_sdk
+from lxml.etree import Element
 from shared.reports.resources import ReportFile
 
 from services.report.report_builder import ReportBuilderSession

--- a/services/report/report_processor.py
+++ b/services/report/report_processor.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Literal
-from xml.etree.ElementTree import Element
 
 import orjson
 import sentry_sdk
@@ -87,7 +86,7 @@ def report_type_matching(
 ) -> (
     tuple[bytes, Literal["txt"] | Literal["plist"]]
     | tuple[dict | list, Literal["json"]]
-    | tuple[Element, Literal["xml"]]
+    | tuple[etree.Element, Literal["xml"]]
 ):
     name = report.filename or ""
     raw_report = report.contents


### PR DESCRIPTION
fixes https://github.com/codecov/internal-issues/issues/965

we import `xml.etree.ElementTree.Element` but what we're actually using is `lxml.etree.Element`. we use lxml for xml parsing, not the standard library module:
https://github.com/codecov/worker/blob/8056e7b5978bac6d826c666fa81b001c18d97397/services/report/report_processor.py#L129

this caused a security alert to misfire