### PR TITLE
feat: don't send autoactivate pr comment if owner autoactivate is off

### DIFF
--- a/services/notification/notifiers/comment/__init__.py
+++ b/services/notification/notifiers/comment/__init__.py
@@ -24,6 +24,7 @@ from services.notification.notifiers.comment.conditions import (
     ComparisonHasPull,
     HasEnoughBuilds,
     HasEnoughRequiredChanges,
+    NoAutoActivateMessageIfAutoActivateIsOff,
     NotifyCondition,
     PullHeadMatchesComparisonHead,
     PullRequestInProvider,
@@ -47,6 +48,7 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
         PullHeadMatchesComparisonHead,
         HasEnoughBuilds,
         HasEnoughRequiredChanges,
+        NoAutoActivateMessageIfAutoActivateIsOff,
     ]
 
     def store_results(self, comparison: ComparisonProxy, result: NotificationResult):


### PR DESCRIPTION
"I think, for now, we just shouldn't send this PR comment (but still send statuses!) in the event that auto activate is disabled on the org repo settings."
