### PR TITLE
Add Impact Analysis Deprecation Message to end of comments

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -8,3 +8,7 @@ CARRYFORWARD_BASE_SEARCH_RANGE_BY_OWNER = Feature("carryforward_base_search_rang
 SYNC_PULL_USE_MERGE_COMMIT_SHA = Feature("sync_pull_use_merge_commit_sha")
 
 CHECKPOINT_ENABLED_REPOSITORIES = Feature("checkpoint_enabled_repositories")
+
+SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG = Feature(
+    "show_impact_analysis_deprecation_message"
+)

--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -9,6 +9,7 @@ from shared.validation.helpers import LayoutStructure
 from database.models.core import Owner
 from helpers.environment import is_enterprise
 from helpers.metrics import metrics
+from rollouts import SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG
 from services.comparison import ComparisonProxy, FilteredComparison
 from services.notification.notifiers.mixins.message.helpers import (
     should_message_be_compact,
@@ -179,7 +180,20 @@ class MessageMixin(object):
                         section_writer,
                     )
 
+        self._possibly_write_impact_analysis_deprecation(comparison, write)
+
         return [m for m in message if m is not None]
+
+    def _possibly_write_impact_analysis_deprecation(self, comparison, write):
+        # CAN BE REMOVED AFTER January 31st 2025
+        # Will only be shown to orgs specified in the feature flag override.
+        repo: Repository = comparison.head.commit.repository
+        if SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG.check_value(
+            identifier=repo.repoid, default=False
+        ):
+            write(
+                ":warning: Impact Analysis from Codecov is deprecated and will be sunset on Jan 31 2025. [See more](https://docs.codecov.com/docs/impact-analysis)"
+            )
 
     def _possibly_write_install_app(
         self, comparison: ComparisonProxy, write: Callable
@@ -229,7 +243,7 @@ class MessageMixin(object):
                     current_yaml=current_yaml,
                 )
             )
-            message.extend(line for line in writer_class.footer_lines())
+            message.extend(line for line in writer_class.footer_lines(comparison))
 
             return message
 

--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -9,8 +9,10 @@ from urllib.parse import urlencode
 from shared.helpers.yaml import walk
 from shared.reports.resources import Report
 
+from database.models import Repository
 from helpers.environment import is_enterprise
 from helpers.reports import get_totals_from_file_in_reports
+from rollouts import SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG
 from services.comparison import ComparisonProxy
 from services.comparison.overlays import OverlayType
 from services.comparison.types import ReportUploadedCount
@@ -103,6 +105,16 @@ class NewFooterSectionWriter(BaseSectionWriter):
                     if repo_service == "github"
                     else "https://gitlab.com/codecov-open-source/codecov-user-feedback/-/issues/4"
                 )
+            )
+
+        # CAN BE REMOVED AFTER January 31st 2025
+        # Will only be shown to orgs specified in the feature flag override.
+        repo: Repository = comparison.head.commit.repository
+        if SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG.check_value(
+            identifier=repo.repoid, default=False
+        ):
+            yield (
+                ":warning: Impact Analysis from Codecov is deprecated and will be sunset on Jan 31 2025. [See more](https://docs.codecov.com/docs/impact-analysis)"
             )
 
 

--- a/services/notification/notifiers/mixins/message/writers.py
+++ b/services/notification/notifiers/mixins/message/writers.py
@@ -5,7 +5,9 @@ from typing import List
 
 from shared.reports.resources import Report
 
+from database.models import Repository
 from helpers.reports import get_totals_from_file_in_reports
+from rollouts import SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG
 from services.comparison import ComparisonProxy
 from services.notification.notifiers.mixins.message.helpers import (
     ellipsis,
@@ -138,7 +140,7 @@ class TeamPlanWriter:
 
         return lines
 
-    def footer_lines(self) -> List[str]:
+    def footer_lines(self, comparison: ComparisonProxy) -> List[str]:
         lines = []
         lines.append("")
         lines.append(
@@ -146,5 +148,13 @@ class TeamPlanWriter:
                 "https://github.com/codecov/feedback/issues/255"
             )
         )
-
+        # CAN BE REMOVED AFTER January 31st 2025
+        # Will only be shown to orgs specified in the feature flag override.
+        repo: Repository = comparison.head.commit.repository
+        if SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG.check_value(
+            identifier=repo.repoid, default=False
+        ):
+            lines.append(
+                ":warning: Impact Analysis from Codecov is deprecated and will be sunset on Jan 31 2025. [See more](https://docs.codecov.com/docs/impact-analysis)"
+            )
         return lines


### PR DESCRIPTION
This is going to only be restricted to certain repos (specified in Feature Flag). And this is temporary, so there's a note to remove this code after a particular date.

Ref: https://github.com/codecov/engineering-team/issues/2987

<!-- Describe your PR here. -->



<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.