### PR TITLE
feat(ta): stop handling old format in finisher

### DIFF
--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -348,8 +348,9 @@ class ReducedError(CodecovBaseModel):
         return self.id_
 
 
-class Flake(CodecovBaseModel, MixinBaseClassNoExternalID):
+class Flake(CodecovBaseModel):
     __tablename__ = "reports_flake"
+    id_ = Column("id", types.BigInteger, primary_key=True)
     repoid = Column(types.Integer, ForeignKey("repos.repoid"))
     repository = relationship("Repository", backref=backref("flakes"))
 
@@ -366,6 +367,10 @@ class Flake(CodecovBaseModel, MixinBaseClassNoExternalID):
     fail_count = Column(types.Integer)
     start_date = Column(types.DateTime)
     end_date = Column(types.DateTime, nullable=True)
+
+    @property
+    def id(self):
+        return self.id_
 
 
 class DailyTestRollup(CodecovBaseModel, MixinBaseClassNoExternalID):

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/c840502d1b4dd7d05b2efc2c1328affaf2acd27c.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/e41a4a1d4dd4efe44a917b47032f1a0d73775426.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/2674ae99811767e63151590906691aed4c5ce1f9.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -328,7 +328,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.6.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/e41a4a1d4dd4efe44a917b47032f1a0d73775426.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/2674ae99811767e63151590906691aed4c5ce1f9.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -339,6 +339,7 @@ def test_results_setup_no_instances(mocker, dbsession):
 class TestUploadTestFinisherTask(object):
     @pytest.mark.integration
     @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.parametrize("successful", [True, [{"successful": True}]])
     def test_upload_finisher_task_call(
         self,
         mocker,
@@ -351,6 +352,7 @@ class TestUploadTestFinisherTask(object):
         test_results_mock_app,
         mock_repo_provider_comments,
         test_results_setup,
+        successful,
     ):
         mock_feature = mocker.patch("services.test_results.FLAKY_TEST_DETECTION")
         mock_feature.check_value.return_value = False
@@ -360,7 +362,7 @@ class TestUploadTestFinisherTask(object):
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                successful,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -486,7 +488,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -541,9 +543,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": False}],
-            ],
+            [False],
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -627,7 +627,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -681,7 +681,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -807,7 +807,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -883,7 +883,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -972,7 +972,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,
@@ -1032,9 +1032,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            [True],
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -1160,7 +1158,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                [{"successful": True}],
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -339,7 +339,6 @@ def test_results_setup_no_instances(mocker, dbsession):
 class TestUploadTestFinisherTask(object):
     @pytest.mark.integration
     @pytest.mark.django_db(databases={"default"})
-    @pytest.mark.parametrize("successful", [True, [{"successful": True}]])
     def test_upload_finisher_task_call(
         self,
         mocker,
@@ -362,7 +361,7 @@ class TestUploadTestFinisherTask(object):
         result = TestResultsFinisherTask().run_impl(
             dbsession,
             [
-                successful,
+                True,
             ],
             repoid=repoid,
             commitid=commit.commitid,

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -70,11 +70,7 @@ class TestUploadTestProcessorTask(object):
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -93,7 +89,7 @@ class TestUploadTestProcessorTask(object):
             failures[0].test.name
             == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
-        assert expected_result == result
+        assert result is True
         assert commit.message == "hello world"
         assert (
             mock_storage.read_file("archive", url)
@@ -152,7 +148,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
         dbsession.add(current_report_row)
         dbsession.flush()
 
-        result = TestResultsProcessorTask().run_impl(
+        _ = TestResultsProcessorTask().run_impl(
             dbsession,
             repoid=commit.repoid,
             commitid=commit.commitid,
@@ -208,11 +204,6 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
 
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
@@ -220,7 +211,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             dbsession.query(TestInstance).filter_by(outcome=str(Outcome.Failure)).all()
         )
 
-        assert result == expected_result
+        assert result is True
 
         assert len(tests) == 4
         assert len(test_instances) == 4
@@ -281,9 +272,8 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [{"successful": False}]
 
-        assert expected_result == result
+        assert result == False
         assert (
             "No test result files were successfully parsed for this upload"
             in caplog.text
@@ -350,11 +340,6 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -373,7 +358,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             failures[0].test.name
             == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
-        assert expected_result == result
+        assert result is True
         assert commit.message == "hello world"
 
     @pytest.mark.integration
@@ -444,11 +429,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -477,7 +458,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             failures[0].test.name
             == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
-        assert expected_result == result
+        assert result is True
         assert commit.message == "hello world"
 
     @pytest.mark.integration
@@ -532,11 +513,6 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
                 commit_yaml={"codecov": {"max_report_age": False}},
                 arguments_list=redis_queue,
             )
-            expected_result = [
-                {
-                    "successful": True,
-                }
-            ]
 
             rollups = dbsession.query(DailyTestRollup).all()
 
@@ -591,13 +567,8 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
                 commit_yaml={"codecov": {"max_report_age": False}},
                 arguments_list=redis_queue,
             )
-            expected_result = [
-                {
-                    "successful": True,
-                }
-            ]
 
-            assert result == expected_result
+            assert result is True
 
             rollups_first_branch: list[DailyTestRollup] = (
                 dbsession.query(DailyTestRollup).filter_by(branch="first_branch").all()
@@ -701,11 +672,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -730,7 +697,7 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             failures[0].test.name
             == "api.temp.calculator.test_calculator\x1ftest_divide"
         )
-        assert expected_result == result
+        assert result is True
         assert commit.message == "hello world"
 
         assert mock_storage.read_file("archive", url).startswith(
@@ -784,9 +751,8 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [[]]
 
-        assert expected_result == result
+        assert result is False
 
     @pytest.mark.integration
     def test_upload_processor_task_call_already_processed_with_junit(
@@ -847,15 +813,10 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
 
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
 
-        assert expected_result == result
+        assert result is True
         assert len(tests) == 4
         assert len(test_instances) == 4


### PR DESCRIPTION
after the processor change will have fully deployed and every processor
is outputting bool as its result we no longer have to handle the old
prev result format so we can remove the code that does that in the
finisher