### PR TITLE
fix: handle empty/windows paths correctly in base-path-aware path fixer

### DIFF
--- a/services/path_fixer/tests/unit/test_path_fixer.py
+++ b/services/path_fixer/tests/unit/test_path_fixer.py
@@ -1,3 +1,5 @@
+from pathlib import PurePosixPath, PureWindowsPath
+
 from shared.yaml import UserYaml
 
 from services.path_fixer import PathFixer, invert_pattern
@@ -127,6 +129,32 @@ class TestBasePathAwarePathFixer(object):
             base_aware_pf("__init__.py", bases_to_try=("/home/travis/build/project",))
             == "project/__init__.py"
         )
+
+    def test_basepath_does_not_resolve_empty_paths(self):
+        toc = ["project/__init__.py", "tests/__init__.py", "tests/test_project.py"]
+        pf = PathFixer.init_from_user_yaml({}, toc, [])
+        coverage_file = "/some/coverage.xml"
+        base_aware_pf = pf.get_relative_path_aware_pathfixer(coverage_file)
+
+        assert base_aware_pf("") is None
+
+    def test_basepath_with_win_and_posix_paths(self):
+        toc = ["project/__init__.py", "tests/__init__.py", "tests/test_project.py"]
+        pf = PathFixer.init_from_user_yaml({}, toc, [])
+
+        posix_coverage_file_path = "/posix_base_path/coverage.xml"
+        posix_base_aware_pf = pf.get_relative_path_aware_pathfixer(
+            posix_coverage_file_path
+        )
+        assert posix_base_aware_pf.base_path == [PurePosixPath("/posix_base_path")]
+
+        windows_coverage_file_path = "C:\\windows_base_path\\coverage.xml"
+        windows_base_aware_pf = pf.get_relative_path_aware_pathfixer(
+            windows_coverage_file_path
+        )
+        assert windows_base_aware_pf.base_path == [
+            PureWindowsPath("C:\\windows_base_path")
+        ]
 
 
 def test_ambiguous_paths():


### PR DESCRIPTION
there are a couple issues in the base-path-aware path fixer:

### empty paths are not skipped
- the regular path fixer early-exits if the passed-in path is `""`
- if the regular path fixer doesn't succeed, the base-aware path fixer retries with some prefixes (one of them being `./` for windows paths due to the other bug fixed in this PR)
- the regular path fixer is retried with the passed-in path of `""`, so it does not early-exit
- however, the next line strips `./` so the path is _turned into_ `""`
- `os.path.relpath()` gets mad

### incorrect usage of `PurePath`
the base-path-aware path fixer uses the parent directory of the coverage file as its base. we use `PurePath` to figure out that parent directory, as it does not perform any actual disk operations, it's just path manipulations.

the issue is, `PurePath` on our Linux prod servers will instantiate a `PurePosixPath`, even if the path we are using is clearly a windows path like `C:\Users\matt`. this is wrong:
```
>>> pure_path = PurePosixPath("C:\\Users\\matt")
>>> pure_path
PurePosixPath("C:\\Users\\matt")

>>> # parent should be C:\Users
>>> pure_path.parent
PurePosixPath(".")
```

the fix is to use `PureWindowsPath` for windows paths and `PurePosixPath` otherwise

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.