### PR TITLE
Handle TA upload error

### DIFF
--- a/database/enums.py
+++ b/database/enums.py
@@ -68,7 +68,3 @@ class FlakeSymptomType(Enum):
     FAILED_IN_DEFAULT_BRANCH = "failed_in_default_branch"
     CONSECUTIVE_DIFF_OUTCOMES = "consecutive_diff_outcomes"
     UNRELATED_MATCHING_FAILURES = "unrelated_matching_failures"
-
-
-class TestResultsProcessingError(Enum):
-    NO_SUCCESS = "no_success"

--- a/database/models/reports.py
+++ b/database/models/reports.py
@@ -331,6 +331,9 @@ class TestResultReportTotals(CodecovBaseModel, MixinBaseClass):
     passed = Column(types.Integer)
     skipped = Column(types.Integer)
     failed = Column(types.Integer)
+
+    # this field is no longer used in the new ta_finisher task
+    # TODO: thus, it will be removed in the future
     error = Column(types.String(100), nullable=True)
 
 

--- a/database/tests/factories/core.py
+++ b/database/tests/factories/core.py
@@ -298,3 +298,12 @@ class ConstantsFactory(Factory):
 
     key = ""
     value = ""
+
+
+class UploadErrorFactory(Factory):
+    class Meta:
+        model = models.UploadError
+
+    report_upload = factory.SubFactory(UploadFactory)
+    error_code = "error"
+    error_params = {"error_message": "error message"}

--- a/database/tests/factories/reports.py
+++ b/database/tests/factories/reports.py
@@ -2,8 +2,18 @@ import datetime as dt
 
 import factory
 
-from database.models.reports import CompareFlag, Flake, RepositoryFlag, Test
-from database.tests.factories.core import CompareCommitFactory, RepositoryFactory
+from database.models.reports import (
+    CompareFlag,
+    Flake,
+    RepositoryFlag,
+    Test,
+    TestResultReportTotals,
+)
+from database.tests.factories.core import (
+    CompareCommitFactory,
+    ReportFactory,
+    RepositoryFactory,
+)
 
 
 class RepositoryFlagFactory(factory.Factory):
@@ -47,3 +57,13 @@ class FlakeFactory(factory.Factory):
 
     start_date = dt.datetime.now()
     end_date = None
+
+
+class TestResultReportTotalsFactory(factory.Factory):
+    class Meta:
+        model = TestResultReportTotals
+
+    report = factory.SubFactory(ReportFactory)
+    passed = 0
+    skipped = 0
+    failed = 0

--- a/services/comparison/__init__.py
+++ b/services/comparison/__init__.py
@@ -266,14 +266,14 @@ class ComparisonProxy(object):
     def all_tests_passed(self) -> bool:
         if self.context:
             return self.context.all_tests_passed or False
-        else:
-            return False
+
+        return False
 
     def test_results_error(self) -> str | None:
         if self.context:
             return self.context.test_results_error
-        else:
-            return None
+
+        return None
 
     def get_existing_statuses(self):
         if self._existing_statuses is None:

--- a/services/comparison/__init__.py
+++ b/services/comparison/__init__.py
@@ -10,7 +10,7 @@ from shared.torngit.base import TorngitBaseAdapter
 from shared.torngit.exceptions import TorngitClientGeneralError
 from shared.utils.sessions import SessionType
 
-from database.enums import CompareCommitState, TestResultsProcessingError
+from database.enums import CompareCommitState
 from database.models import CompareCommit
 from services.archive import ArchiveService
 from services.comparison.changes import get_changes
@@ -27,7 +27,7 @@ class ComparisonContext(object):
 
     repository_service: TorngitBaseAdapter | None = None
     all_tests_passed: bool | None = None
-    test_results_error: TestResultsProcessingError | None = None
+    test_results_error: str | None = None
     gh_app_installation_name: str | None = None
     gh_is_using_codecov_commenter: bool = False
     # GitLab has a "merge results pipeline" (see https://docs.gitlab.com/ee/ci/pipelines/merged_results_pipelines.html)
