### PR TITLE
Use billiard>=4.2.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -3,6 +3,7 @@ https://github.com/codecov/shared/archive/2674ae99811767e63151590906691aed4c5ce1
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1
+billiard>=4.2.1
 boto3>=1.34
 celery>=5.3.6
 click

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,10 @@ asgiref==3.7.2
     #   django
 backoff==1.6.0
     # via analytics-python
-billiard==4.2.0
-    # via celery
+billiard==4.2.1
+    # via
+    #   -r requirements.in
+    #   celery
 boto3==1.34.73
     # via
     #   -r requirements.in


### PR DESCRIPTION
Celery billiard has a bug where billiard.util.get_logger() is broken for Python 3.13.

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.