### PR TITLE
fix: call ta processors using chain

### DIFF
--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import mock
 import pytest
 from celery.exceptions import Retry
+from mock import call
 from redis.exceptions import LockError
 from shared.reports.enums import UploadState, UploadType
 from shared.torngit import GitlabEnterprise
@@ -357,7 +358,7 @@ class TestUploadTaskIntegration(object):
                 "upload_pk": None,
             },
         )
-        chain.assert_called_with([processor_sig])
+        assert call([processor_sig]) in chain.mock_calls
 
     def test_upload_task_call_test_results(
         self,
@@ -369,7 +370,7 @@ class TestUploadTaskIntegration(object):
         mock_redis,
         celery_app,
     ):
-        chord = mocker.patch("tasks.upload.chord")
+        chord = mocker.patch("tasks.upload.chain")
         storage_path = "v4/raw/2019-05-22/C3C4715CA57C910D11D5EB899FC86A7E/4c4e4654ac25037ae869caeb3619d485970b6304/a84d445c-9c1e-434f-8275-f18f1f320f81.txt"
         redis_queue = [{"url": storage_path, "build_code": "some_random_build"}]
         jsonified_redis_queue = [json.dumps(x) for x in redis_queue]

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -665,7 +665,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             "commit_yaml": commit_yaml,
         }
         finisher_kwargs = TestResultsFlow.save_to_kwargs(finisher_kwargs)
-        return chord(
+        return chain(
             processor_task_group,
             test_results_finisher_task.signature(kwargs=finisher_kwargs),
         ).apply_async()


### PR DESCRIPTION
we don't want to call the ta processors using a chord because we want to temporarily reduce the amount of lock contention in the database

this is a short term fix, we eventually want to move the test results writes to the finisher step, which will achieve the same effect as this fix
