### PR TITLE
[Bundle Analysis] Don't overwrite existing cache config state when co…

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/996ecb2aaf7767bf4c2944c75835c1ee1eb2b566.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/efe48352e172f658c21465371453dcefc98f6793.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/169540881694ba1ce614b917666ecf46704b2e8c.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/996ecb2aaf7767bf4c2944c75835c1ee1eb2b566.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/2eeb955fff2aa9bf0fff57213caca2d77f677446.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/67879c17712e42067f67d3b60dd0e2c1a5db5170.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/996ecb2aaf7767bf4c2944c75835c1ee1eb2b566.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/169540881694ba1ce614b917666ecf46704b2e8c.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/2eeb955fff2aa9bf0fff57213caca2d77f677446.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -336,7 +336,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.6.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/efe48352e172f658c21465371453dcefc98f6793.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/169540881694ba1ce614b917666ecf46704b2e8c.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -336,7 +336,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.6.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/2eeb955fff2aa9bf0fff57213caca2d77f677446.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/67879c17712e42067f67d3b60dd0e2c1a5db5170.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -336,7 +336,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.6.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/169540881694ba1ce614b917666ecf46704b2e8c.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/2eeb955fff2aa9bf0fff57213caca2d77f677446.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -267,7 +267,7 @@ class BundleAnalysisReportService(BaseReportService):
                 # Turn on caching option by default for all new bundles only for default branch
                 if commit.branch == commit.repository.branch:
                     for bundle in bundle_report.bundle_reports():
-                        BundleAnalysisCacheConfigService.update_cache_option(
+                        BundleAnalysisCacheConfigService.create_cache_option(
                             commit.repoid, bundle.name
                         )
 

--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -267,7 +267,7 @@ class BundleAnalysisReportService(BaseReportService):
                 # Turn on caching option by default for all new bundles only for default branch
                 if commit.branch == commit.repository.branch:
                     for bundle in bundle_report.bundle_reports():
-                        BundleAnalysisCacheConfigService.create_cache_option(
+                        BundleAnalysisCacheConfigService.create_if_not_exists(
                             commit.repoid, bundle.name
                         )
 

--- a/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -922,7 +922,7 @@ def test_bundle_analysis_processor_task_cache_config_saved(
     bundle_load_mock_save.return_value = None
 
     bundle_config_mock = mocker.patch(
-        "shared.django_apps.bundle_analysis.service.bundle_analysis.BundleAnalysisCacheConfigService.update_cache_option"
+        "shared.django_apps.bundle_analysis.service.bundle_analysis.BundleAnalysisCacheConfigService.create_cache_option"
     )
 
     commit = CommitFactory.create(state="pending")

--- a/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -922,7 +922,7 @@ def test_bundle_analysis_processor_task_cache_config_saved(
     bundle_load_mock_save.return_value = None
 
     bundle_config_mock = mocker.patch(
-        "shared.django_apps.bundle_analysis.service.bundle_analysis.BundleAnalysisCacheConfigService.create_cache_option"
+        "shared.django_apps.bundle_analysis.service.bundle_analysis.BundleAnalysisCacheConfigService.create_if_not_exists"
     )
 
     commit = CommitFactory.create(state="pending")


### PR DESCRIPTION
Add get_or_create, will have to use this instead of update_or_create in the BA processor. Currently we will always overwrite what the caching bool to true when doing a new commit into default branch. When switching to this the intention is that if the bundle cache data already exists we will not overwrite it to true.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.