### PR TITLE
Split big commit's into 3

### DIFF
--- a/tasks/compute_comparison.py
+++ b/tasks/compute_comparison.py
@@ -68,6 +68,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
         # Because we have a HEAD report and a base commit to get the diff from
         patch_totals = comparison_proxy.get_patch_totals()
         comparison.patch_totals = minimal_totals(patch_totals)
+        db_session.commit()
 
         if not comparison_proxy.has_project_coverage_base_report():
             comparison.error = CompareCommitError.missing_base_report.value
@@ -96,6 +97,7 @@ class ComputeComparisonTask(BaseCodecovTask, name=compute_comparison_task_name):
         path = self.store_results(comparison, impacted_files)
 
         comparison.report_storage_path = path
+        db_session.commit()
 
         comparison.state = CompareCommitState.processed.value
         log.info("Computing comparison successful", extra=log_extra)


### PR DESCRIPTION
Attempting to help locks https://github.com/codecov/engineering-team/issues/3148

These 3 commits split the query into 3 different logs - verified by locally logging DB logs and seeing the query separate into these individual ones. 
### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.