### PR TITLE
Do not trigger `Notify` twice from `TestResultsFinisher`

### DIFF
--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -26,7 +26,7 @@ from services.billing import BillingPlan
 from services.repository import EnrichedPull
 from services.test_results import generate_test_id
 from services.urls import get_members_url
-from tasks.test_results_finisher import QUEUE_NOTIFY_KEY, TestResultsFinisherTask
+from tasks.test_results_finisher import TestResultsFinisherTask
 
 here = Path(__file__)
 
@@ -358,7 +358,7 @@ class TestUploadTestFinisherTask(object):
         expected_result = {
             "notify_attempted": True,
             "notify_succeeded": True,
-            QUEUE_NOTIFY_KEY: False,
+            "queue_notify": False,
         }
 
         test_results_mock_app.tasks[
@@ -485,7 +485,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
         expected_result = {
             "notify_attempted": False,
             "notify_succeeded": False,
-            QUEUE_NOTIFY_KEY: True,
+            "queue_notify": True,
         }
         test_results_mock_app.tasks[
             "app.tasks.notify.Notify"
@@ -542,7 +542,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
         expected_result = {
             "notify_attempted": False,
             "notify_succeeded": False,
-            QUEUE_NOTIFY_KEY: True,
+            "queue_notify": True,
         }
 
         assert expected_result == result
@@ -628,7 +628,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
         expected_result = {
             "notify_attempted": False,
             "notify_succeeded": False,
-            QUEUE_NOTIFY_KEY: False,
+            "queue_notify": False,
         }
 
         assert expected_result == result
@@ -685,7 +685,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
         expected_result = {
             "notify_attempted": True,
             "notify_succeeded": True,
-            QUEUE_NOTIFY_KEY: False,
+            "queue_notify": False,
         }
 
         test_results_mock_app.tasks[
@@ -812,7 +812,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
         expected_result = {
             "notify_attempted": True,
             "notify_succeeded": False,
-            QUEUE_NOTIFY_KEY: False,
+            "queue_notify": False,
         }
 
         test_results_mock_app.tasks[
@@ -1041,7 +1041,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
         expected_result = {
             "notify_attempted": True,
             "notify_succeeded": True,
-            QUEUE_NOTIFY_KEY: False,
+            "queue_notify": False,
         }
 
         assert expected_result == result
@@ -1138,9 +1138,7 @@ Got feedback? Let us know on [Github](https://github.com/codecov/feedback/issues
         test_results_setup,
         plan,
     ):
-        mocked_get_flaky_tests = mocker.patch.object(
-            TestResultsFinisherTask, "get_flaky_tests"
-        )
+        mocker.patch.object(TestResultsFinisherTask, "get_flaky_tests")
         mock_feature = mocker.patch("services.test_results.FLAKY_TEST_DETECTION")
         mock_feature.check_value.return_value = True
         commit_yaml = {


### PR DESCRIPTION
This also fixes up the return value in case the test results comment was updates.

Plus, it does a little formatting and typing cleanup.