### PR TITLE
fix(ta): don't process already processed upload

### DIFF
--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -166,6 +166,10 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
         flaky_test_set: set[str],
         flags: list[str],
     ):
+        log.info(
+            "Writing tests to database",
+            extra=dict(repoid=repoid, commitid=commitid, upload_id=upload_id),
+        )
         test_data = {}
         test_instance_data = []
         test_flag_bridge_data = []
@@ -308,6 +312,11 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
             db_session.execute(insert_on_conflict_do_update)
             db_session.commit()
 
+        log.info(
+            "Upserted tests to database",
+            extra=dict(repoid=repoid, commitid=commitid, upload_id=upload_id),
+        )
+
         if len(test_flag_bridge_data):
             insert_on_conflict_do_nothing_flags = (
                 insert(TestFlagBridge.__table__)
@@ -316,6 +325,11 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
             )
             db_session.execute(insert_on_conflict_do_nothing_flags)
             db_session.commit()
+
+        log.info(
+            "Inserted new test flag bridges to database",
+            extra=dict(repoid=repoid, commitid=commitid, upload_id=upload_id),
+        )
 
         # Upsert Daily Test Totals
         if len(daily_totals) > 0:
@@ -352,6 +366,11 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
             db_session.execute(stmt)
             db_session.commit()
 
+        log.info(
+            "Upserted daily test rollups to database",
+            extra=dict(repoid=repoid, commitid=commitid, upload_id=upload_id),
+        )
+
         # Save TestInstances
         if len(test_instance_data) > 0:
             insert_test_instances = insert(TestInstance.__table__).values(
@@ -359,6 +378,11 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
             )
             db_session.execute(insert_test_instances)
             db_session.commit()
+
+        log.info(
+            "Inserted test instances to database",
+            extra=dict(repoid=repoid, commitid=commitid, upload_id=upload_id),
+        )
 
     def process_individual_upload(
         self, db_session, repoid, commitid, upload_obj: Upload, flaky_test_set: set[str]
@@ -403,6 +427,11 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
             arg_processing_result.network_files,
             flaky_test_set,
             upload_obj.flag_names,
+        )
+
+        log.info(
+            "Finished processing individual upload",
+            extra=dict(repoid=repoid, commitid=commitid, upload_id=upload_id),
         )
 
         return {
@@ -482,6 +511,14 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
 
         db_session.flush()
         db_session.commit()
+        log.info(
+            "Marked upload as processed",
+            extra=dict(
+                upload_id=upload.id,
+                repoid=upload.report.commit.repoid,
+                commitid=upload.report.commit_id,
+            ),
+        )
 
         readable_report = self.rewrite_readable(network, report_contents)
         archive_service.write_file(upload.storage_path, readable_report.getvalue())


### PR DESCRIPTION
we were running into this issue where the test results processor task
was failing with a JSONDecodeError, and this started when we started
rewriting reports as readable.

It turns out that some processor tasks are retrying (reason unknown)
after having rewritten the report as readable which meant that during
the retry the task would fail

so now, before rewriting the report as readable we set the state of the
upload to "processed" or "has_failed" so we know to skip processing
tasks with that state, this will 100% avoid processing tasks with
readable reports, but the drawback is that there might be some reports
that end up not being rewritten as readable

also set tags on the sentry exceptions instead of extras so we can
filter by state
