### PR TITLE
fix: remove test count query from sync pull

### DIFF
--- a/tasks/sync_pull.py
+++ b/tasks/sync_pull.py
@@ -17,7 +17,7 @@ from shared.yaml import UserYaml
 from shared.yaml.user_yaml import OwnerContext
 
 from app import celery_app
-from database.models import Commit, Pull, Repository, Test
+from database.models import Commit, Pull, Repository
 from helpers.exceptions import NoConfiguredAppsAvailable, RepositoryWithoutValidBotError
 from helpers.github_installation import get_installation_name_for_owner_for_task
 from helpers.metrics import metrics
@@ -535,11 +535,7 @@ class PullSyncTask(BaseCodecovTask, name=pulls_task_name):
         pull_head: str,
         current_yaml: UserYaml,
     ):
-        if (
-            should_do_flaky_detection(repository, current_yaml)
-            and db_session.query(Test).filter(Test.repoid == repository.repoid).count()
-            > 0
-        ):
+        if should_do_flaky_detection(repository, current_yaml):
             redis_client = get_redis_connection()
             redis_client.set(f"flake_uploads:{repository.repoid}", 0)
             self.app.tasks[process_flakes_task_name].apply_async(

--- a/tasks/tests/unit/test_sync_pull.py
+++ b/tasks/tests/unit/test_sync_pull.py
@@ -72,11 +72,6 @@ def test_update_pull_commits_merged(
     mock_feature = mocker.patch("services.test_results.FLAKY_TEST_DETECTION")
     mock_feature.check_value.return_value = True
 
-    if tests_exist:
-        t = TestFactory(repository=repository)
-        dbsession.add(t)
-        dbsession.flush()
-
     pull.state = "merged"
     pullid = pull.pullid
     base_commit.pullid = pullid
@@ -135,15 +130,12 @@ def test_update_pull_commits_merged(
         repository,
     )
 
-    if tests_exist:
-        apply_async.assert_called_once_with(
-            kwargs=dict(
-                repo_id=repository.repoid,
-                commit_id=head_commit.commitid,
-            )
+    apply_async.assert_called_once_with(
+        kwargs=dict(
+            repo_id=repository.repoid,
+            commit_id=head_commit.commitid,
         )
-    else:
-        apply_async.assert_not_called()
+    )
 
     assert res == {"merged_count": 2, "soft_deleted_count": 2}
     dbsession.refresh(first_commit)


### PR DESCRIPTION
this query is really expensive on the database so let's just remove it