### PR TITLE
fix: Sync plan_activated_users during sync_teams

### DIFF
--- a/tasks/sync_teams.py
+++ b/tasks/sync_teams.py
@@ -59,11 +59,13 @@ class SyncTeamsTask(BaseCodecovTask, name=sync_teams_task_name):
                 ),
             )
             for org_ownerid in removed_orgs:
-                org = db_session.query(Owner).filter(Owner.ownerid == org_ownerid).first()
+                org = (
+                    db_session.query(Owner).filter(Owner.ownerid == org_ownerid).first()
+                )
                 if org and ownerid in org.plan_activated_users:
                     log.info(
                         "Removing user from org's plan_activated_users",
-                        extra=dict(user_ownerid=ownerid, org_ownerid=org_ownerid)
+                        extra=dict(user_ownerid=ownerid, org_ownerid=org_ownerid),
                     )
                     org.plan_activated_users.remove(ownerid)
 

--- a/tasks/sync_teams.py
+++ b/tasks/sync_teams.py
@@ -58,8 +58,14 @@ class SyncTeamsTask(BaseCodecovTask, name=sync_teams_task_name):
                     ownerid=ownerid,
                 ),
             )
-            for org in removed_orgs:
-                org.plan_activated_users.remove(ownerid)
+            for org_ownerid in removed_orgs:
+                org = db_session.query(Owner).filter(Owner.ownerid == org_ownerid).first()
+                if org and ownerid in org.plan_activated_users:
+                    log.info(
+                        "Removing user from org's plan_activated_users",
+                        extra=dict(user_ownerid=ownerid, org_ownerid=org_ownerid)
+                    )
+                    org.plan_activated_users.remove(ownerid)
 
         owner.updatestamp = datetime.now()
         owner.organizations = team_ids

--- a/tasks/sync_teams.py
+++ b/tasks/sync_teams.py
@@ -58,6 +58,8 @@ class SyncTeamsTask(BaseCodecovTask, name=sync_teams_task_name):
                     ownerid=ownerid,
                 ),
             )
+            for org in removed_orgs:
+                org.plan_activated_users.remove(ownerid)
 
         owner.updatestamp = datetime.now()
         owner.organizations = team_ids

--- a/tasks/tests/unit/test_sync_teams_task.py
+++ b/tasks/tests/unit/test_sync_teams_task.py
@@ -37,10 +37,12 @@ class TestSyncTeamsTaskUnit(object):
             service="github",
             unencrypted_oauth_token=token,
         )
+        prev_team.plan_activated_users = [user.ownerid]
         dbsession.add(user)
         dbsession.flush()
         SyncTeamsTask().run_impl(dbsession, user.ownerid, using_integration=False)
         assert prev_team.ownerid not in user.organizations
+        assert user.ownerid not in prev_team.plan_activated_users
 
     def test_team_data_updated(
         self, mocker, mock_configuration, dbsession, codecov_vcr

--- a/tasks/tests/unit/test_sync_teams_task.py
+++ b/tasks/tests/unit/test_sync_teams_task.py
@@ -39,6 +39,7 @@ class TestSyncTeamsTaskUnit(object):
         )
         prev_team.plan_activated_users = [user.ownerid]
         dbsession.add(user)
+        dbsession.add(prev_team)
         dbsession.flush()
         SyncTeamsTask().run_impl(dbsession, user.ownerid, using_integration=False)
         assert prev_team.ownerid not in user.organizations


### PR DESCRIPTION
`sync_teams` runs to take a user (e.g., `suejung-sentry`) and update its `organizations`.
When it does this, it should also remove from that organization (e.g., `codecov`)'s `plan_activated_users`, so the 2 places remain consistent.
That is, owners table row for owner `suejung-sentry` has `owners.organizations=['codecov','other-org','other-org-2']` and owners table row for owner `codecov` has `owners.plan_activated_users=['suejung-sentry','other-user','other-user-2']` and we need both those updated.

Special handling for "outside collaborators" - There may be "outside collaborators" that are not members of the org but may still be activated seats in codecov, so does keeping the 2 lists consistent make sense? Per [here](https://github.com/codecov/internal-issues/issues/394), I think we don't expressly support this feature and can employ a manual workaround in the infrequent cases a particular customer requires it.


`sync_teams` job is triggered from [here](https://github.com/codecov/codecov-api/blob/ae83c2fa69b4d572b0096c54803d8068a8f13ebe/webhook_handlers/views/github.py#L606)

Here's another place it can be triggered by https://github.com/codecov/codecov-api/blob/354b64076170dd4115a4c83fbda63ba4478a23d7/services/refresh.py#L38
https://github.com/codecov/codecov-api/blob/354b64076170dd4115a4c83fbda63ba4478a23d7/graphql_api/types/mutation/sync_with_git_provider/sync_with_git_provider.py#L12 (graphql api resolve_sync_with_git_provider)
where it's called in gazebo 
https://github.com/codecov/gazebo/blob/26d07c7dd517ae4a45751fa5b2d45785a264f98f/src/services/user/useResyncUser.ts#L33
Can't find your repo resync button (https://github.com/codecov/gazebo/blob/26d07c7dd517ae4a45751fa5b2d45785a264f98f/src/shared/ListRepo/OrgControlTable/RepoOrgNotFound/RepoOrgNotFound.tsx#L61)


Closes https://github.com/codecov/internal-issues/issues/1085