### PR TITLE
fix: a couple uncaught exceptions during coverage processing

### DIFF
--- a/services/report/languages/simplecov.py
+++ b/services/report/languages/simplecov.py
@@ -37,6 +37,12 @@ def from_json(json: dict, report_builder_session: ReportBuilderSession) -> None:
         )
 
         for ln, cov in enumerate(coverage_to_check, start=1):
+            if cov == "ignored":
+                # Lines that simplecov skipped are recorded as "ignored" by
+                # https://github.com/codeclimate-community/simplecov_json_formatter
+                # and we in turn record that as -1 which indicates a skipped line
+                # in our report
+                cov = -1
             _file.append(
                 ln,
                 report_builder_session.create_coverage_line(

--- a/services/report/report_processor.py
+++ b/services/report/report_processor.py
@@ -129,7 +129,7 @@ def report_type_matching(
         processed = etree.fromstring(raw_report, parser=parser)
         if processed is not None and len(processed) > 0:
             return processed, "xml"
-    except ValueError:
+    except (ValueError, etree.XMLSyntaxError):
         pass
 
     return raw_report, "txt"


### PR DESCRIPTION
related to https://github.com/codecov/engineering-team/issues/1520

i reviewed all of the uncaught exceptions during report processing. this PR addresses two of the highest-firing ones. others should be addressed but are more work and don't fire as frequently so i am punting on them

the `services/report/report_processor.py` change addresses a somewhat common uncaught exception: `ValueError: invalid literal for int() with base 10: 'ignored'`. JSON-ified simplecov reports have "ignored" as a coverage value for skipped lines. we should convert those to -1 which is [how the pyreport format represents skipped lines](https://github.com/codecov/shared/blob/511b553fd19113f1716326b0363b9d9a4afca1d7/shared/utils/merge.py#L300-L301)

the `services/report/languages/simplecov.py` change addresses the dominant uncaught exception during report processing: `lxml.etree.XMLSyntaxError: Document is empty, line 1, column 1`. the surrounding code is basically blindly attempting to parse it as JSON, and then attempting to parse it as XML, and then returning "it's a text file" if neither passes. so failing to parse it as XML is fine, we just weren't catching all the relevant exceptions. now we are. if these are truly empty files, i think they will no-op and if the overall upload has no non-empty files then we will return a `ReportEmptyError` and set the appropriate error code.