### PR TITLE
Add bulk_create fn to upload processes to help w/ lock contention

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/996ecb2aaf7767bf4c2944c75835c1ee1eb2b566.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/efe48352e172f658c21465371453dcefc98f6793.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/b186b3c89fe16a4f9512cf160f39cfd262ba2eb8.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -336,7 +336,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.6.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/efe48352e172f658c21465371453dcefc98f6793.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/b186b3c89fe16a4f9512cf160f39cfd262ba2eb8.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/report/__init__.py
+++ b/services/report/__init__.py
@@ -18,7 +18,6 @@ from shared.reports.resources import Report
 from shared.storage.exceptions import FileNotInStorageError
 from shared.torngit.exceptions import TorngitError
 from shared.upload.constants import UploadErrorCode
-from shared.upload.utils import UploaderType, insert_coverage_measurement
 from shared.utils.sessions import Session, SessionType
 from shared.yaml import UserYaml
 from sqlalchemy.orm import Session as DbSession
@@ -226,24 +225,6 @@ class ReportService(BaseReportService):
     ) -> Upload:
         upload = super().create_report_upload(arguments, commit_report)
         self._attach_flags_to_upload(upload, arguments["flags"])
-
-        # Insert entry in user measurements table only
-        # for reports with coverage type
-        commit = commit_report.commit
-        repository = commit.repository
-        owner = repository.owner
-
-        insert_coverage_measurement(
-            owner_id=owner.ownerid,
-            repo_id=repository.repoid,
-            commit_id=commit.id,
-            upload_id=upload.id,
-            # CLI precreates the upload in API so this defaults to Legacy
-            uploader_used=UploaderType.LEGACY.value,
-            private_repo=repository.private,
-            report_type=commit_report.report_type,
-        )
-
         return upload
 
     def _attach_flags_to_upload(self, upload: Upload, flag_names: list[str]):

