### PR TITLE
fix: test results processor return type

### DIFF
--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -360,7 +360,7 @@ class TestUploadTestFinisherTask(object):
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -486,7 +486,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -541,9 +541,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": False}],
-            ],
+            [False],
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -627,7 +625,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -681,7 +679,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -807,7 +805,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -883,7 +881,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -972,7 +970,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -1032,9 +1030,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            [True],
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -1160,7 +1156,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -70,11 +70,7 @@ class TestUploadTestProcessorTask(object):
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -93,7 +89,7 @@ class TestUploadTestProcessorTask(object):
             failures[0].test.name
             == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
-        assert expected_result == result
+        assert result is True
         assert commit.message == "hello world"
         assert (
             mock_storage.read_file("archive", url)
@@ -152,7 +148,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
         dbsession.add(current_report_row)
         dbsession.flush()
 
-        result = TestResultsProcessorTask().run_impl(
+        _ = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -208,11 +204,6 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
 
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
@@ -220,7 +211,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             dbsession.query(TestInstance).filter_by(outcome=str(Outcome.Failure)).all()
         )
 
-        assert result == expected_result
+        assert result is True
 
         assert len(tests) == 4
         assert len(test_instances) == 4
@@ -281,9 +272,8 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [{"successful": False}]
 
-        assert expected_result == result
+        assert result == False
         assert (
             "No test result files were successfully parsed for this upload"
             in caplog.text
@@ -350,11 +340,6 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -373,7 +358,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             failures[0].test.name
             == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
-        assert expected_result == result
+        assert result is True
         assert commit.message == "hello world"
 
     @pytest.mark.integration
@@ -444,11 +429,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -477,7 +458,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             failures[0].test.name
             == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
-        assert expected_result == result
+        assert result is True
         assert commit.message == "hello world"
 
     @pytest.mark.integration
@@ -532,11 +513,6 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
                 commit_yaml={"codecov": {"max_report_age": False}},
                 arguments_list=redis_queue,
             )
-            expected_result = [
-                {
-                    "successful": True,
-                }
-            ]
 
             rollups = dbsession.query(DailyTestRollup).all()
 
@@ -591,13 +567,8 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
                 commit_yaml={"codecov": {"max_report_age": False}},
                 arguments_list=redis_queue,
             )
-            expected_result = [
-                {
-                    "successful": True,
-                }
-            ]
 
-            assert result == expected_result
+            assert result is True
 
             rollups_first_branch: list[DailyTestRollup] = (
                 dbsession.query(DailyTestRollup).filter_by(branch="first_branch").all()
@@ -701,11 +672,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -730,7 +697,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             failures[0].test.name
             == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
-        assert expected_result == result
+        assert result is True
         assert commit.message == "hello world"
 
         assert mock_storage.read_file("archive", url).startswith(
@@ -784,9 +751,8 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [[]]
 
-        assert expected_result == result
+        assert result is False
 
     @pytest.mark.integration
     def test_upload_processor_task_call_already_processed_with_junit(
@@ -847,15 +813,10 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
 
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
 
-        assert expected_result == result
+        assert result is True
         assert len(tests) == 4
         assert len(test_instances) == 4


### PR DESCRIPTION
there's a sentry bug currently happening because the finisher is not handling one of the possible return values of the processor

so i'm generally changing this to make it clearer:
- a processor either succeeds or fails, and this is represented by the return value being a boolean
  - a success means that the processor successfully parsed at least one file in any of the raw uploads it was processing
  - else, fail
- since the finisher is called in a chord with the processor it will receive a list of such booleans, if there is any success in this list of results then there is some valid test result data
- otherwise, we can just fail the finisher and make an error comment and try to notify coverage since there may be some valid coverage data