### PR TITLE
Resolve notifier `pull` on demand

### DIFF
--- a/services/test_results.py
+++ b/services/test_results.py
@@ -296,10 +296,6 @@ class TestResultsNotifier(BaseNotifier):
     def error_comment(self):
         pull = self.get_pull()
         if pull is None:
-            log.info(
-                "Not notifying since there is no pull request associated with this commit",
-                extra=dict(commitid=self.commit.commitid),
-            )
             return False, "no_pull"
 
         message = ":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."
@@ -313,10 +309,6 @@ class TestResultsNotifier(BaseNotifier):
     def upgrade_comment(self):
         pull = self.get_pull()
         if pull is None:
-            log.info(
-                "Not notifying since there is no pull request associated with this commit",
-                extra=dict(commitid=self.commit.commitid),
-            )
             return False, "no_pull"
 
         db_pull = pull.database_pull


### PR DESCRIPTION
A recent change to load the `repo_provider` and `pull` ahead of time regressed the happy path of test results when no test failures are present. In that case, no notification has to be performed, so no `repo_provider` or `pull` is needed.

Additionally to fixing this regression, this also fixes the case when the `pull` is legitimately `None`, but the on-demand loading was trying to fetch it once again.

---

fixes a slight regression from https://github.com/codecov/worker/pull/924