### PR TITLE
fix: upsert branch and pull when updating commit

### DIFF
--- a/tasks/commit_update.py
+++ b/tasks/commit_update.py
@@ -4,7 +4,7 @@ from shared.celery_config import commit_update_task_name
 from shared.torngit.exceptions import TorngitClientError, TorngitRepoNotFoundError
 
 from app import celery_app
-from database.models import Commit
+from database.models import Branch, Commit, Pull
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
 from services.repository import (
@@ -43,6 +43,69 @@ class CommitUpdateTask(BaseCodecovTask, name=commit_update_task_name):
             was_updated = possibly_update_commit_from_provider_info(
                 commit, repository_service
             )
+
+            # upsert pull
+            pull = (
+                db_session.query(Pull)
+                .filter(Pull.repoid == repoid, Pull.pullid == commit.pullid)
+                .first()
+            )
+
+            if pull is None:
+                pull = Pull(
+                    repoid=repoid,
+                    pullid=commit.pullid,
+                    author_id=commit.author_id,
+                    head=commit.commitid,
+                )
+                db_session.add(pull)
+            else:
+                previous_pull_head = (
+                    db_session.query(Commit)
+                    .filter(Commit.repoid == repoid, Commit.commitid == pull.head)
+                    .first()
+                )
+                if (
+                    previous_pull_head is None
+                    or previous_pull_head.deleted == True
+                    or previous_pull_head.timestamp < commit.timestamp
+                ):
+                    pull.head = commit.commitid
+
+            # upsert branch
+            branch = (
+                db_session.query(Branch)
+                .filter(Branch.repoid == repoid, Branch.branch == commit.branch)
+                .first()
+            )
+
+            if branch is None:
+                branch = Branch(
+                    repoid=repoid,
+                    branch=commit.branch,
+                    head=commit.commitid,
+                    authors=[commit.author_id],
+                )
+                db_session.add(branch)
+            else:
+                if commit.author_id not in branch.authors:
+                    branch.authors.append(commit.author_id)
+
+                previous_branch_head = (
+                    db_session.query(Commit)
+                    .filter(Commit.repoid == repoid, Commit.commitid == branch.head)
+                    .first()
+                )
+
+                if (
+                    previous_branch_head is None
+                    or previous_branch_head.deleted == True
+                    or previous_branch_head.timestamp < commit.timestamp
+                ):
+                    branch.head = commit.commitid
+
+            db_session.flush()
+
         except RepositoryWithoutValidBotError:
             log.warning(
                 "Unable to reach git provider because repo doesn't have a valid bot",


### PR DESCRIPTION
when we update a commit, we want to ensure the commit's corresponding pull and branch are also upserted to reflect whatever changes were made to the commit

this is duplicating the logic in the `commits_insert_pr_branch` and `commits_update_heads` db triggers