### PR TITLE
feat: update pull and branch head in commit update

### DIFF
--- a/tasks/commit_update.py
+++ b/tasks/commit_update.py
@@ -1,10 +1,11 @@
+import datetime as dt
 import logging
 
 from shared.celery_config import commit_update_task_name
 from shared.torngit.exceptions import TorngitClientError, TorngitRepoNotFoundError
 
 from app import celery_app
-from database.models import Commit
+from database.models import Branch, Commit, Pull
 from helpers.exceptions import RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
 from services.repository import (
@@ -43,6 +44,80 @@ class CommitUpdateTask(BaseCodecovTask, name=commit_update_task_name):
             was_updated = possibly_update_commit_from_provider_info(
                 commit, repository_service
             )
+
+            if isinstance(commit.timestamp, str):
+                commit.timestamp = dt.datetime.fromisoformat(commit.timestamp).replace(
+                    tzinfo=None
+                )
+
+            if commit.pullid is not None:
+                # upsert pull
+                pull = (
+                    db_session.query(Pull)
+                    .filter(Pull.repoid == repoid, Pull.pullid == commit.pullid)
+                    .first()
+                )
+
+                if pull is None:
+                    pull = Pull(
+                        repoid=repoid,
+                        pullid=commit.pullid,
+                        author_id=commit.author_id,
+                        head=commit.commitid,
+                    )
+                    db_session.add(pull)
+                else:
+                    previous_pull_head = (
+                        db_session.query(Commit)
+                        .filter(Commit.repoid == repoid, Commit.commitid == pull.head)
+                        .first()
+                    )
+                    if (
+                        previous_pull_head is None
+                        or previous_pull_head.deleted == True
+                        or previous_pull_head.timestamp < commit.timestamp
+                    ):
+                        pull.head = commit.commitid
+
+                db_session.flush()
+
+            if commit.branch is not None:
+                # upsert branch
+                branch = (
+                    db_session.query(Branch)
+                    .filter(Branch.repoid == repoid, Branch.branch == commit.branch)
+                    .first()
+                )
+
+                if branch is None:
+                    branch = Branch(
+                        repoid=repoid,
+                        branch=commit.branch,
+                        head=commit.commitid,
+                        authors=[commit.author_id],
+                    )
+                    db_session.add(branch)
+                else:
+                    if commit.author_id is not None:
+                        if branch.authors is None:
+                            branch.authors = [commit.author_id]
+                        elif commit.author_id not in branch.authors:
+                            branch.authors.append(commit.author_id)
+
+                    previous_branch_head = (
+                        db_session.query(Commit)
+                        .filter(Commit.repoid == repoid, Commit.commitid == branch.head)
+                        .first()
+                    )
+
+                    if (
+                        previous_branch_head is None
+                        or previous_branch_head.deleted == True
+                        or previous_branch_head.timestamp < commit.timestamp
+                    ):
+                        branch.head = commit.commitid
+
+                db_session.flush()
 
         except RepositoryWithoutValidBotError:
             log.warning(

--- a/tasks/tests/unit/test_commit_update.py
+++ b/tasks/tests/unit/test_commit_update.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 import pytest
 from shared.torngit.exceptions import (
     TorngitClientError,
@@ -5,7 +7,8 @@ from shared.torngit.exceptions import (
     TorngitRepoNotFoundError,
 )
 
-from database.tests.factories import CommitFactory
+from database.models import Branch
+from database.tests.factories import BranchFactory, CommitFactory, PullFactory
 from helpers.exceptions import RepositoryWithoutValidBotError
 from tasks.commit_update import CommitUpdateTask
 
@@ -168,6 +171,9 @@ class TestCommitUpdate(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
 
+    @pytest.mark.parametrize("branch_authors", [None, False, True])
+    @pytest.mark.parametrize("prev_head", ["old_head", "new_head"])
+    @pytest.mark.parametrize("deleted", [False, True])
     def test_update_commit_already_populated(
         self,
         mocker,
@@ -176,6 +182,9 @@ class TestCommitUpdate(object):
         mock_redis,
         mock_repo_provider,
         mock_storage,
+        branch_authors,
+        prev_head,
+        deleted,
     ):
         commit = CommitFactory.create(
             message="commit_msg",
@@ -184,10 +193,59 @@ class TestCommitUpdate(object):
             repository__owner__username="test-acc9",
             repository__yaml={"codecov": {"max_report_age": "764y ago"}},
             repository__name="test_example",
-            branch="main",
-            pullid=1,
+            timestamp=dt.datetime.fromisoformat("2019-02-01T17:59:47"),
         )
         dbsession.add(commit)
+        dbsession.flush()
+
+        commit.branch = "featureA"
+        commit.pullid = 1
+        dbsession.flush()
+
+        old_head = CommitFactory.create(
+            message="",
+            commitid="b2d3e3c30547a000f026daa47610bb3f7b63aece",
+            repository=commit.repository,
+            timestamp=dt.datetime.fromisoformat("2019-01-01T17:59:47"),
+        )
+        dbsession.add(old_head)
+        dbsession.flush()
+
+        old_head.branch = "featureA"
+        old_head.pullid = 1
+        dbsession.flush()
+
+        pull = PullFactory(
+            repository=commit.repository, pullid=1, head=old_head.commitid
+        )
+        dbsession.add(pull)
+        dbsession.flush()
+
+        if branch_authors is False:
+            branch_authors = []
+        elif branch_authors is True:
+            branch_authors = [commit.author_id]
+
+        if prev_head == "old_head":
+            prev_head = old_head
+        elif prev_head == "new_head":
+            prev_head = commit
+
+        if deleted:
+            prev_head.deleted = True
+            dbsession.flush()
+
+        b = dbsession.query(Branch).first()
+        dbsession.delete(b)
+        dbsession.flush()
+
+        branch = BranchFactory(
+            repository=commit.repository,
+            branch="featureA",
+            head=prev_head.commitid,
+            authors=branch_authors,
+        )
+        dbsession.add(branch)
         dbsession.flush()
 
         result = CommitUpdateTask().run_impl(dbsession, commit.repoid, commit.commitid)
@@ -195,3 +253,11 @@ class TestCommitUpdate(object):
         assert expected_result == result
         assert commit.message == "commit_msg"
         assert commit.parent_commit_id is None
+        assert commit.timestamp == dt.datetime.fromisoformat("2019-02-01T17:59:47")
+        assert commit.branch == "featureA"
+
+        dbsession.refresh(pull)
+        assert pull.head == commit.commitid
+
+        dbsession.refresh(branch)
+        assert branch.head == commit.commitid


### PR DESCRIPTION
we want to eventually replace the db triggers that exist to update the pull head and branch head when a commit is either inserted or updated

as a first step we want to duplicate the logic that those db triggers run in this commit update task which should run whenever a commit is inserted

the second step will be to run this task when a commit object is updated which is usually when we receive a webhook from github with some new information about a commit

the last step will be to remove the newly redundant db triggers

Fixes: https://github.com/codecov/internal-issues/issues/1027