### PR TITLE
build: upload test results first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -232,8 +232,8 @@ test_env.run_integration:
 	docker-compose exec worker make test.integration
 
 test_env.upload:
-	docker-compose exec worker make test_env.container_upload CODECOV_UPLOAD_TOKEN=${CODECOV_UPLOAD_TOKEN} CODECOV_URL=${CODECOV_URL}
 	docker-compose exec worker make test_env.container_upload_test_results CODECOV_UPLOAD_TOKEN=${CODECOV_UPLOAD_TOKEN} CODECOV_URL=${CODECOV_URL}
+	docker-compose exec worker make test_env.container_upload CODECOV_UPLOAD_TOKEN=${CODECOV_UPLOAD_TOKEN} CODECOV_URL=${CODECOV_URL}
 
 test_env.container_upload:
 	codecovcli -u ${CODECOV_URL} do-upload --flag unit --file unit.coverage.xml --disable-search


### PR DESCRIPTION
this is so if there are failures and issues with uploading coverage at least the PR comment for test results will be accurate.

It makes sense for all users to upload their test results first, then their coverage