### PR TITLE
Use the correct `owner.service` for `get_ownerid_if_member`

### DIFF
--- a/services/yaml/__init__.py
+++ b/services/yaml/__init__.py
@@ -146,7 +146,7 @@ def maybe_update_repo_bot(
     new_bot_owner_username = read_yaml_field(new_yaml, ("codecov", "bot"))
     if new_bot_owner_username:
         bot_owner_id = get_ownerid_if_member(
-            repository.service_id, new_bot_owner_username, repository.ownerid
+            repository.owner.service, new_bot_owner_username, repository.ownerid
         )
         if bot_owner_id and bot_owner_id != repository.bot_id:
             repository.bot_id = bot_owner_id


### PR DESCRIPTION
https://github.com/codecov/worker/pull/926 has caused [WORKER-Q99](https://codecov.sentry.io/issues/6108679584/).
We have to use the `owner.service` (which is a DB enum containing `"github"`, etc) here instead of the `service_id`, which I believe represents an opaque ID of the repo *on a particular service*.