--- a/tasks/tests/integration/test_upload_e2e.py
+++ b/tasks/tests/integration/test_upload_e2e.py
@@ -163,7 +163,7 @@ def setup_mocks(
 
 
 @pytest.mark.integration
-@pytest.mark.django_db
+@pytest.mark.django_db(databases={"default"}, transaction=True)
 def test_full_upload(
     dbsession: DbSession,
     mocker,
@@ -369,7 +369,7 @@ end_of_record
 
 
 @pytest.mark.integration
-@pytest.mark.django_db()
+@pytest.mark.django_db(databases={"default"}, transaction=True)
 def test_full_carryforward(
     dbsession: DbSession,
     mocker,

--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -124,7 +124,7 @@ def clear_log_context(mocker):
 
 @pytest.mark.integration
 class TestUploadTaskIntegration(object):
-    @pytest.mark.django_db(databases={"default"})
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_call(
         self,
         mocker,
@@ -225,6 +225,7 @@ class TestUploadTaskIntegration(object):
         ]
         mock_checkpoint_submit.assert_has_calls(calls)
 
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_call_bundle_analysis(
         self,
         mocker,
@@ -294,6 +295,7 @@ class TestUploadTaskIntegration(object):
         )
         chain.assert_called_with([processor_sig, notify_sig])
 
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_call_bundle_analysis_no_upload(
         self,
         mocker,
@@ -360,6 +362,7 @@ class TestUploadTaskIntegration(object):
         )
         assert call([processor_sig]) in chain.mock_calls
 
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_call_test_results(
         self,
         mocker,
@@ -469,7 +472,7 @@ class TestUploadTaskIntegration(object):
         assert commit.message == ""
         assert commit.parent_commit_id is None
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_upload_processing_delay_not_enough_delay(
         self,
         mocker,
@@ -520,7 +523,7 @@ class TestUploadTaskIntegration(object):
         assert redis.exists(f"uploads/{commit.repoid}/{commit.commitid}")
         assert not mock_possibly_update_commit_from_provider_info.called
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_upload_processing_delay_enough_delay(
         self,
         mocker,
@@ -572,7 +575,7 @@ class TestUploadTaskIntegration(object):
         assert not redis.exists(f"uploads/{commit.repoid}/{commit.commitid}")
         mocked_chord.assert_called_with([mocker.ANY, mocker.ANY], mocker.ANY)
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_upload_processing_delay_upload_is_none(
         self,
         mocker,
@@ -619,7 +622,7 @@ class TestUploadTaskIntegration(object):
         assert not redis.exists(f"uploads/{commit.repoid}/{commit.commitid}")
         mocked_chord.assert_called_with([mocker.ANY, mocker.ANY], mocker.ANY)
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_call_multiple_processors(
         self,
         mocker,
@@ -758,7 +761,7 @@ class TestUploadTaskIntegration(object):
             timeout=300,
         )
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_no_bot(
         self,
         mocker,
@@ -825,7 +828,7 @@ class TestUploadTaskIntegration(object):
         )
         assert not mocked_fetch_yaml.called
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_bot_no_permissions(
         self,
         mocker,
@@ -893,7 +896,7 @@ class TestUploadTaskIntegration(object):
         )
         assert not mocked_fetch_yaml.called
 
-    @pytest.mark.django_db
+    @pytest.mark.django_db(databases={"default"}, transaction=True)
     def test_upload_task_bot_unauthorized(
         self,
         mocker,

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -9,12 +9,15 @@ import orjson
 import sentry_sdk
 from asgiref.sync import async_to_sync
 from celery import chain, chord
+from django.utils import timezone
 from redis import Redis
 from redis.exceptions import LockError
 from shared.celery_config import upload_task_name
 from shared.config import get_config
+from shared.django_apps.user_measurements.models import UserMeasurement
 from shared.metrics import Histogram
 from shared.torngit.exceptions import TorngitClientError, TorngitRepoNotFoundError
+from shared.upload.utils import UploaderType, bulk_insert_coverage_measurements
 from shared.yaml import UserYaml
 from shared.yaml.user_yaml import OwnerContext
 from sqlalchemy.orm import Session
@@ -494,15 +497,35 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             self.retry(countdown=60, kwargs=upload_context.kwargs_for_retry(kwargs))
 
         argument_list: list[UploadArguments] = []
+        # Measurements insertion performance
+        measurements = []
+        created_at = timezone.now()
+
         for arguments in upload_context.arguments_list():
             arguments = upload_context.normalize_arguments(commit, arguments)
             if "upload_id" not in arguments:
                 upload = report_service.create_report_upload(arguments, commit_report)
                 arguments["upload_id"] = upload.id_
+                # Adding measurements to array to later add in bulk
+                measurements.append(
+                    UserMeasurement(
+                        owner_id=repository.owner.ownerid,
+                        repo_id=repository.repoid,
+                        commit_id=commit.id,
+                        upload_id=upload.id,
+                        # CLI precreates the upload in API so this defaults to Legacy
+                        uploader_used=UploaderType.LEGACY.value,
+                        private_repo=repository.private,
+                        report_type=commit_report.report_type,
+                        created_at=created_at,
+                    )
+                )
 
             # TODO(swatinem): eventually migrate from `upload_pk` to `upload_id`:
             arguments["upload_pk"] = arguments["upload_id"]
             argument_list.append(arguments)
+
+        bulk_insert_coverage_measurements(measurements=measurements)
 
         if argument_list:
             db_session.commit()

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -9,8 +9,8 @@ import orjson
 import sentry_sdk
 from asgiref.sync import async_to_sync
 from celery import chain, chord
-from django.utils import timezone
 from django.db import transaction as django_transaction
+from django.utils import timezone
 from redis import Redis
 from redis.exceptions import LockError
 from shared.celery_config import upload_task_name
@@ -527,7 +527,9 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             argument_list.append(arguments)
 
         # Bulk insert coverage measurements
-        self._bulk_insert_coverage_measurements(measurements=measurements)
+        if measurements:
+            print("test - I am here!", measurements)
+            self._bulk_insert_coverage_measurements(measurements=measurements)
 
         if argument_list:
             db_session.commit()
@@ -561,7 +563,7 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
             )
         return {"was_setup": was_setup, "was_updated": was_updated}
 
-    def _bulk_insert_coverage_measurements(measurements: list[UserMeasurement]):
+    def _bulk_insert_coverage_measurements(self, measurements: list[UserMeasurement]):
         bulk_insert_coverage_measurements(measurements=measurements)
         django_transaction.commit()
 


### PR DESCRIPTION
More lock contentions help! We have this query, https://codecov.sentry.io/issues/5707951012/?project=4165036&statsPeriod=24h, causing a bunch of N+1 queries. One of them is this one, so this is an effort to extract measurements inserts into one batched insert

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.