### PR TITLE
add root_organization property to worker, clean up decoration service, change notification urls for GL

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -3,6 +3,7 @@ import string
 import uuid
 from datetime import datetime
 from functools import cached_property
+from typing import Optional
 
 from shared.plan.constants import PlanName
 from sqlalchemy import Column, ForeignKey, Index, UniqueConstraint, types
@@ -154,11 +155,11 @@ class Owner(CodecovBaseModel):
     )
 
     @property
-    def slug(self):
+    def slug(self: "Owner") -> str:
         return self.username
 
     @property
-    def root_organization(self):
+    def root_organization(self: "Owner") -> Optional["Owner"]:
         """
         Find the root organization of Gitlab OwnerOrg, by using the root_parent_service_id
         if it exists, otherwise iterating through the parents and cache it in root_parent_service_id
@@ -178,17 +179,19 @@ class Owner(CodecovBaseModel):
             db_session.commit()
         return root
 
-    def _get_owner_by_service_id(self, db_session, service_id):
+    def _get_owner_by_service_id(
+        self: "Owner", db_session: Session, service_id: str
+    ) -> "Owner":
         """
         Helper method to fetch an Owner by service_id.
         """
         return (
             db_session.query(Owner)
             .filter_by(service_id=service_id, service=self.service)
-            .one_or_none()
+            .one()
         )
 
-    def __repr__(self):
+    def __repr__(self: "Owner") -> str:
         return f"Owner<{self.ownerid}@service<{self.service}>>"
 
 

--- a/database/tests/factories/core.py
+++ b/database/tests/factories/core.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 import factory
 from factory import Factory
+from shared.plan.constants import PlanName
 
 from database import enums, models
 from services.encryption import encryptor
@@ -49,6 +50,7 @@ class OwnerFactory(Factory):
     trial_status = enums.TrialStatus.NOT_STARTED.value
     trial_fired_by = None
     upload_token_required_for_public_repos = False
+    plan = PlanName.BASIC_PLAN_NAME.value
 
     oauth_token = factory.LazyAttribute(
         lambda o: encrypt_oauth_token(o.unencrypted_oauth_token)

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/190bbc8a911099749928e13d5fe57f6027ca1e74.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/de4b37bc5a736317c6e7c93f9c58e9ae07f8c96b.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/b5dc7eba3fb09c7f65101b102c1f9384be47380f.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/190bbc8a911099749928e13d5fe57f6027ca1e74.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/b5dc7eba3fb09c7f65101b102c1f9384be47380f.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/191837f5e35f5efc410e670aac7e50e0d09e43e1.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -375,7 +375,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.7.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/de4b37bc5a736317c6e7c93f9c58e9ae07f8c96b.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/b5dc7eba3fb09c7f65101b102c1f9384be47380f.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -375,7 +375,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.7.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/b5dc7eba3fb09c7f65101b102c1f9384be47380f.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/191837f5e35f5efc410e670aac7e50e0d09e43e1.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/tests/test_billing.py
+++ b/services/tests/test_billing.py
@@ -1,15 +1,21 @@
 from django.test import override_settings
-from shared.billing import BillingPlan, is_pr_billing_plan
+from shared.plan.constants import PlanName
+from shared.plan.service import PlanService
 
 from database.tests.factories import OwnerFactory
 
 
 class TestBillingServiceTestCase(object):
+    """
+    BillingService is deprecated - use PlanService instead.
+    """
+
     def test_pr_author_plan_check(self, request, dbsession, with_sql_functions):
         owner = OwnerFactory.create(service="github", plan="users-pr-inappm")
         dbsession.add(owner)
         dbsession.flush()
-        assert is_pr_billing_plan(owner.plan)
+        plan = PlanService(owner)
+        assert plan.is_pr_billing_plan
 
     @override_settings(IS_ENTERPRISE=True)
     def test_pr_author_enterprise_plan_check(
@@ -25,16 +31,20 @@ class TestBillingServiceTestCase(object):
             "https://codecov.mysite.com"
         )
 
-        assert is_pr_billing_plan(owner.plan)
+        plan = PlanService(owner)
+
+        assert plan.is_pr_billing_plan
 
     def test_plan_not_pr_author(self, request, dbsession, with_sql_functions):
         owner = OwnerFactory.create(
-            service="github", plan=BillingPlan.users_monthly.value
+            service="github", plan=PlanName.CODECOV_PRO_MONTHLY_LEGACY.value
         )
         dbsession.add(owner)
         dbsession.flush()
 
-        assert not is_pr_billing_plan(owner.plan)
+        plan = PlanService(owner)
+
+        assert not plan.is_pr_billing_plan
 
     @override_settings(IS_ENTERPRISE=True)
     def test_pr_author_enterprise_plan_check_non_pr_plan(
@@ -49,5 +59,6 @@ class TestBillingServiceTestCase(object):
         mock_configuration.params["setup"]["codecov_dashboard_url"] = (
             "https://codeov.mysite.com"
         )
+        plan = PlanService(owner)
 
-        assert not is_pr_billing_plan(owner.plan)
+        assert not plan.is_pr_billing_plan

--- a/tasks/tests/unit/test_ta_finisher_task.py
+++ b/tasks/tests/unit/test_ta_finisher_task.py
@@ -15,6 +15,7 @@ from database.tests.factories import (
     RepositoryFactory,
     UploadFactory,
 )
+from services.seats import SeatActivationInfo
 from services.urls import services_short_dict
 from tasks.ta_finisher import TAFinisherTask
 from tasks.ta_processor import TAProcessorTask
@@ -153,6 +154,10 @@ def test_test_analytics(dbsession, mocker, mock_storage, celery_app, snapshot):
     mocker.patch(
         "tasks.ta_finisher.fetch_and_update_pull_request_information_from_commit",
         return_value=mock_pull_request_information,
+    )
+    mocker.patch(
+        "tasks.ta_finisher.determine_seat_activation",
+        return_value=SeatActivationInfo(reason="public_repo"),
     )
 
     result = TAProcessorTask().run_impl(


### PR DESCRIPTION
<!-- Describe your PR here. -->
Decoration service was causing confusion for GitLab users. Cleaned it up and added some comments to clarify the current GL org strategy which is: 
- the root org owns the plan, so when dealing with a GL org's plan, look at the plan from the root org
- membership and activation through `plan_activated_user` also happens on the root org instead of a subgroup org
- if a notification has the `plan` or `member` url, give GL users the correct url (correct url is to root group, not subgroup)

more details on ticket https://github.com/codecov/engineering-team/issues/2710

