### PR TITLE
use new UploadErrorCode value for processing timeouts

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -678,6 +678,17 @@ class ReportService(BaseReportService):
             result.error = ProcessingError(code=UploadErrorCode.REPORT_EMPTY, params={})
             raw_report_info.error = result.error
             return result
+        except SoftTimeLimitExceeded as e:
+            sentry_sdk.capture_exception(e)
+            log.warning(
+                "Timed out while processing report", extra=dict(reportid=reportid)
+            )
+            result.error = ProcessingError(
+                code=UploadErrorCode.PROCESSING_TIMEOUT, params={}
+            )
+            raw_report_info.error = result.error
+            # Return and attempt to save the error result rather than re-raise
+            return result
         except Exception as e:
             sentry_sdk.capture_exception(e)
             log.exception(


### PR DESCRIPTION
sibling PRs:
- https://github.com/codecov/gazebo/pull/3522
- https://github.com/codecov/shared/pull/431
- https://github.com/codecov/codecov-api/pull/1036

merge after the API PR has been deployed

when we receive a `SoftTimeLimitExceeded` exception we will now attempt to stop and save an upload error, but it's possible that we will get a hard timeout before we can actually commit. so there may still be timeouts that aren't properly coded. but hopefully for a lot of them we can display something more descriptive