@@ -263,11 +263,17 @@ class ComparisonProxy(object):
             ]
         return self._behind_by
 
-    def all_tests_passed(self):
-        return self.context is not None and self.context.all_tests_passed
+    def all_tests_passed(self) -> bool:
+        if self.context:
+            return self.context.all_tests_passed or False
+        else:
+            return False
 
-    def test_results_error(self):
-        return self.context is not None and self.context.test_results_error
+    def test_results_error(self) -> str | None:
+        if self.context:
+            return self.context.test_results_error
+        else:
+            return None
 
     def get_existing_statuses(self):
         if self._existing_statuses is None:

--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -30,6 +30,8 @@ from services.yaml.reader import get_components_from_yaml, round_number
 
 log = logging.getLogger(__name__)
 
+ALL_TESTS_PASSED_MSG = ":white_check_mark: All tests successful. No failed tests found."
+
 
 def get_section_class_from_layout_name(layout_name):
     if layout_name.startswith("flag"):
@@ -108,14 +110,12 @@ class NewFooterSectionWriter(BaseSectionWriter):
 
 class HeaderSectionWriter(BaseSectionWriter):
     def _possibly_include_test_result_setup_confirmation(self, comparison):
-        if comparison.test_results_error():
+        if ta_error_msg := comparison.test_results_error():
             yield ("")
-            yield (
-                ":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."
-            )
+            yield (ta_error_msg)
         elif comparison.all_tests_passed():
             yield ""
-            yield (":white_check_mark: All tests successful. No failed tests found.")
+            yield (ALL_TESTS_PASSED_MSG)
 
     def do_write_section(self, comparison, diff, changes, links, behind_by=None):
         yaml = self.current_yaml

--- a/services/notification/notifiers/mixins/message/writers.py
+++ b/services/notification/notifiers/mixins/message/writers.py
@@ -50,17 +50,14 @@ class TeamPlanWriter:
 
         hide_project_coverage = settings.get("hide_project_coverage", False)
         if hide_project_coverage:
-            if comparison.test_results_error():
+            if ta_error_msg := comparison.test_results_error():
                 lines.append("")
-                lines.append(
-                    ":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."
-                )
+                lines.append(ta_error_msg)
             elif comparison.all_tests_passed():
                 lines.append("")
                 lines.append(
                     ":white_check_mark: All tests successful. No failed tests found."
                 )
