### PR TITLE
Update bot if we see that the bot field has changed in the YAML

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/c840502d1b4dd7d05b2efc2c1328affaf2acd27c.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/f96b72f47583a083e0c78ec7c7ff4da5d3ad6a19.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/c481846ba657aee3fc15a613a0fd2c18ac1eabd2.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -328,7 +328,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.6.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/f96b72f47583a083e0c78ec7c7ff4da5d3ad6a19.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/c481846ba657aee3fc15a613a0fd2c18ac1eabd2.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/yaml/tests/test_yaml_saving.py
+++ b/services/yaml/tests/test_yaml_saving.py
@@ -1,4 +1,6 @@
-from database.tests.factories import CommitFactory
+import pytest
+
+from database.tests.factories import CommitFactory, OwnerFactory
 from services.yaml import save_repo_yaml_to_database_if_needed
 from test_utils.base import BaseTestCase
 
@@ -13,16 +15,26 @@ class TestYamlSavingService(BaseTestCase):
         assert res
         assert commit.repository.yaml == commit_yaml
         assert commit.repository.branch == "master"
+        assert commit.repository.bot_id is None
 
-    def test_save_repo_yaml_to_database_if_needed_with_new_branch(self, mocker):
+    @pytest.mark.django_db
+    def test_save_repo_yaml_to_database_if_needed_with_new_branch_and_bot(self, mocker):
         commit = CommitFactory.create(
-            branch="master", repository__branch="master", repository__yaml={"old_stuff"}
+            branch="master",
+            repository__branch="master",
+            repository__service_id="github",
+            repository__yaml={"old_stuff"},
         )
-        commit_yaml = {"new_values": "aHAAA", "codecov": {"branch": "brand_new_branch"}}
+        bot_owner = OwnerFactory.create(name="robot", service="github")
+        commit_yaml = {
+            "new_values": "aHAAA",
+            "codecov": {"branch": "brand_new_branch", "bot": "robot"},
+        }
         res = save_repo_yaml_to_database_if_needed(commit, commit_yaml)
         assert res
         assert commit.repository.yaml == commit_yaml
         assert commit.repository.branch == "brand_new_branch"
+        assert commit.repository.bot_id == bot_owner.ownerid
 
     def test_save_repo_yaml_to_database_not_needed(self, mocker):
         commit = CommitFactory.create(


### PR DESCRIPTION
This will help us get rid of one of the repo triggers to update the bot/branch field ([here](https://github.com/codecov/codecov-api/blob/168d5f2b8f4f3081c9c4dd1e459ff0511ad33ab5/legacy_migrations/migrations/legacy_sql/main/triggers/repos.py#L13)). Branch is already updated, so we only need to update the bot field.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.