### PR TITLE
fix: only query tests if flake detection enabled

### DIFF
--- a/tasks/process_flakes.py
+++ b/tasks/process_flakes.py
@@ -103,7 +103,9 @@ def get_test_instances(
         TestInstance.objects.filter(
             repo_commit_branch_filter
             & (test_failed_filter | test_passed_but_flaky_filter)
-        ).all()
+        )
+        .select_related("test")
+        .all()
     )
     return test_instances
 

--- a/tasks/tests/unit/test_sync_pull.py
+++ b/tasks/tests/unit/test_sync_pull.py
@@ -542,7 +542,12 @@ def test_trigger_process_flakes(dbsession, mocker, flake_detection, repository):
         task.app.tasks["app.tasks.flakes.ProcessFlakesTask"], "apply_async"
     )
 
+    if flake_detection:
+        TestFactory.create(repository=repository)
+        dbsession.flush()
+
     task.trigger_process_flakes(
+        dbsession,
         repository,
         commit.commitid,
         "main",


### PR DESCRIPTION
this was previously always running the reports test query but we don't need to query it if flake detection is not enabled