### PR TITLE
Enable timeseries for local testing environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,7 +243,7 @@ test_env.container_upload_test_results:
 	codecovcli -v -u ${CODECOV_URL} do-upload --report-type test_results || true
 
 test_env:
-	make test_env.up
+	TIMESERIES_ENABLED=true make test_env.up
 	make test_env.prepare
 	make test_env.check_db
 	make test_env.run_unit


### PR DESCRIPTION
All the `Skipping timeseries migration` logs are due to the fact that a timeseries database is configured (by default) but it's not enabled, which doesn't trigger the migration and hence the warning. We _could_ probably also remove the warning, as it's kind of noisy. But this is quicker, because the warning is in [`shared`.](https://github.com/codecov/shared/blob/511b553fd19113f1716326b0363b9d9a4afca1d7/shared/django_apps/db_routers/__init__.py#L36)

I could also be convinced to just set line 207 to hardcode `TIMESERIES_ENABLED=true` (this will affect the tests in CI, but this doesn't really affect test runs). 

BTW, running the tests on the `umbrella-hat` version of worker doesn't have this issue because the configuration in `umbrella-hat` sets `timeseries` to be enabled.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.