### PR TITLE
fix(flakes): process uploads only once

### DIFF
--- a/tasks/process_flakes.py
+++ b/tasks/process_flakes.py
@@ -35,23 +35,23 @@ class ProcessFlakesTask(BaseCodecovTask, name=process_flakes_task_name):
         **kwargs: Any,
     ):
         """
-        this task wants to iterate through uploads for a given commit that have yet to be
-        "flake processed"
+        This task wants to iterate through uploads for a given commit that have yet to be
+        "flake processed".
 
-        for each of those uploads it wants to iterate through its test instances and
+        For each of those uploads it wants to iterate through its test instances and
         update existing flakes' count, recent_passes_count, fail_count, and end_date fields
-        depending on whether the test instance passed or failed
+        depending on whether the test instance passed or failed.
 
-        for each upload it wants to keep track of newly created flakes and keep those in a separate
+        For each upload it wants to keep track of newly created flakes and keep those in a separate
         collection than the existing flakes, so at the end it can bulk create the new flakes and
-        bulk update the existing flakes
+        bulk update the existing flakes.
 
-        it also wants to increment the flaky_fail_count of the relevant DailyTestRollup when it creates
-        a new flake so it keeps track of those changes and bulk updates those as well
+        It also wants to increment the flaky_fail_count of the relevant DailyTestRollup when it creates
+        a new flake so it keeps track of those changes and bulk updates those as well.
 
-        when it's done with an upload it merges the new flakes dictionary into the existing flakes dictionary
+        When it's done with an upload it merges the new flakes dictionary into the existing flakes dictionary
         and then clears the new flakes dictionary so the following upload considers the flakes created during the previous
-        iteration as existing
+        iteration as existing.
         """
         log.info(
             "Received process flakes task",

--- a/tasks/process_flakes.py
+++ b/tasks/process_flakes.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from django.db import transaction as django_transaction
 from django.db.models import Q
@@ -12,13 +13,10 @@ from shared.django_apps.reports.models import (
 )
 
 from app import celery_app
-from helpers.metrics import metrics
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
 
-
-FlakeDict = dict[tuple[str, int], Flake]
 
 FLAKE_EXPIRY_COUNT = 30
 
@@ -30,66 +28,102 @@ class ProcessFlakesTask(BaseCodecovTask, name=process_flakes_task_name):
 
     def run_impl(
         self,
-        _db_session,
+        _db_session: Any,
         *,
-        repo_id,
-        commit_id,
-        **kwargs,
+        repo_id: int,
+        commit_id: str,
+        **kwargs: Any,
     ):
-        repo_id = int(repo_id)
+        """
+        this task wants to iterate through uploads for a given commit that have yet to be
+        "flake processed"
+
+        for each of those uploads it wants to iterate through its test instances and
+        update existing flakes' count, recent_passes_count, fail_count, and end_date fields
+        depending on whether the test instance passed or failed
+
+        for each upload it wants to keep track of newly created flakes and keep those in a separate
+        collection than the existing flakes, so at the end it can bulk create the new flakes and
+        bulk update the existing flakes
+
+        it also wants to increment the flaky_fail_count of the relevant DailyTestRollup when it creates
+        a new flake so it keeps track of those changes and bulk updates those as well
+
+        when it's done with an upload it merges the new flakes dictionary into the existing flakes dictionary
+        and then clears the new flakes dictionary so the following upload considers the flakes created during the previous
+        iteration as existing
+        """
         log.info(
             "Received process flakes task",
             extra=dict(repoid=repo_id, commit=commit_id),
         )
 
-        uploads = (
-            ReportSession.objects.select_related("report", "report__commit")
-            .filter(
-                report__report_type=CommitReport.ReportType.TEST_RESULTS.value,
-                report__commit__commitid=commit_id,
-                state="processed",
+        uploads = ReportSession.objects.filter(
+            report__report_type=CommitReport.ReportType.TEST_RESULTS.value,
+            report__commit__commitid=commit_id,
+            state="processed",
+        ).all()
+
+        curr_flakes = fetch_curr_flakes(repo_id)
+        new_flakes: dict[str, Flake] = dict()
+
+        rollups_to_update: list[DailyTestRollup] = []
+
+        flaky_tests = list(curr_flakes.keys())
+
+        for upload in uploads:
+            test_instances = get_test_instances(upload, flaky_tests)
+            for test_instance in test_instances:
+                if test_instance.outcome == TestInstance.Outcome.PASS.value:
+                    flake = {**new_flakes, **curr_flakes}.get(test_instance.test_id)
+                    if flake is not None:
+                        update_flake(flake, test_instance)
+                elif test_instance.outcome in (
+                    TestInstance.Outcome.FAILURE.value,
+                    TestInstance.Outcome.ERROR.value,
+                ):
+                    flake = {**new_flakes, **curr_flakes}.get(test_instance.test_id)
+                    if flake:
+                        update_flake(flake, test_instance)
+                    else:
+                        flake, rollup = create_flake(test_instance, repo_id)
+
+                        new_flakes[test_instance.test_id] = flake
+
+                        if rollup:
+                            rollups_to_update.append(rollup)
+
+            if rollups_to_update:
+                DailyTestRollup.objects.bulk_update(
+                    rollups_to_update,
+                    ["flaky_fail_count"],
+                )
+
+            merge_flake_dict = {}
+
+            if new_flakes:
+                flakes_to_merge = Flake.objects.bulk_create(new_flakes.values())
+                merge_flake_dict: dict[str, Flake] = {
+                    flake.test_id: flake for flake in flakes_to_merge
+                }
+
+            Flake.objects.bulk_update(
+                curr_flakes.values(),
+                [
+                    "count",
+                    "fail_count",
+                    "recent_passes_count",
+                    "end_date",
+                ],
             )
-            .all()
-        )
 
-        print(f"uploads: {uploads}")
+            curr_flakes = {**merge_flake_dict, **curr_flakes}
 
-        with metrics.timer("process_flakes"):
-            flake_dict = generate_flake_dict(repo_id)
+            new_flakes.clear()
 
-            flaky_tests: list[str] = [
-                test_id for (test_id, _) in list(flake_dict.keys())
-            ]
-
-            for upload in uploads:
-                test_instances = get_test_instances(upload, flaky_tests)
-                for test_instance in test_instances:
-                    if test_instance.outcome == TestInstance.Outcome.PASS.value:
-                        flake = flake_dict.get(
-                            (test_instance.test_id, test_instance.reduced_error_id)
-                        )
-                        if flake is not None:
-                            update_passed_flakes(test_instance, flake)
-                    elif test_instance.outcome in (
-                        TestInstance.Outcome.FAILURE.value,
-                        TestInstance.Outcome.ERROR.value,
-                    ):
-                        flake = flake_dict.get(
-                            (test_instance.test_id, test_instance.reduced_error_id)
-                        )
-                        upserted_flake = upsert_failed_flake(
-                            test_instance, flake, repo_id
-                        )
-                        if flake is None:
-                            flake_dict[
-                                (
-                                    upserted_flake.test_id,
-                                    upserted_flake.reduced_error_id,
-                                )
-                            ] = upserted_flake
-                upload.state = "flake_processed"
-                upload.save()
-                django_transaction.commit()
+            upload.state = "flake_processed"
+            upload.save()
+            django_transaction.commit()
 
         log.info(
             "Successfully processed flakes",
@@ -103,7 +137,7 @@ def get_test_instances(
     upload: ReportSession,
     flaky_tests: list[str],
 ) -> list[TestInstance]:
-    # get test instances on this repo commit branch combination that either:
+    # get test instances on this upload that either:
     # - failed
     # - passed but belong to an already flaky test
 
@@ -124,69 +158,65 @@ def get_test_instances(
     return test_instances
 
 
-def generate_flake_dict(repo_id: int) -> FlakeDict:
+def fetch_curr_flakes(repo_id: int) -> dict[str, Flake]:
     flakes = Flake.objects.filter(repository_id=repo_id, end_date__isnull=True).all()
-    flake_dict = dict()
-    for flake in flakes:
-        flake_dict[(flake.test_id, flake.reduced_error_id)] = flake
-    return flake_dict
+    return {flake.test_id: flake for flake in flakes}
 
 
-def update_passed_flakes(test_instance: TestInstance, flake: Flake) -> None:
-    flake.count += 1
-    flake.recent_passes_count += 1
-
-    if flake.recent_passes_count == FLAKE_EXPIRY_COUNT:
-        flake.end_date = test_instance.created_at
-
-    flake.save()
-
-
-def upsert_failed_flake(
+def create_flake(
     test_instance: TestInstance,
-    flake: Flake | None,
     repo_id: int,
-) -> Flake:
-    if flake is None:
-        flake = Flake(
-            repository_id=repo_id,
-            test=test_instance.test,
-            reduced_error=test_instance.reduced_error_id,
-            count=1,
-            fail_count=1,
-            start_date=test_instance.created_at,
-            recent_passes_count=0,
-        )
-        flake.save()
+) -> tuple[Flake, DailyTestRollup | None]:
+    # retroactively mark newly caught flake as flaky failure in its rollup
+    rollup = DailyTestRollup.objects.filter(
+        repoid=repo_id,
+        date=test_instance.created_at.date(),
+        branch=test_instance.branch,
+        test_id=test_instance.test_id,
+    ).first()
 
-        # retroactively mark newly caught flake as flaky failure in its rollup
-        rollup = DailyTestRollup.objects.filter(
-            repoid=repo_id,
-            date=test_instance.created_at.date(),
-            branch=test_instance.branch,
-            test_id=test_instance.test_id,
-        ).first()
-
-        if rollup:
-            rollup.flaky_fail_count += 1
-            rollup.save()
-        else:
-            log.warning(
-                "Could not find rollup when trying to update its flaky fail count",
-                extra=dict(
-                    repoid=repo_id,
-                    testid=test_instance.test_id,
-                    branch=test_instance.branch,
-                    date=test_instance.created_at.date(),
-                ),
-            )
+    if rollup:
+        rollup.flaky_fail_count += 1
     else:
-        flake.count += 1
-        flake.fail_count += 1
-        flake.recent_passes_count = 0
-        flake.save()
+        log.warning(
+            "Could not find rollup when trying to update its flaky fail count",
+            extra=dict(
+                repoid=repo_id,
+                testid=test_instance.test_id,
+                branch=test_instance.branch,
+                date=test_instance.created_at.date(),
+            ),
+        )
 
-    return flake
+    f = Flake(
+        repository_id=repo_id,
+        test=test_instance.test,
+        reduced_error=None,
+        count=1,
+        fail_count=1,
+        start_date=test_instance.created_at,
+        recent_passes_count=0,
+    )
+
+    return f, rollup
+
+
+def update_flake(
+    flake: Flake,
+    test_instance: TestInstance,
+) -> None:
+    flake.count += 1
+
+    match test_instance.outcome:
+        case TestInstance.Outcome.PASS.value:
+            flake.recent_passes_count += 1
+            if flake.recent_passes_count == FLAKE_EXPIRY_COUNT:
+                flake.end_date = test_instance.created_at
+        case TestInstance.Outcome.FAILURE.value | TestInstance.Outcome.ERROR.value:
+            flake.fail_count += 1
+            flake.recent_passes_count = 0
+        case _:
+            pass
 
 
 RegisteredProcessFlakesTask = celery_app.register_task(ProcessFlakesTask())

--- a/tasks/process_flakes.py
+++ b/tasks/process_flakes.py
@@ -75,14 +75,18 @@ class ProcessFlakesTask(BaseCodecovTask, name=process_flakes_task_name):
             test_instances = get_test_instances(upload, flaky_tests)
             for test_instance in test_instances:
                 if test_instance.outcome == TestInstance.Outcome.PASS.value:
-                    flake = {**new_flakes, **curr_flakes}.get(test_instance.test_id)
+                    flake = new_flakes.get(test_instance.test_id) or curr_flakes.get(
+                        test_instance.test_id
+                    )
                     if flake is not None:
                         update_flake(flake, test_instance)
                 elif test_instance.outcome in (
                     TestInstance.Outcome.FAILURE.value,
                     TestInstance.Outcome.ERROR.value,
                 ):
-                    flake = {**new_flakes, **curr_flakes}.get(test_instance.test_id)
+                    flake = new_flakes.get(test_instance.test_id) or curr_flakes.get(
+                        test_instance.test_id
+                    )
                     if flake:
                         update_flake(flake, test_instance)
                     else:

--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -407,7 +407,6 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
                         db_session,
                         repository,
                         pull.head,
-                        pull_dict["head"]["branch"],
                         current_yaml,
                     )
 
@@ -534,7 +533,6 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         db_session: sqlalchemy.orm.Session,
         repository: Repository,
         pull_head: str,
-        branch: str,
         current_yaml: UserYaml,
     ):
         if (
@@ -543,9 +541,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
             > 0
         ):
             self.app.tasks[process_flakes_task_name].apply_async(
-                kwargs=dict(
-                    repo_id=repository.repoid, commit_id_list=[pull_head], branch=branch
-                )
+                kwargs=dict(repo_id=repository.repoid, commit_id=pull_head)
             )
 
     def trigger_ai_pr_review(self, enriched_pull: EnrichedPull, current_yaml: UserYaml):

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -121,14 +121,14 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         assert commit, "commit not found"
         repo = commit.repository
 
-        if should_do_flaky_detection(repo, commit_yaml) and (
-            commit.merged is True or commit.branch == repo.branch
-        ):
-            self.app.tasks[process_flakes_task_name].apply_async(
-                kwargs=dict(
-                    repo_id=repoid, commit_id_list=[commit.commitid], branch=repo.branch
+        if should_do_flaky_detection(repo, commit_yaml):
+            if commit.merged is True or commit.branch == repo.branch:
+                self.app.tasks[process_flakes_task_name].apply_async(
+                    kwargs=dict(
+                        repo_id=repoid,
+                        commit_id=commit.commitid,
+                    )
                 )
-            )
 
         if commit.branch is not None:
             self.app.tasks[cache_test_rollups_task_name].apply_async(

--- a/tasks/tests/unit/test_process_flakes.py
+++ b/tasks/tests/unit/test_process_flakes.py
@@ -3,11 +3,17 @@ from collections import defaultdict
 
 import time_machine
 from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
-from shared.django_apps.reports.models import DailyTestRollup, Flake, TestInstance
+from shared.django_apps.reports.models import (
+    CommitReport,
+    DailyTestRollup,
+    Flake,
+    TestInstance,
+)
 from shared.django_apps.reports.tests.factories import (
     FlakeFactory,
     TestFactory,
     TestInstanceFactory,
+    UploadFactory,
 )
 
 from tasks.process_flakes import (
@@ -37,19 +43,22 @@ class RepoSimulator:
         self.test_count = 0
         return c
 
-    def merge(self, c):
-        c.merged = True
-        c.branch = self.repo.branch
-        c.save()
-        self.test_count = 0
-
-    def add_test_instance(self, c, outcome=TestInstance.Outcome.PASS.value):
+    def add_test_instance(
+        self, c, outcome=TestInstance.Outcome.PASS.value, state="processed"
+    ):
+        upload = UploadFactory(
+            report__commit=c,
+            report__report_type=CommitReport.ReportType.TEST_RESULTS.value,
+            state=state,
+        )
+        upload.save()
         ti = TestInstanceFactory(
             commitid=c.commitid,
             repoid=self.repo.repoid,
             branch=c.branch,
             outcome=outcome,
             test=self.test_map[self.test_count],
+            upload=upload,
         )
         ti.save()
 
@@ -121,18 +130,18 @@ def test_generate_flake_dict(transactional_db):
 def test_get_test_instances_when_test_is_flaky(transactional_db):
     repo = RepositoryFactory()
     commit = CommitFactory()
+    upload = UploadFactory(report__commit=commit)
 
     ti = TestInstanceFactory(
         commitid=commit.commitid,
         repoid=repo.repoid,
         branch="main",
         outcome=TestInstance.Outcome.FAILURE.value,
+        upload=upload,
     )
     ti.save()
 
-    tis = get_test_instances(
-        commit.commitid, repo.repoid, "main", flaky_tests=[ti.test_id]
-    )
+    tis = get_test_instances(upload, flaky_tests=[ti.test_id])
     assert len(tis) == 1
     assert tis[0].commitid
 
@@ -140,16 +149,18 @@ def test_get_test_instances_when_test_is_flaky(transactional_db):
 def test_get_test_instances_when_instance_is_failure(transactional_db):
     repo = RepositoryFactory()
     commit = CommitFactory()
+    upload = UploadFactory(report__commit=commit)
 
     ti = TestInstanceFactory(
         commitid=commit.commitid,
         repoid=repo.repoid,
         branch="main",
         outcome=TestInstance.Outcome.FAILURE.value,
+        upload=upload,
     )
     ti.save()
 
-    tis = get_test_instances(commit.commitid, repo.repoid, "main", flaky_tests=[])
+    tis = get_test_instances(upload, flaky_tests=[])
     assert len(tis) == 1
     assert tis[0].commitid
 
@@ -157,34 +168,36 @@ def test_get_test_instances_when_instance_is_failure(transactional_db):
 def test_get_test_instances_when_test_is_flaky_and_instance_is_skip(transactional_db):
     repo = RepositoryFactory()
     commit = CommitFactory()
+    upload = UploadFactory(report__commit=commit)
 
     ti = TestInstanceFactory(
         commitid=commit.commitid,
         repoid=repo.repoid,
         branch="main",
         outcome=TestInstance.Outcome.SKIP.value,
+        upload=upload,
     )
     ti.save()
 
-    tis = get_test_instances(
-        commit.commitid, repo.repoid, "main", flaky_tests=[ti.test_id]
-    )
+    tis = get_test_instances(upload, flaky_tests=[ti.test_id])
     assert len(tis) == 0
 
 
 def test_get_test_instances_when_instance_is_pass(transactional_db):
     repo = RepositoryFactory()
     commit = CommitFactory()
+    upload = UploadFactory(report__commit=commit)
 
     ti = TestInstanceFactory(
         commitid=commit.commitid,
         repoid=repo.repoid,
         branch="main",
         outcome=TestInstance.Outcome.PASS.value,
+        upload=upload,
     )
     ti.save()
 
-    tis = get_test_instances(commit.commitid, repo.repoid, "main", flaky_tests=[])
+    tis = get_test_instances(upload, flaky_tests=[])
     assert len(tis) == 0
 
 
@@ -221,51 +234,25 @@ def test_upsert_failed_flakes(transactional_db):
     upsert_failed_flake(ti, f, repo.repoid)
 
 
-def test_it_does_not_detect_unmerged_tests(transactional_db):
-    rs = RepoSimulator()
-    c1 = rs.create_commit()
-
-    rs.add_test_instance(c1)
-
-    rs.add_test_instance(c1)
-
-    ProcessFlakesTask().run_impl(
-        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
-    )
-
-    assert len(Flake.objects.all()) == 0
-
-
 def test_it_handles_only_passes(transactional_db):
     rs = RepoSimulator()
     c1 = rs.create_commit()
-
+    rs.add_test_instance(c1)
     rs.add_test_instance(c1)
 
-    rs.add_test_instance(c1)
-
-    rs.merge(c1)
-
-    ProcessFlakesTask().run_impl(
-        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
-    )
+    ProcessFlakesTask().run_impl(None, repo_id=rs.repo.repoid, commit_id=c1.commitid)
 
     assert len(Flake.objects.all()) == 0
 
 
 @time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
-def test_it_creates_flakes_from_orig_branch(transactional_db):
+def test_it_creates_flakes_from_processed_uploads(transactional_db):
     rs = RepoSimulator()
     c1 = rs.create_commit()
-    orig_branch = c1.branch
     rs.add_test_instance(c1)
     rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
-    rs.merge(c1)
-    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
 
-    ProcessFlakesTask().run_impl(
-        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=orig_branch
-    )
+    ProcessFlakesTask().run_impl(None, repo_id=rs.repo.repoid, commit_id=c1.commitid)
 
     assert len(Flake.objects.all()) == 1
     assert Flake.objects.first().count == 1
@@ -274,107 +261,42 @@ def test_it_creates_flakes_from_orig_branch(transactional_db):
 
 
 @time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
-def test_it_creates_flakes_from_new_branch_only(transactional_db):
+def test_it_does_not_create_flakes_from_flake_processed_uploads(transactional_db):
     rs = RepoSimulator()
     c1 = rs.create_commit()
-    orig_branch = c1.branch
     rs.add_test_instance(c1)
-    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
-    rs.merge(c1)
-    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
-
-    ProcessFlakesTask().run_impl(
-        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
+    rs.add_test_instance(
+        c1, outcome=TestInstance.Outcome.FAILURE.value, state="flake_processed"
     )
-
-    assert len(Flake.objects.all()) == 1
-    assert Flake.objects.first().count == 1
-    assert Flake.objects.first().fail_count == 1
-    assert Flake.objects.first().start_date == dt.datetime.now(dt.UTC)
-
-
-@time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
-def test_it_creates_flakes_fail_after_merge(transactional_db):
-    rs = RepoSimulator()
-    c1 = rs.create_commit()
-
-    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
-    rs.merge(c1)
-
-    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
-
-    ProcessFlakesTask().run_impl(
-        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
-    )
-
-    assert len(Flake.objects.all()) == 1
-    flake = Flake.objects.first()
-    assert flake.recent_passes_count == 0
-    assert flake.count == 1
-    assert flake.fail_count == 1
-    assert flake.start_date == dt.datetime.now(dt.UTC)
-
-    ProcessFlakesTask().run_impl(
-        None, repo_id=rs.repo.repoid, commit_id_list=[c1.commitid], branch=c1.branch
-    )
-
-    assert len(Flake.objects.all()) == 1
-    flake = Flake.objects.first()
-    assert flake.recent_passes_count == 0
-    assert flake.count == 2
-    assert flake.fail_count == 2
-    assert flake.start_date == dt.datetime.now(dt.UTC)
-
-
-@time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
-def test_it_processes_two_commits_together(transactional_db):
-    rs = RepoSimulator()
-    c1 = rs.create_commit()
-    rs.merge(c1)
-    rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
-
-    c2 = rs.create_commit()
-    rs.merge(c2)
-    rs.add_test_instance(c2, outcome=TestInstance.Outcome.FAILURE.value)
 
     ProcessFlakesTask().run_impl(
         None,
         repo_id=rs.repo.repoid,
-        commit_id_list=[c1.commitid, c2.commitid],
-        branch=c1.branch,
+        commit_id=c1.commitid,
     )
 
-    assert len(Flake.objects.all()) == 1
-    flake = Flake.objects.first()
-    assert flake.recent_passes_count == 0
-    assert flake.count == 2
-    assert flake.fail_count == 2
-    assert flake.start_date == dt.datetime.now(dt.UTC)
+    assert len(Flake.objects.all()) == 0
 
 
 @time_machine.travel(dt.datetime.now(tz=dt.UTC), tick=False)
 def test_it_processes_two_commits_separately(transactional_db):
     rs = RepoSimulator()
     c1 = rs.create_commit()
-    rs.merge(c1)
     rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
 
     ProcessFlakesTask().run_impl(
         None,
         repo_id=rs.repo.repoid,
-        commit_id_list=[c1.commitid],
-        branch=c1.branch,
+        commit_id=c1.commitid,
     )
 
     c2 = rs.create_commit()
-    rs.merge(c2)
     rs.add_test_instance(c2, outcome=TestInstance.Outcome.FAILURE.value)
 
     ProcessFlakesTask().run_impl(
         None,
         repo_id=rs.repo.repoid,
-        commit_id_list=[c2.commitid],
-        branch=c2.branch,
+        commit_id=c2.commitid,
     )
 
     assert len(Flake.objects.all()) == 1
@@ -390,14 +312,12 @@ def test_it_creates_flakes_expires(transactional_db):
         rs = RepoSimulator()
         commits = []
         c1 = rs.create_commit()
-        rs.merge(c1)
         rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
 
         ProcessFlakesTask().run_impl(
             None,
             repo_id=rs.repo.repoid,
-            commit_id_list=[c1.commitid],
-            branch=rs.repo.branch,
+            commit_id=c1.commitid,
         )
 
         old_time = dt.datetime.now(dt.UTC)
@@ -406,13 +326,14 @@ def test_it_creates_flakes_expires(transactional_db):
 
         for _ in range(0, 29):
             c = rs.create_commit()
-            rs.merge(c)
             rs.add_test_instance(c, outcome=TestInstance.Outcome.PASS.value)
             commits.append(c.commitid)
 
-        ProcessFlakesTask().run_impl(
-            None, repo_id=rs.repo.repoid, commit_id_list=commits, branch=rs.repo.branch
-        )
+            ProcessFlakesTask().run_impl(
+                None,
+                repo_id=rs.repo.repoid,
+                commit_id=c.commitid,
+            )
 
         assert len(Flake.objects.all()) == 1
         flake = Flake.objects.first()
@@ -423,14 +344,12 @@ def test_it_creates_flakes_expires(transactional_db):
         assert flake.end_date is None
 
         c = rs.create_commit()
-        rs.merge(c)
         rs.add_test_instance(c, outcome=TestInstance.Outcome.PASS.value)
 
         ProcessFlakesTask().run_impl(
             None,
             repo_id=rs.repo.repoid,
-            commit_id_list=[c.commitid],
-            branch=rs.repo.branch,
+            commit_id=c.commitid,
         )
 
         assert len(Flake.objects.all()) == 1
@@ -447,28 +366,24 @@ def test_it_creates_rollups(transactional_db):
         rs = RepoSimulator()
         commits = []
         c1 = rs.create_commit()
-        rs.merge(c1)
         rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
         rs.add_test_instance(c1, outcome=TestInstance.Outcome.FAILURE.value)
 
         ProcessFlakesTask().run_impl(
             None,
             repo_id=rs.repo.repoid,
-            commit_id_list=[c1.commitid],
-            branch=rs.repo.branch,
+            commit_id=c1.commitid,
         )
 
     with time_machine.travel("1970-1-2T00:00:00Z"):
         c2 = rs.create_commit()
-        rs.merge(c2)
         rs.add_test_instance(c2, outcome=TestInstance.Outcome.FAILURE.value)
         rs.add_test_instance(c2, outcome=TestInstance.Outcome.FAILURE.value)
 
         ProcessFlakesTask().run_impl(
             None,
             repo_id=rs.repo.repoid,
-            commit_id_list=[c2.commitid],
-            branch=rs.repo.branch,
+            commit_id=c2.commitid,
         )
 
         rollups = DailyTestRollup.objects.all().order_by("date")

--- a/tasks/tests/unit/test_sync_pull.py
+++ b/tasks/tests/unit/test_sync_pull.py
@@ -139,8 +139,7 @@ def test_update_pull_commits_merged(
         apply_async.assert_called_once_with(
             kwargs=dict(
                 repo_id=repository.repoid,
-                commit_id_list=[head_commit.commitid],
-                branch="thing",
+                commit_id=head_commit.commitid,
             )
         )
     else:
@@ -550,15 +549,13 @@ def test_trigger_process_flakes(dbsession, mocker, flake_detection, repository):
         dbsession,
         repository,
         commit.commitid,
-        "main",
         current_yaml,
     )
     if flake_detection:
         apply_async.assert_called_once_with(
             kwargs=dict(
                 repo_id=repository.repoid,
-                commit_id_list=[commit.commitid],
-                branch="main",
+                commit_id=commit.commitid,
             )
         )
     else:

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -992,8 +992,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         ].apply_async.assert_called_with(
             kwargs={
                 "repo_id": repoid,
-                "commit_id_list": [commit.commitid],
-                "branch": "main",
+                "commit_id": commit.commitid,
             },
         )
         test_results_mock_app.tasks[
@@ -1180,7 +1179,6 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         ].apply_async.assert_called_with(
             kwargs={
                 "repo_id": repoid,
-                "commit_id_list": [commit.commitid],
-                "branch": "main",
+                "commit_id": commit.commitid,
             },
         )


### PR DESCRIPTION
we want to process test instances related to an upload only once. If an upload has already been taken into account we don't want to take them into account again.

we are still only processing test instances that are related to code that is on the main branch since this task is only being run when:
- we receive a sync pulls task for the PR associated with this commit (merge existing test instances)
- we process test results for this commit that come from the main branch (we receive new relevant test instances)

This PR then refactors the process flakes task to use bulk create and update for general efficiency and also commits the transaction after processing a single upload since that should be smallest unit of work that must get done