### PR TITLE
Hopefully help DB lock contention

### DIFF
--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -243,6 +243,8 @@ class ReportService(BaseReportService):
             private_repo=repository.private,
             report_type=commit_report.report_type,
         )
+        db_session = upload.get_db_session()
+        db_session.commit()
 
         return upload
 


### PR DESCRIPTION
We're seeing this in Sentry, https://codecov.sentry.io/issues/5707951012/?project=4165036&statsPeriod=24h, likely because we're waiting till here https://github.com/codecov/worker/blob/57e5f92720532ce1099731be23e7908db718b89d/tasks/upload.py#L508-L509 to commit everything. This is an attempt to commit preemptively to help with DB lock contention

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.