### PR TITLE
disable populating log_context based on commit_sha/commit_id

### DIFF
--- a/helpers/tests/unit/test_log_context.py
+++ b/helpers/tests/unit/test_log_context.py
@@ -75,18 +75,11 @@ def test_populate_just_commit_sha(dbsession):
 
 
 def test_populate_just_commit_id(dbsession):
-    owner, repo, commit = create_db_records(dbsession)
+    _owner, _repo, commit = create_db_records(dbsession)
     log_context = LogContext(commit_id=commit.id_)
     log_context.populate_from_sqlalchemy(dbsession)
 
     assert log_context == LogContext(
-        repo_id=repo.repoid,
-        repo_name="example-python",
-        owner_id=owner.ownerid,
-        owner_username="codecove2e",
-        owner_service="github",
-        owner_plan="users-basic",
-        commit_sha=commit.commitid,
         commit_id=commit.id_,
     )
 
@@ -104,7 +97,6 @@ def test_populate_repo_and_commit_sha(dbsession):
         owner_service="github",
         owner_plan="users-basic",
         commit_sha=commit.commitid,
-        commit_id=commit.id_,
     )
 
 
@@ -135,7 +127,9 @@ def test_set_and_get_log_context(dbsession):
 
 def test_as_dict(dbsession, mocker):
     owner, repo, commit = create_db_records(dbsession)
-    log_context = LogContext(commit_id=commit.id_, task_name="foo", task_id="bar")
+    log_context = LogContext(
+        commit_sha=commit.commitid, repo_id=repo.repoid, task_name="foo", task_id="bar"
+    )
     log_context.populate_from_sqlalchemy(dbsession)
 
     mock_span = mocker.Mock()
@@ -147,7 +141,7 @@ def test_as_dict(dbsession, mocker):
     assert log_context.as_dict() == {
         "task_name": "foo",
         "task_id": "bar",
-        "commit_id": commit.id_,
+        "commit_id": None,
         "commit_sha": commit.commitid,
         "repo_id": repo.repoid,
         "repo_name": repo.name,


### PR DESCRIPTION
apparently populating the log context was slamming the commit table. so this PR stops using the commit table when populating log context

previously:
- if `commit_id` or `commit_sha`+`repo_id` were available, query the commits table to populate every field
- everything is populated this way, including `commit_id` (the DB PK for the commit)

now:
- `commit_id` and `commit_sha` will be set if available but not used to query anything else
- if `repo_id` is available, that will take care of populating the repo + owner

it's possible this will just move the problem to the repos table. if that is the case, it's solvable but will take a little elbow grease:
- transform `populate_from_sqlalchemy()` in `helpers/log_context.py` into `populate_log_context(kwargs) -> (Commit, Repository, Owner)` in `tasks/base.py`
- add a `run_impl()` stub to `BaseCodecovTask` which takes `owner`, `commit`, and `repo` kwargs, make all task subclasses accept the same (with default `None`) values
- in several followup PRs, update task subclasses to use the passed-in models instead of re-fetching them

follow-up issue for model reuse: https://github.com/codecov/engineering-team/issues/3140