### PR TITLE
Update CI to expose JUnit artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,11 +24,11 @@ jobs:
   lint:
     name: Run Lint
 
-    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.26
+    uses: codecov/gha-workflows/.github/workflows/lint.yml@v1.2.27
 
   build:
     name: Build Worker
-    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.26
+    uses: codecov/gha-workflows/.github/workflows/build-app.yml@v1.2.27
 
     secrets: inherit
     with:
@@ -37,14 +37,14 @@ jobs:
   codecovstartup:
     name: Codecov Startup
     needs: build
-    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.26
+    uses: codecov/gha-workflows/.github/workflows/codecov-startup.yml@v1.2.27
 
     secrets: inherit
 
   test:
     name: Test
     needs: [build]
-    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.26
+    uses: codecov/gha-workflows/.github/workflows/run-tests.yml@v1.2.27
 
     secrets: inherit
     with:
@@ -54,7 +54,7 @@ jobs:
     name: Build Self Hosted Worker
     needs: [build, test]
 
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.26
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.27
     secrets: inherit
     with:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
@@ -63,7 +63,7 @@ jobs:
     name: Push Staging Image
     needs: [build, test]
     if: ${{ github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/staging') && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.26
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.27
     secrets: inherit
     with:
       environment: staging
@@ -73,7 +73,7 @@ jobs:
     name: Push Production Image
     needs: [build, test]
     if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.26
+    uses: codecov/gha-workflows/.github/workflows/push-env.yml@v1.2.27
     secrets: inherit
     with:
       environment: production
@@ -84,7 +84,7 @@ jobs:
     needs: [build-self-hosted, test]
     secrets: inherit
     if: ${{ github.event_name == 'push' && github.event.ref == 'refs/heads/main' && github.repository_owner == 'codecov' }}
-    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.26
+    uses: codecov/gha-workflows/.github/workflows/self-hosted.yml@v1.2.27
     with:
       push_rolling: true
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}


### PR DESCRIPTION
This will allow us to download the junit xml files that gets generated during CI run. Having the raw file will be useful for debugging test analytics stuff.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.