### PR TITLE
Slight `ParsedRawReport` cleanup

### DIFF
--- a/services/path_fixer/fixpaths.py
+++ b/services/path_fixer/fixpaths.py
@@ -115,6 +115,7 @@ def clean_toc(toc: str) -> list[str]:
             continue
 
         # This path is good; save it.
-        rv.append(path)
+        if path:
+            rv.append(path)
 
     return rv

--- a/services/path_fixer/tests/unit/test_fixpaths.py
+++ b/services/path_fixer/tests/unit/test_fixpaths.py
@@ -3,7 +3,6 @@ import os
 import pytest
 
 from services.path_fixer import fixpaths
-from test_utils.base import BaseTestCase
 
 # Hand-written TOCs.
 paths = [
@@ -24,33 +23,35 @@ unquoted_files = {
 }
 
 
-class TestFixpaths(BaseTestCase):
-    @pytest.mark.parametrize("toc, result", paths)
-    def test_clean_toc(self, toc, result):
-        assert fixpaths.clean_toc(toc) == result
+@pytest.mark.parametrize("toc, result", paths)
+def test_clean_toc(toc, result):
+    assert fixpaths.clean_toc(toc) == result
 
-    def test_clean_toc_with_space(self):
-        assert fixpaths.clean_toc("a\\ b") == ["a b"]
 
-    @pytest.mark.parametrize("path, result", list(unquoted_files.items()))
-    def test_unquote_git_path(self, path, result):
-        assert fixpaths.unquote_git_path(path) == result
+def test_clean_toc_with_space():
+    assert fixpaths.clean_toc("a\\ b") == ["a b"]
 
-    def test_some_real_git_paths(self):
-        prefix = "services/path_fixer/tests/testdir"
-        filenames = [
-            "café.txt",
-            "comma,txt",
-            "🍭.txt",
-            'fixture/get_breakdown_values_escaped_".json',
-        ]
-        joined = [os.path.join(prefix, filename) for filename in filenames]
-        toc = """"services/path_fixer/tests/testdir/caf\\303\\251.txt"
+
+@pytest.mark.parametrize("path, result", list(unquoted_files.items()))
+def test_unquote_git_path(path, result):
+    assert fixpaths.unquote_git_path(path) == result
+
+
+def test_some_real_git_paths():
+    prefix = "services/path_fixer/tests/testdir"
+    filenames = [
+        "café.txt",
+        "comma,txt",
+        "🍭.txt",
+        'fixture/get_breakdown_values_escaped_".json',
+    ]
+    joined = [os.path.join(prefix, filename) for filename in filenames]
+    toc = """"services/path_fixer/tests/testdir/caf\\303\\251.txt"
 services/path_fixer/tests/testdir/comma,txt
 "services/path_fixer/tests/testdir/\\360\\237\\215\\255.txt"
 "services/path_fixer/tests/testdir/fixture/get_breakdown_values_escaped_\\".json"
 """
-        cleaned = fixpaths.clean_toc(toc)
-        joined.sort()
-        cleaned.sort()
-        assert joined == cleaned
+    cleaned = fixpaths.clean_toc(toc)
+    joined.sort()
+    cleaned.sort()
+    assert joined == cleaned

--- a/services/processing/processing.py
+++ b/services/processing/processing.py
@@ -99,7 +99,4 @@ def rewrite_or_delete_upload(
 
     elif isinstance(report_info.raw_report, VersionOneParsedRawReport):
         # only a version 1 report needs to be "rewritten readable"
-
-        archive_service.write_file(
-            archive_url, report_info.raw_report.content().getvalue()
-        )
+        archive_service.write_file(archive_url, report_info.raw_report.as_readable())

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -539,14 +539,8 @@ class ReportService(BaseReportService):
         """
         archive_service = self.get_archive_service(repo)
         archive_url = upload.storage_path
-
         log.info(
-            "Parsing the raw report from storage",
-            extra=dict(
-                commit=upload.report.commit_id,
-                repoid=repo.repoid,
-                archive_url=archive_url,
-            ),
+            "Parsing the raw report from storage", extra=dict(archive_url=archive_url)
         )
 
         archive_file = archive_service.read_file(archive_url)
@@ -559,13 +553,11 @@ class ReportService(BaseReportService):
 
         raw_uploaded_report = parser.parse_raw_report_from_bytes(archive_file)
 
-        raw_report_count = len(raw_uploaded_report.get_uploaded_files())
+        raw_report_count = len(raw_uploaded_report.uploaded_files)
         if raw_report_count < 1:
             log.warning(
                 "Raw upload contains no uploaded files",
                 extra=dict(
-                    commit=upload.report.commit_id,
-                    repoid=repo.repoid,
                     raw_report_count=raw_report_count,
                     upload_version=upload_version,
                     archive_url=archive_url,

--- a/services/report/parser/legacy.py
+++ b/services/report/parser/legacy.py
@@ -3,6 +3,7 @@ from io import BytesIO
 
 import sentry_sdk
 
+from services.path_fixer.fixpaths import clean_toc
 from services.report.parser.types import LegacyParsedRawReport, ParsedUploadedReportFile
 
 
@@ -67,7 +68,6 @@ class LegacyReportParser(object):
 
         This function takes the proper steps to find all the relevant sections of a report:
             - toc: the 'network', list of files present on this report
-            - env: the envvars the user set on the upload
             - uploaded_files: the actual report files
             - report_fixes: the report fixes some languages need
 
@@ -99,8 +99,8 @@ class LegacyReportParser(object):
                     while i_start < i_end and raw_report[i_start] in whitespaces:
                         i_start += 1
                 yield {
-                    "contents": raw_report[i_start:i_end],
                     "filename": filename,
+                    "contents": raw_report[i_start:i_end],
                     "footer": separator,
                 }
 
@@ -110,32 +110,27 @@ class LegacyReportParser(object):
             self.ignore_from_now_on_marker
         )
         sections = self.cut_sections(raw_report)
-        res = self._generate_parsed_report_from_sections(sections)
-        return res
+        return self._generate_parsed_report_from_sections(sections)
 
     def _generate_parsed_report_from_sections(self, sections):
         uploaded_files = []
-        toc_section = None
-        env_section = None
-        report_fixes_section = None
+        toc = None
+        report_fixes = None
         for sect in sections:
             if sect["footer"] == self.network_separator:
-                toc_section = sect["contents"]
+                toc = clean_toc(sect["contents"].decode(errors="replace").strip())
             elif sect["footer"] == self.env_separator:
-                env_section = sect["contents"]
+                pass
+            elif sect["filename"] == "fixes":
+                report_fixes = sect["contents"]
             else:
-                if sect["filename"] == "fixes":
-                    report_fixes_section = sect["contents"]
-                else:
-                    uploaded_files.append(
-                        ParsedUploadedReportFile(
-                            filename=sect.get("filename"),
-                            file_contents=sect["contents"],
-                        )
-                    )
+                file = ParsedUploadedReportFile(
+                    filename=sect["filename"], file_contents=sect["contents"]
+                )
+                uploaded_files.append(file)
+
         return LegacyParsedRawReport(
-            toc=toc_section,
-            env=env_section,
+            toc=toc or [],
             uploaded_files=uploaded_files,
-            report_fixes=report_fixes_section,
+            report_fixes=report_fixes,
         )

--- a/services/report/parser/types.py
+++ b/services/report/parser/types.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 from typing import Any
 
-from services.path_fixer.fixpaths import clean_toc
 from services.report.fixes import get_fixes_from_raw
 
 
@@ -30,8 +29,6 @@ class ParsedRawReport(object):
     toc
         table of contents, this lists the files relevant to the report,
         i.e. the files contained in the repository
-    env
-        list of env vars in environment of uploader (legacy only)
     uploaded_files
         list of class ParsedUploadedReportFile describing uploaded coverage files
     report_fixes
@@ -41,21 +38,13 @@ class ParsedRawReport(object):
 
     def __init__(
         self,
-        toc: Any,
-        env: Any,
+        toc: list[str],
         uploaded_files: list[ParsedUploadedReportFile],
         report_fixes: Any,
     ):
         self.toc = toc
-        self.env = env
         self.uploaded_files = uploaded_files
         self.report_fixes = report_fixes
-
-    def has_toc(self) -> bool:
-        return self.toc is not None
-
-    def has_env(self) -> bool:
-        return self.env is not None
 
     def has_report_fixes(self) -> bool:
         return self.report_fixes is not None
@@ -64,18 +53,16 @@ class ParsedRawReport(object):
     def size(self):
         return sum(f.size for f in self.uploaded_files)
 
-    def content(self) -> BytesIO:
-        buffer = BytesIO()
-        if self.has_toc():
-            for file in self.get_toc():
-                buffer.write(f"{file}\n".encode("utf-8"))
-            buffer.write(b"<<<<<< network\n\n")
-        for file in self.uploaded_files:
-            buffer.write(f"# path={file.filename}\n".encode("utf-8"))
-            buffer.write(file.contents)
-            buffer.write(b"\n<<<<<< EOF\n\n")
-        buffer.seek(0)
-        return buffer
+
+class LegacyParsedRawReport(ParsedRawReport):
+    """
+    report_fixes : bytes
+    <filename>:<line number>,<line number>,...
+    """
+
+    def get_report_fixes(self, path_fixer) -> dict[str, dict[str, Any]]:
+        report_fixes = self.report_fixes.decode(errors="replace")
+        return get_fixes_from_raw(report_fixes, path_fixer)
 
 
 class VersionOneParsedRawReport(ParsedRawReport):
@@ -90,34 +77,17 @@ class VersionOneParsedRawReport(ParsedRawReport):
     }
     """
 
-    def get_toc(self) -> list[str]:
-        return self.toc
-
-    def get_env(self):
-        return self.env
-
-    def get_uploaded_files(self):
-        return self.uploaded_files
-
     def get_report_fixes(self, path_fixer) -> dict[str, dict[str, Any]]:
         return self.report_fixes
 
-
-class LegacyParsedRawReport(ParsedRawReport):
-    """
-    report_fixes : BinaryIO
-    <filename>:<line number>,<line number>,...
-    """
-
-    def get_toc(self) -> list[str]:
-        return clean_toc(self.toc.decode(errors="replace").strip())
-
-    def get_env(self):
-        return self.env.decode(errors="replace")
-
-    def get_uploaded_files(self):
-        return self.uploaded_files
-
-    def get_report_fixes(self, path_fixer) -> dict[str, dict[str, Any]]:
-        report_fixes = self.report_fixes.decode(errors="replace")
-        return get_fixes_from_raw(report_fixes, path_fixer)
+    def as_readable(self) -> bytes:
+        buffer = b""
+        if self.toc:
+            for path in self.toc:
+                buffer += f"{path}\n".encode()
+            buffer += b"<<<<<< network\n\n"
+        for file in self.uploaded_files:
+            buffer += f"# path={file.filename}\n".encode()
+            buffer += file.contents
+            buffer += b"\n<<<<<< EOF\n\n"
+        return buffer

--- a/services/report/parser/version_one.py
+++ b/services/report/parser/version_one.py
@@ -15,36 +15,37 @@ log = logging.getLogger(__name__)
 
 class VersionOneReportParser(object):
     @sentry_sdk.trace
-    def parse_raw_report_from_bytes(self, raw_report: bytes):
+    def parse_raw_report_from_bytes(
+        self, raw_report: bytes
+    ) -> VersionOneParsedRawReport:
         data = orjson.loads(raw_report)
+        # want backwards compatibility with older versions of the CLI that still name this section path_fixes
+        report_fixes = (
+            data["report_fixes"] if "report_fixes" in data else data["path_fixes"]
+        )
         return VersionOneParsedRawReport(
             toc=data["network_files"],
-            env=None,
             uploaded_files=[
-                self._parse_single_coverage_file(x) for x in data["coverage_files"]
+                _parse_single_coverage_file(x) for x in data["coverage_files"]
             ],
-            report_fixes=self._parse_report_fixes(
-                # want backwards compatibility with older versions of the CLI that still name this section path_fixes
-                data["report_fixes"] if "report_fixes" in data else data["path_fixes"]
-            ),
+            report_fixes=report_fixes["value"],
         )
 
-    def _parse_report_fixes(self, value):
-        return value["value"]
 
-    def _parse_single_coverage_file(self, coverage_file):
-        actual_data = self._parse_coverage_file_contents(coverage_file)
-        return ParsedUploadedReportFile(
-            filename=coverage_file["filename"],
-            file_contents=actual_data,
-            labels=coverage_file["labels"],
-        )
+def _parse_single_coverage_file(coverage_file: dict) -> ParsedUploadedReportFile:
+    actual_data = _parse_coverage_file_contents(coverage_file)
+    return ParsedUploadedReportFile(
+        filename=coverage_file["filename"],
+        file_contents=actual_data,
+        labels=coverage_file["labels"],
+    )
 
-    def _parse_coverage_file_contents(self, coverage_file):
-        if coverage_file["format"] == "base64+compressed":
-            return zlib.decompress(base64.b64decode(coverage_file["data"]))
-        log.warning(
-            "Unkown format found while parsing upload",
-            extra=dict(coverage_file_filename=coverage_file["filename"]),
-        )
-        return coverage_file["data"]
+
+def _parse_coverage_file_contents(coverage_file: dict) -> bytes:
+    if coverage_file["format"] == "base64+compressed":
+        return zlib.decompress(base64.b64decode(coverage_file["data"]))
+    log.warning(
+        "Unkown format found while parsing upload",
+        extra=dict(coverage_file_filename=coverage_file["filename"]),
+    )
+    return coverage_file["data"]

--- a/services/report/raw_upload_processor.py
+++ b/services/report/raw_upload_processor.py
@@ -33,16 +33,8 @@ def process_raw_upload(
     # ----------------------
     # Extract `git ls-files`
     # ----------------------
-    toc = []
-    if raw_reports.has_toc():
-        toc = raw_reports.get_toc()
-
-    if raw_reports.has_env():
-        env = raw_reports.get_env()
-        session.env = dict([e.split("=", 1) for e in env.split("\n") if "=" in e])
-
     path_fixer = PathFixer.init_from_user_yaml(
-        commit_yaml=commit_yaml, toc=toc, flags=session.flags
+        commit_yaml=commit_yaml, toc=raw_reports.toc, flags=session.flags
     )
 
     # ------------------
@@ -54,7 +46,7 @@ def process_raw_upload(
 
     # [javascript] check for both coverage.json and coverage/coverage.lcov
     skip_files = set()
-    for report_file in raw_reports.get_uploaded_files():
+    for report_file in raw_reports.uploaded_files:
         if report_file.filename == "coverage/coverage.json":
             skip_files.add("coverage/coverage.lcov")
 
@@ -64,7 +56,7 @@ def process_raw_upload(
     # ---------------
     # Process reports
     # ---------------
-    for report_file in raw_reports.get_uploaded_files():
+    for report_file in raw_reports.uploaded_files:
         current_filename = report_file.filename
         if current_filename in skip_files or not report_file.contents:
             continue

--- a/services/report/tests/unit/test_parser.py
+++ b/services/report/tests/unit/test_parser.py
@@ -317,22 +317,19 @@ github.com/mypath/bugsbunny.go:20.36,22.17 2 1"""
 class TestParser(object):
     def test_parser_with_toc(self):
         res = LegacyReportParser().parse_raw_report_from_bytes(simple_content)
-        assert res.has_toc()
-        assert not res.has_env()
+        assert res.toc
         assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 1
 
     def test_parser_no_toc(self):
         res = LegacyReportParser().parse_raw_report_from_bytes(simple_no_toc)
-        assert not res.has_toc()
-        assert not res.has_env()
+        assert not res.toc
         assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 1
 
     def test_parser_more_complete(self):
         res = LegacyReportParser().parse_raw_report_from_bytes(more_complex)
-        assert res.has_toc()
-        assert res.has_env()
+        assert res.toc
         assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
@@ -346,8 +343,7 @@ class TestParser(object):
         res = LegacyReportParser().parse_raw_report_from_bytes(
             more_complex_with_line_end
         )
-        assert res.has_toc()
-        assert res.has_env()
+        assert res.toc
         assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
@@ -371,8 +367,7 @@ class TestParser(object):
 
     def test_line_end_no_line_break(self):
         res = LegacyReportParser().parse_raw_report_from_bytes(line_end_no_line_break)
-        assert res.has_toc()
-        assert res.has_env()
+        assert res.toc
         assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
@@ -398,21 +393,17 @@ class TestParser(object):
         res = LegacyReportParser().parse_raw_report_from_bytes(
             cases_little_mor_ridiculous
         )
-        assert res.has_toc()
-        assert res.toc == b"\n".join(
-            [
-                b"./codecov.yaml",
-                b"Makefile",
-                b"awesome/__init__.py",
-                b"awesome/code_fib.py",
-                b"dev.sh",
-                b"tests/__init__.py",
-                b"tests/test_number_two.py",
-                b"tests/test_sample.py",
-                b"unit.coverage.xml",
-            ]
-        )
-        assert res.has_env()
+        assert res.toc == [
+            "codecov.yaml",
+            "Makefile",
+            "awesome/__init__.py",
+            "awesome/code_fib.py",
+            "dev.sh",
+            "tests/__init__.py",
+            "tests/test_number_two.py",
+            "tests/test_sample.py",
+            "unit.coverage.xml",
+        ]
         assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
@@ -436,21 +427,17 @@ class TestParser(object):
 
     def test_cases_no_eof_end(self):
         res = LegacyReportParser().parse_raw_report_from_bytes(cases_no_eof_end)
-        assert res.has_toc()
-        assert res.toc == b"\n".join(
-            [
-                b"./codecov.yaml",
-                b"Makefile",
-                b"awesome/__init__.py",
-                b"awesome/code_fib.py",
-                b"dev.sh",
-                b"tests/__init__.py",
-                b"tests/test_number_two.py",
-                b"tests/test_sample.py",
-                b"unit.coverage.xml",
-            ]
-        )
-        assert res.has_env()
+        assert res.toc == [
+            "codecov.yaml",
+            "Makefile",
+            "awesome/__init__.py",
+            "awesome/code_fib.py",
+            "dev.sh",
+            "tests/__init__.py",
+            "tests/test_number_two.py",
+            "tests/test_sample.py",
+            "unit.coverage.xml",
+        ]
         assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 2
         assert res.uploaded_files[0].filename == "unit.coverage.xml"
@@ -468,18 +455,14 @@ class TestParser(object):
         res = LegacyReportParser().parse_raw_report_from_bytes(
             cases_emptylines_betweenpath_and_content
         )
-        assert res.has_toc()
-        assert res.toc == b"\n".join(
-            [
-                b"p2/redis/b_test.go",
-                b"p1/driver.go",
-                b"p1/driver_test.go",
-                b"p1/options.go",
-                b"p2/a.go",
-                b"p2/a_test.go",
-            ]
-        )
-        assert not res.has_env()
+        assert res.toc == [
+            "p2/redis/b_test.go",
+            "p1/driver.go",
+            "p1/driver_test.go",
+            "p1/options.go",
+            "p2/a.go",
+            "p2/a_test.go",
+        ]
         assert not res.has_report_fixes()
         assert len(res.uploaded_files) == 1
         assert res.uploaded_files[0].filename == "coverage.txt"
@@ -503,11 +486,9 @@ github.com/mypath/bugsbunny.go:20.36,22.17 2 1"""
         would_be_simple_content_res = LegacyReportParser().parse_raw_report_from_bytes(
             simple_content
         )
-        assert res.has_toc()
-        assert would_be_simple_content_res.has_toc()
+        assert res.toc
+        assert would_be_simple_content_res.toc
         assert res.toc == would_be_simple_content_res.toc
-        assert not res.has_env()
-        assert not would_be_simple_content_res.has_env()
         assert not res.has_report_fixes()
         assert not would_be_simple_content_res.has_report_fixes()
         assert len(res.uploaded_files) == len(
@@ -531,11 +512,9 @@ github.com/mypath/bugsbunny.go:20.36,22.17 2 1"""
         would_be_simple_content_res = LegacyReportParser().parse_raw_report_from_bytes(
             simple_content
         )
-        assert res.has_toc()
-        assert would_be_simple_content_res.has_toc()
+        assert res.toc
+        assert would_be_simple_content_res.toc
         assert res.toc == would_be_simple_content_res.toc
-        assert not res.has_env()
-        assert not would_be_simple_content_res.has_env()
         assert not res.has_report_fixes()
         assert not would_be_simple_content_res.has_report_fixes()
         assert len(res.uploaded_files) == len(

--- a/services/report/tests/unit/test_process.py
+++ b/services/report/tests/unit/test_process.py
@@ -82,9 +82,6 @@ class TestProcessRawUpload(BaseTestCase):
         )
         master = process.process_raw_upload(None, parsed_report, Session())
 
-        if "e" in keys:
-            assert master.sessions[0].env == {"A": "b"}
-
         assert master.totals.files == 1 + (
             1 if ("m" in keys and "n" not in keys) else 0
         )
@@ -719,8 +716,7 @@ class TestProcessReport(BaseTestCase):
         third_banana.append(5, ReportLine.create(0, sessions=[LineSession(0, 0)]))
         third_raw_report_result.append(third_banana)
         uploaded_reports = LegacyParsedRawReport(
-            toc=None,
-            env=None,
+            toc=[],
             report_fixes=None,
             uploaded_files=[
                 ParsedUploadedReportFile(
@@ -801,8 +797,7 @@ class TestProcessReport(BaseTestCase):
     def test_process_raw_upload_expired_report(self, mocker):
         filename = "/Users/path/to/app.coverage.txt"
         uploaded_reports = LegacyParsedRawReport(
-            toc=None,
-            env=None,
+            toc=[],
             report_fixes=None,
             uploaded_files=[
                 ParsedUploadedReportFile(

--- a/tasks/tests/unit/test_upload_processing_task.py
+++ b/tasks/tests/unit/test_upload_processing_task.py
@@ -15,7 +15,6 @@ from helpers.exceptions import ReportEmptyError, ReportExpiredException
 from services.archive import ArchiveService
 from services.processing.processing import process_upload
 from services.report import ProcessingError, RawReportInfo, ReportService
-from services.report.parser.legacy import LegacyReportParser
 from tasks.upload_processor import UploadProcessorTask
 
 here = Path(__file__)
@@ -179,11 +178,6 @@ class TestUploadProcessorTask(object):
             "arguments": {"url": url, "upload_id": upload.id_},
             "successful": True,
         }
-
-        # storage is overwritten with parsed contents
-        data = mock_storage.read_file("archive", url)
-        parsed = LegacyReportParser().parse_raw_report_from_bytes(content)
-        assert data == parsed.content().getvalue()
 
     @pytest.mark.django_db(databases={"default"})
     def test_upload_task_call_exception_within_individual_upload(


### PR DESCRIPTION
Removes a bunch of has/get methods in favor of accessing fields directly. Removes the `env` field completely.
Avoids a `BytesIO` indirection in the renamed `as_readable` method.