### PR TITLE
fix: test analytics chain prev result handling

### DIFF
--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -359,9 +359,7 @@ class TestUploadTestFinisherTask(object):
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            True,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -485,9 +483,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            True,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -541,9 +537,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": False}],
-            ],
+            False,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -626,9 +620,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            True,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -680,9 +672,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            True,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -806,9 +796,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            True,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -882,9 +870,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            True,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={
@@ -971,9 +957,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            True,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml=commit_yaml,
@@ -1031,9 +1015,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            True,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
@@ -1158,9 +1140,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
         dbsession.flush()
         result = TestResultsFinisherTask().run_impl(
             dbsession,
-            [
-                [{"successful": True}],
-            ],
+            True,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml=commit_yaml,

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -65,16 +65,13 @@ class TestUploadTestProcessorTask(object):
         dbsession.flush()
         result = TestResultsProcessorTask().run_impl(
             dbsession,
+            previous_result=False,
             repoid=upload.report.commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+        expected_result = True
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -154,13 +151,16 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
 
         result = TestResultsProcessorTask().run_impl(
             dbsession,
+            previous_result=False,
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
+
         print(caplog.text)
         assert "Error parsing file" in caplog.text
+        assert result == False
 
     @pytest.mark.integration
     def test_test_result_processor_task_delete_archive(
@@ -203,16 +203,13 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
         dbsession.flush()
         result = TestResultsProcessorTask().run_impl(
             dbsession,
+            previous_result=False,
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+        expected_result = True
 
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
@@ -276,12 +273,13 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
         dbsession.flush()
         result = TestResultsProcessorTask().run_impl(
             dbsession,
+            previous_result=False,
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [{"successful": False}]
+        expected_result = False
 
         assert expected_result == result
         assert (
@@ -345,16 +343,13 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
 
         result = TestResultsProcessorTask().run_impl(
             dbsession,
+            previous_result=False,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+        expected_result = True
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -439,16 +434,13 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
 
         result = TestResultsProcessorTask().run_impl(
             dbsession,
+            previous_result=False,
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+        expected_result = True
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -527,16 +519,13 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
 
             result = TestResultsProcessorTask().run_impl(
                 dbsession,
+                previous_result=False,
                 repoid=repoid,
                 commitid=first_commit.commitid,
                 commit_yaml={"codecov": {"max_report_age": False}},
                 arguments_list=redis_queue,
             )
-            expected_result = [
-                {
-                    "successful": True,
-                }
-            ]
+            expected_result = True
 
             rollups = dbsession.query(DailyTestRollup).all()
 
@@ -586,16 +575,13 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
 
             result = TestResultsProcessorTask().run_impl(
                 dbsession,
+                previous_result=False,
                 repoid=repoid,
                 commitid=second_commit.commitid,
                 commit_yaml={"codecov": {"max_report_age": False}},
                 arguments_list=redis_queue,
             )
-            expected_result = [
-                {
-                    "successful": True,
-                }
-            ]
+            expected_result = True
 
             assert result == expected_result
 
@@ -696,16 +682,13 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
         dbsession.flush()
         result = TestResultsProcessorTask().run_impl(
             dbsession,
+            previous_result=False,
             repoid=upload.report.commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+        expected_result = True
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()
         failures = (
@@ -779,12 +762,13 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
         dbsession.flush()
         result = TestResultsProcessorTask().run_impl(
             dbsession,
+            previous_result=False,
             repoid=upload.report.commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [[]]
+        expected_result = True
 
         assert expected_result == result
 
@@ -842,16 +826,13 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
         dbsession.flush()
         result = TestResultsProcessorTask().run_impl(
             dbsession,
+            previous_result=False,
             repoid=upload.report.commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
             arguments_list=redis_queue,
         )
-        expected_result = [
-            {
-                "successful": True,
-            }
-        ]
+        expected_result = True
 
         tests = dbsession.query(Test).all()
         test_instances = dbsession.query(TestInstance).all()

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -408,6 +408,7 @@ class TestUploadTaskIntegration(object):
         assert len(uploads) == 1
         upload = dbsession.query(Upload).filter_by(report_id=commit_report.id).first()
         processor_sig = test_results_processor_task.s(
+            False,
             repoid=commit.repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": "1y ago"}},

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -659,6 +659,8 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             for chunk in itertools.batched(argument_list, CHUNK_SIZE)
         ]
 
+        task_group[0].args = (False,)
+
         finisher_kwargs = {
             "repoid": commit.repoid,
             "commitid": commit.commitid,


### PR DESCRIPTION
i previously forgot that chains pass through a single previous result through all the tasks so this commit fixes that

we pass a boolean that at first is false, if at any point there is a single parsing success then it becomes true and means there was at least one success in parsing a test results file

the finisher then replaces the call to check_if_no_success with checking if the previous result is false
