### PR TITLE
Remove the Impact Analysis Deprecation from footer

### DIFF
--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -9,10 +9,8 @@ from urllib.parse import urlencode
 from shared.helpers.yaml import walk
 from shared.reports.resources import Report
 
-from database.models import Repository
 from helpers.environment import is_enterprise
 from helpers.reports import get_totals_from_file_in_reports
-from rollouts import SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG
 from services.comparison import ComparisonProxy
 from services.comparison.overlays import OverlayType
 from services.comparison.types import ReportUploadedCount
@@ -105,16 +103,6 @@ class NewFooterSectionWriter(BaseSectionWriter):
                     if repo_service == "github"
                     else "https://gitlab.com/codecov-open-source/codecov-user-feedback/-/issues/4"
                 )
-            )
-
-        # CAN BE REMOVED AFTER January 31st 2025
-        # Will only be shown to orgs specified in the feature flag override.
-        repo: Repository = comparison.head.commit.repository
-        if SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG.check_value(
-            identifier=repo.repoid, default=False
-        ):
-            yield (
-                ":warning: Impact Analysis from Codecov is deprecated and will be sunset on Jan 31 2025. [See more](https://docs.codecov.com/docs/impact-analysis)"
             )
 
 

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -3898,7 +3898,6 @@ class TestNewFooterSectionWriter(object):
             "",
             "[:umbrella: View full report in Codecov by Sentry](pull.link?dropdown=coverage&src=pr&el=continue).   ",
             ":loudspeaker: Have feedback on the report? [Share it here](https://about.codecov.io/codecov-pr-comment-feedback/).",
-            ":warning: Impact Analysis from Codecov is deprecated and will be sunset on Jan 31 2025. [See more](https://docs.codecov.com/docs/impact-analysis)",
         ]
 
     def test_footer_section_writer_in_gitlab(self, mocker):


### PR DESCRIPTION
This was duplicated because it's also added at the end of the message. So, removing this from the footer to ensure that the message is on more comments. It is being hidden by a feature flag that checks for eligible repos, so the impact of this change should be fairly low.

See this PR for an example of the duplicate message: https://github.com/codecov/worker/pull/964#issuecomment-2549084965

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.