-
         return lines
 
     def middle_lines(

--- a/services/notification/notifiers/mixins/message/writers.py
+++ b/services/notification/notifiers/mixins/message/writers.py
@@ -14,6 +14,9 @@ from services.notification.notifiers.mixins.message.helpers import (
     escape_markdown,
     make_patch_only_metrics,
 )
+from services.notification.notifiers.mixins.message.sections import (
+    ALL_TESTS_PASSED_MSG,
+)
 
 log = logging.getLogger(__name__)
 
@@ -55,9 +58,7 @@ class TeamPlanWriter:
                 lines.append(ta_error_msg)
             elif comparison.all_tests_passed():
                 lines.append("")
-                lines.append(
-                    ":white_check_mark: All tests successful. No failed tests found."
-                )
+                lines.append(ALL_TESTS_PASSED_MSG)
         return lines
 
     def middle_lines(

--- a/services/notification/notifiers/tests/integration/test_comment.py
+++ b/services/notification/notifiers/tests/integration/test_comment.py
@@ -3,7 +3,6 @@ from unittest.mock import PropertyMock
 import pytest
 from shared.reports.readonly import ReadOnlyReport
 
-from database.enums import TestResultsProcessingError
 from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
 from services.comparison import ComparisonContext, ComparisonProxy
 from services.comparison.types import Comparison, EnrichedPull, FullCommit
@@ -413,7 +412,7 @@ class TestCommentNotifierIntegration(object):
     ):
         sample_comparison.context = ComparisonContext(
             all_tests_passed=False,
-            test_results_error=TestResultsProcessingError.NO_SUCCESS,
+            test_results_error=":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format.",
         )
         mock_configuration._params["setup"] = {
             "codecov_url": None,

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -18,7 +18,6 @@ from shared.utils.sessions import Session
 from shared.validation.types import CoverageCommentRequiredChanges
 from shared.yaml import UserYaml
 
-from database.enums import TestResultsProcessingError
 from database.models.core import Commit, GithubAppInstallation, Pull, Repository
 from database.tests.factories import RepositoryFactory
 from database.tests.factories.core import CommitFactory, OwnerFactory, PullFactory
@@ -3724,7 +3723,7 @@ class TestNewHeaderSectionWriter(object):
     ):
         sample_comparison.context = ComparisonContext(
             all_tests_passed=False,
-            test_results_error=TestResultsProcessingError.NO_SUCCESS,
+            test_results_error=":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format.",
         )
         writer = HeaderSectionWriter(
             mocker.MagicMock(),
@@ -3812,7 +3811,7 @@ class TestNewHeaderSectionWriter(object):
     ):
         sample_comparison.context = ComparisonContext(
             all_tests_passed=False,
-            test_results_error=TestResultsProcessingError.NO_SUCCESS,
+            test_results_error=":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format.",
         )
         writer = HeaderSectionWriter(
             mocker.MagicMock(),
@@ -4651,7 +4650,7 @@ class TestCommentNotifierInNewLayout(object):
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
         sample_comparison_coverage_carriedforward.context = ComparisonContext(
             all_tests_passed=False,
-            test_results_error=TestResultsProcessingError.NO_SUCCESS,
+            test_results_error=":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format.",
         )
         comparison = sample_comparison_coverage_carriedforward
         comparison.repository_service.service = "github"

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -341,8 +341,7 @@ class TestResultsNotifier(BaseNotifier):
 
     def error_comment(self):
         """
-        This method assumes that the list is not empty, so
-        if the list is empty, we raise an error.
+        This is no longer used in the new TA finisher task, but this is what used to display the error comment
         """
         message: str
 

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -18,6 +18,7 @@ from database.models import (
     RepositoryFlag,
     TestInstance,
     Upload,
+    UploadError,
 )
 from helpers.notifier import BaseNotifier
 from rollouts import FLAKY_TEST_DETECTION
@@ -136,12 +137,17 @@ class FlakeInfo:
 
 
 @dataclass
+class TACommentInDepthInfo:
+    failures: list[TestResultsNotificationFailure]
+    flaky_tests: dict[str, FlakeInfo]
+
+
+@dataclass
 class TestResultsNotificationPayload:
     failed: int
     passed: int
     skipped: int
-    failures: list[TestResultsNotificationFailure]
-    flaky_tests: dict[str, FlakeInfo]
+    info: TACommentInDepthInfo | None = None
 
 
 def wrap_in_details(summary: str, content: str):
@@ -237,72 +243,121 @@ def messagify_flake(
     return make_quoted(f"{test_name}\n{flake_rate_section}\n{stack_trace}")
 
 
+def specific_error_message(upload_error: UploadError) -> str:
+    title = f"### :x: {upload_error.error_code}"
+    if upload_error.error_code == "Unsupported file format":
+        description = "\n".join(
+            [
+                "Upload processing failed due to unsupported file format. Please review the parser error message:",
+                f"`{upload_error.error_params['error_message']}`",
+                "For more help, visit our [troubleshooting guide](https://docs.codecov.com/docs/test-analytics#troubleshooting).",
+            ]
+        )
+    elif upload_error.error_code == "File not found":
+        description = "\n".join(
+            [
+                "No result to display due to the CLI not being able to find the file.",
+                "Please ensure the file contains `junit` in the name and automated file search is enabled,",
+                "or the desired file specified by the `file` and `search_dir` arguments of the CLI.",
+            ]
+        )
+    else:
+        raise ValueError("Unrecognized error code")
+    message = [
+        title,
+        make_quoted(description),
+    ]
+    return "\n".join(message)
+
+
 @dataclass
 class TestResultsNotifier(BaseNotifier):
     payload: TestResultsNotificationPayload | None = None
+    error: UploadError | None = None
 
     def build_message(self) -> str:
         if self.payload is None:
             raise ValueError("Payload passed to notifier is None, cannot build message")
 
-        message = [f"### :x: {self.payload.failed} Tests Failed:"]
+        message = []
 
-        completed = self.payload.failed + self.payload.passed
+        if self.error:
+            message.append(specific_error_message(self.error))
 
-        message += [
-            "| Tests completed | Failed | Passed | Skipped |",
-            "|---|---|---|---|",
-            f"| {completed} | {self.payload.failed} | {self.payload.passed} | {self.payload.skipped} |",
-        ]
+        if self.error and self.payload.info:
+            message.append("---")
 
-        failures = sorted(
-            (
-                failure
-                for failure in self.payload.failures
-                if failure.test_id not in self.payload.flaky_tests
-            ),
-            key=lambda x: (x.duration_seconds, x.display_name),
-        )
-        if failures:
-            failure_content = [f"{messagify_failure(failure)}" for failure in failures]
+        if self.payload.info:
+            message.append(f"### :x: {self.payload.failed} Tests Failed:")
 
-            top_3_failed_section = wrap_in_details(
-                f"View the top {min(3, len(failures))} failed tests by shortest run time",
-                "\n".join(failure_content),
-            )
+            completed = self.payload.failed + self.payload.passed
 
-            message.append(top_3_failed_section)
-
-        flaky_failures = [
-            failure
-            for failure in self.payload.failures
-            if failure.test_id in self.payload.flaky_tests
-        ]
-        if flaky_failures:
-            flake_content = [
-                f"{messagify_flake(flaky_failure, self.payload.flaky_tests[flaky_failure.test_id])}"
-                for flaky_failure in flaky_failures
+            message += [
+                "| Tests completed | Failed | Passed | Skipped |",
+                "|---|---|---|---|",
+                f"| {completed} | {self.payload.failed} | {self.payload.passed} | {self.payload.skipped} |",
             ]
 
-            flaky_section = wrap_in_details(
-                f"View the full list of {len(flaky_failures)} :snowflake: flaky tests",
-                "\n".join(flake_content),
+            failures = sorted(
+                (
+                    failure
+                    for failure in self.payload.info.failures
+                    if failure.test_id not in self.payload.info.flaky_tests
+                ),
+                key=lambda x: (x.duration_seconds, x.display_name),
             )
+            if failures:
+                failure_content = [
+                    f"{messagify_failure(failure)}" for failure in failures
+                ]
 
-            message.append(flaky_section)
+                top_3_failed_section = wrap_in_details(
+                    f"View the top {min(3, len(failures))} failed tests by shortest run time",
+                    "\n".join(failure_content),
+                )
 
-        message.append(generate_view_test_analytics_line(self.commit))
+                message.append(top_3_failed_section)
+
+            flaky_failures = [
+                failure
+                for failure in self.payload.info.failures
+                if failure.test_id in self.payload.info.flaky_tests
+            ]
+            if flaky_failures:
+                flake_content = [
+                    f"{messagify_flake(flaky_failure, self.payload.info.flaky_tests[flaky_failure.test_id])}"
+                    for flaky_failure in flaky_failures
+                ]
+
+                flaky_section = wrap_in_details(
+                    f"View the full list of {len(flaky_failures)} :snowflake: flaky tests",
+                    "\n".join(flake_content),
+                )
+
+                message.append(flaky_section)
+
+            message.append(generate_view_test_analytics_line(self.commit))
         return "\n".join(message)
 
     def error_comment(self):
+        """
+        This method assumes that the list is not empty, so
+        if the list is empty, we raise an error.
+        """
+        message: str
+
+        if self.error is None:
+            message = ":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."
+        else:
+            message = specific_error_message(self.error)
+
         pull = self.get_pull()
         if pull is None:
             return False, "no_pull"
 
-        message = ":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."
-
         sent_to_provider = self.send_to_provider(pull, message)
-        if sent_to_provider == False:
+
+        if sent_to_provider is False:
             return (False, "torngit_error")
 
         return (True, "comment_posted")

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -2,14 +2,17 @@ import mock
 import pytest
 from shared.torngit.exceptions import TorngitClientError
 
+from database.models import UploadError
 from database.tests.factories import (
     CommitFactory,
     OwnerFactory,
     RepositoryFactory,
+    UploadFactory,
 )
 from helpers.notifier import NotifierResult
 from services.test_results import (
     FlakeInfo,
+    TACommentInDepthInfo,
     TestResultsNotificationFailure,
     TestResultsNotificationPayload,
     TestResultsNotifier,
@@ -112,7 +115,8 @@ def test_build_message():
         1.0,
         "https://example.com/build_url",
     )
-    payload = TestResultsNotificationPayload(1, 2, 3, [fail], dict())
+    info = TACommentInDepthInfo(failures=[fail], flaky_tests={})
+    payload = TestResultsNotificationPayload(1, 2, 3, info)
     commit = CommitFactory(branch="thing/thing")
     tn = TestResultsNotifier(commit, None, None, None, payload)
     res = tn.build_message()
@@ -159,10 +163,9 @@ def test_build_message_with_flake():
         1.0,
         "https://example.com/build_url",
     )
-
-    payload = TestResultsNotificationPayload(
-        1, 2, 3, [fail], {test_id: FlakeInfo(1, 3)}
-    )
+    flaky_test = FlakeInfo(1, 3)
+    info = TACommentInDepthInfo(failures=[fail], flaky_tests={test_id: flaky_test})
+    payload = TestResultsNotificationPayload(1, 2, 3, info)
     commit = CommitFactory(branch="test_branch")
     tn = TestResultsNotifier(commit, None, None, None, payload)
     res = tn.build_message()
@@ -274,3 +277,58 @@ def test_should_do_flake_detection(
     result = should_do_flaky_detection(repo, UserYaml.from_dict(yaml))
 
     assert result == ex_result
+
+
+def test_specific_error_message(mocker):
+    mock_repo_service = mock.AsyncMock()
+    mocker.patch(
+        "helpers.notifier.get_repo_provider_service", return_value=mock_repo_service
+    )
+    mocker.patch(
+        "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
+        return_value=mock.AsyncMock(),
+    )
+
+    upload = UploadFactory()
+    error = UploadError(
+        report_upload=upload,
+        error_code="Unsupported file format",
+        error_params={
+            "error_message": "Error parsing JUnit XML in test.xml at 4:32: ParserError: No name found"
+        },
+    )
+    tn = TestResultsNotifier(CommitFactory(), None, error=error)
+    result = tn.error_comment()
+    expected = """### :x: Unsupported file format
+
+> Upload processing failed due to unsupported file format. Please review the parser error message:
+> `Error parsing JUnit XML in test.xml at 4:32: ParserError: No name found`
+> For more help, visit our [troubleshooting guide](https://docs.codecov.com/docs/test-analytics#troubleshooting).
+"""
+
+    assert result == (True, "comment_posted")
+    print(mock_repo_service.mock_calls)
+    mock_repo_service.edit_comment.assert_called_with(
+        tn._pull.database_pull.pullid, tn._pull.database_pull.commentid, expected
+    )
+
+
+def test_specific_error_message_no_error(mocker):
+    mock_repo_service = mock.AsyncMock()
+    mocker.patch(
+        "helpers.notifier.get_repo_provider_service", return_value=mock_repo_service
+    )
+    mocker.patch(
+        "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
+        return_value=mock.AsyncMock(),
+    )
+
+    tn = TestResultsNotifier(CommitFactory(), None)
+    result = tn.error_comment()
+    expected = """:x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."""
+
+    assert result == (True, "comment_posted")
+    print(mock_repo_service.mock_calls)
+    mock_repo_service.edit_comment.assert_called_with(
+        tn._pull.database_pull.pullid, tn._pull.database_pull.commentid, expected
+    )

--- a/tasks/notify.py
+++ b/tasks/notify.py
@@ -31,6 +31,7 @@ from database.models import (
     CommitReport,
     Pull,
     TestResultReportTotals,
+    Upload,
     UploadError,
 )
 from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME, CompareCommit
@@ -898,10 +899,14 @@ def get_ta_relevant_context(
     ta_error_msg: str | None = None
 
     if ta_commit_report:
-        test_result_uploads = [upload.id for upload in ta_commit_report.uploads]
+        ta_upload_ids = (
+            db_session.query(Upload.id_)
+            .filter(Upload.report_id == ta_commit_report.id_)
+            .subquery()
+        )
         upload_error = (
             db_session.query(UploadError)
-            .filter(UploadError.upload_id.in_(test_result_uploads))
+            .filter(UploadError.upload_id.in_(ta_upload_ids))
             .first()
         )
 

--- a/tasks/ta_finisher.py
+++ b/tasks/ta_finisher.py
@@ -2,7 +2,6 @@ import logging
 from dataclasses import dataclass
 from typing import Any
 
-import sentry_sdk
 from asgiref.sync import async_to_sync
 from shared.reports.types import UploadType
 from shared.typings.torngit import AdditionalData
@@ -10,7 +9,7 @@ from shared.yaml import UserYaml
 from sqlalchemy.orm import Session
 
 from app import celery_app
-from database.enums import FlakeSymptomType, ReportType, TestResultsProcessingError
+from database.enums import FlakeSymptomType, ReportType
 from database.models import (
     Commit,
     CommitReport,
@@ -18,6 +17,7 @@ from database.models import (
     Repository,
     TestResultReportTotals,
     Upload,
+    UploadError,
 )
 from helpers.checkpoint_logger.flows import TestResultsFlow
 from helpers.notifier import NotifierResult
@@ -33,6 +33,7 @@ from services.repository import (
 from services.seats import ShouldActivateSeat, determine_seat_activation
 from services.test_results import (
     FlakeInfo,
+    TACommentInDepthInfo,
     TestResultsNotificationFailure,
     TestResultsNotificationPayload,
     TestResultsNotifier,
@@ -110,37 +111,10 @@ def get_totals(
         totals.passed = 0
         totals.skipped = 0
         totals.failed = 0
-        totals.error = str(TestResultsProcessingError.NO_SUCCESS)
         db_session.add(totals)
         db_session.flush()
 
     return totals
-
-
-def handle_processor_fail(
-    totals: TestResultReportTotals, commit: Commit, commit_yaml: UserYaml
-) -> dict[str, bool]:
-    # every processor errored, nothing to notify on
-    queue_notify = False
-
-    # if error is None this whole process should be a noop
-    if totals.error is not None:
-        # make an attempt to make test results comment
-        notifier = TestResultsNotifier(commit, commit_yaml)
-        success, reason = notifier.error_comment()
-        if not success and reason == "torngit_error":
-            sentry_sdk.capture_message(
-                "Error posting error comment in test results finisher due to torngit error"
-            )
-
-        # also make attempt to make coverage comment
-        queue_notify = True
-
-    return {
-        "notify_attempted": False,
-        "notify_succeeded": False,
-        "queue_notify": queue_notify,
-    }
 
 
 def populate_failures(
@@ -238,7 +212,6 @@ class TAFinisherTask(BaseCodecovTask, name=ta_finisher_task_name):
                     repoid=repoid,
                     commitid=commitid,
                     commit_yaml=UserYaml.from_dict(commit_yaml),
-                    previous_result=chord_result,
                     **kwargs,
                 )
             if finisher_result["queue_notify"]:
@@ -261,7 +234,6 @@ class TAFinisherTask(BaseCodecovTask, name=ta_finisher_task_name):
         repoid: int,
         commitid: str,
         commit_yaml: UserYaml,
-        previous_result: list[bool],
         **kwargs,
     ):
         log.info("Running test results finishers", extra=self.extra_dict)
@@ -275,9 +247,9 @@ class TAFinisherTask(BaseCodecovTask, name=ta_finisher_task_name):
         commit_report = commit.commit_report(ReportType.TEST_RESULTS)
 
         totals = get_totals(commit_report, db_session)
-
-        if not any(previous_result):
-            return handle_processor_fail(totals, commit, commit_yaml)
+        uploads = get_uploads(
+            db_session, commit
+        )  # processed uploads that have yet to be persisted
 
         repo = commit.repository
         branch = commit.branch
@@ -294,28 +266,32 @@ class TAFinisherTask(BaseCodecovTask, name=ta_finisher_task_name):
         totals.skipped = test_summary.get("skip", 0)
         totals.passed = test_summary.get("pass", 0)
         db_session.flush()
-        if not totals.failed:
-            return {
-                "notify_attempted": False,
-                "notify_succeeded": False,
-                "queue_notify": True,
-            }
 
-        escaper = StringEscaper(ESCAPE_FAILURE_MESSAGE_DEFN)
-        shorten_paths = commit_yaml.read_yaml_field(
-            "test_analytics", "shorten_paths", _else=True
-        )
+        info = None
+        if totals.failed:
+            escaper = StringEscaper(ESCAPE_FAILURE_MESSAGE_DEFN)
+            shorten_paths = commit_yaml.read_yaml_field(
+                "test_analytics", "shorten_paths", _else=True
+            )
 
-        failures = []
-        populate_failures(
-            failures,
-            db_session,
-            repoid,
-            commitid,
-            shorten_paths,
-            uploads,
-            escaper,
-        )
+            failures = []
+            populate_failures(
+                failures,
+                db_session,
+                repoid,
+                commitid,
+                shorten_paths,
+                uploads,
+                escaper,
+            )
+
+            flaky_tests = dict()
+            if should_do_flaky_detection(repo, commit_yaml):
+                flaky_tests = get_flaky_tests(db_session, repoid, failures)
+
+            failures = sorted(failures, key=lambda x: x.duration_seconds)[:3]
+
+            info = TACommentInDepthInfo(failures, flaky_tests)
 
         additional_data: AdditionalData = {"upload_type": UploadType.TEST_RESULTS}
         repo_service = get_repo_provider_service(repo, additional_data=additional_data)
@@ -330,19 +306,31 @@ class TAFinisherTask(BaseCodecovTask, name=ta_finisher_task_name):
             if seat_activation_result:
                 return seat_activation_result
 
-        flaky_tests = dict()
-        if should_do_flaky_detection(repo, commit_yaml):
-            flaky_tests = get_flaky_tests(db_session, repoid, failures)
+        upload_error = (
+            db_session.query(UploadError)
+            .filter(UploadError.upload_id.in_(uploads.keys()))
+            .first()
+        )
 
-        failures = sorted(failures, key=lambda x: x.duration_seconds)[:3]
+        if not (info or upload_error):
+            return {
+                "notify_attempted": False,
+                "notify_succeeded": False,
+                "queue_notify": True,
+            }
+
         payload = TestResultsNotificationPayload(
-            totals.failed, totals.passed, totals.skipped, failures, flaky_tests
+            totals.failed, totals.passed, totals.skipped, info
         )
         notifier = TestResultsNotifier(
-            commit, commit_yaml, payload=payload, _pull=pull, _repo_service=repo_service
+            commit,
+            commit_yaml,
+            payload=payload,
+            _pull=pull,
+            _repo_service=repo_service,
+            error=upload_error,
         )
         notifier_result = notifier.notify()
-
         for upload in uploads.values():
             upload.state = "v2_finished"
         db_session.commit()
@@ -359,7 +347,7 @@ class TAFinisherTask(BaseCodecovTask, name=ta_finisher_task_name):
         return {
             "notify_attempted": True,
             "notify_succeeded": success,
-            "queue_notify": False,
+            "queue_notify": not info,
         }
 
     def seat_activation(


### PR DESCRIPTION
- we want to persist upload errors in the ta_processor
- we want to surface those errors when we notify either TA or coverage
