### PR TITLE
Making log context able to be disabled.

### DIFF
--- a/helpers/log_context.py
+++ b/helpers/log_context.py
@@ -4,6 +4,7 @@ from dataclasses import asdict, dataclass, field, replace
 
 import sentry_sdk
 from sentry_sdk import get_current_span
+from shared.config import get_config
 
 from database.models.core import Commit, Owner, Repository
 
@@ -51,7 +52,9 @@ class LogContext:
 
         Ignore exceptions; no need to fail a task for a missing context field.
         """
-        if self._populated_from_db:
+        if self._populated_from_db or not get_config(
+            "setup", "log_context", "populate", default=True
+        ):
             return
 
         try:

--- a/helpers/tests/unit/test_log_context.py
+++ b/helpers/tests/unit/test_log_context.py
@@ -208,4 +208,6 @@ def test_log_context_populate_from_sqlalchemy_is_disabled(
         "owner_username": None,
         "owner_service": None,
         "sentry_trace_id": None,
+        "checkpoints_data": {},
+        "owner_plan": None,
     }

--- a/helpers/tests/unit/test_log_context.py
+++ b/helpers/tests/unit/test_log_context.py
@@ -187,3 +187,25 @@ def test_add_to_sentry(dbsession, mocker):
     expected_sentry_fields.pop("sentry_trace_id")
     expected_sentry_fields.pop("checkpoints_data")
     mock_set_tags.assert_called_with(expected_sentry_fields)
+
+
+def test_log_context_populate_from_sqlalchemy_is_disabled(
+    mock_configuration, dbsession
+):
+    mock_configuration.set_params({"setup": {"log_context": {"populate": False}}})
+    log_context = LogContext(task_name="foo", task_id="bar")
+    log_context.populate_from_sqlalchemy(dbsession)
+
+    assert log_context == LogContext(task_name="foo", task_id="bar")
+    assert log_context.as_dict() == {
+        "task_name": "foo",
+        "task_id": "bar",
+        "commit_id": None,
+        "commit_sha": None,
+        "repo_id": None,
+        "repo_name": None,
+        "owner_id": None,
+        "owner_username": None,
+        "owner_service": None,
+        "sentry_trace_id": None,
+    }


### PR DESCRIPTION
<!-- Describe your PR here. -->

Make log context disableable in the case we want to test perf with it off.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.