### PR TITLE
feat: only parse git diff of files that exist in the PR of the head commit

### DIFF
--- a/tasks/label_analysis.py
+++ b/tasks/label_analysis.py
@@ -361,7 +361,16 @@ class LabelAnalysisRequestProcessingTask(
                 label_analysis_request.base_commit.commitid,
                 label_analysis_request.head_commit.commitid,
             )
-            return list(parse_git_diff_json(git_diff))
+            try:
+                git_pr = async_to_sync(repo_service.find_pull_request)(
+                    label_analysis_request.head_commit.commitid,
+                )
+                pr_files = async_to_sync(repo_service.get_pull_request_files)(
+                    git_pr["id"]
+                )
+            except Exception:
+                pr_files = []
+            return list(parse_git_diff_json(git_diff, pr_files))
         except Exception:
             # temporary general catch while we find possible problems on this
             log.exception(


### PR DESCRIPTION
The code ensures that only the files meeting these conditions are processed further:

1. The file still exists in the head commit (i.e., it is not deleted).
2. The file exists in the pull request of the head commit.

This aligns with the goal of limiting the parsing to files that are relevant to the PR, avoiding unnecessary processing of files not part of the PR or already deleted.


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.