### PR TITLE
Install more shared `django_apps`

### DIFF
--- a/database/models/profiling.py
+++ b/database/models/profiling.py
@@ -32,7 +32,7 @@ class ProfilingCommit(CodecovBaseModel, MixinBaseClass):
 
 class ProfilingUpload(CodecovBaseModel, MixinBaseClass):
     __tablename__ = "profiling_profilingupload"
-    raw_upload_location = Column(types.Text)
+    raw_upload_location = Column(types.Text, nullable=False)
     profiling_commit_id = Column(
         types.BigInteger, ForeignKey("profiling_profilingcommit.id")
     )

--- a/database/models/staticanalysis.py
+++ b/database/models/staticanalysis.py
@@ -17,7 +17,7 @@ class StaticAnalysisSingleFileSnapshot(CodecovBaseModel, MixinBaseClass):
     repository_id = Column(types.Integer, ForeignKey("repos.repoid"))
     file_hash = Column(UUID, nullable=False)
     content_location = Column(types.Text, nullable=False)
-    state_id = Column(types.Integer)
+    state_id = Column(types.Integer, nullable=False)
     # relationships
     repository = relationship("Repository")
 

--- a/database/tests/factories/profiling.py
+++ b/database/tests/factories/profiling.py
@@ -14,6 +14,7 @@ class ProfilingCommitFactory(factory.Factory):
 
 class ProfilingUploadFactory(factory.Factory):
     profiling_commit = factory.SubFactory(ProfilingCommitFactory)
+    raw_upload_location = factory.Faker("url")
 
     class Meta:
         model = ProfilingUpload

--- a/database/tests/factories/staticanalysis.py
+++ b/database/tests/factories/staticanalysis.py
@@ -1,6 +1,7 @@
 from uuid import uuid4
 
 import factory
+from shared.labelanalysis import LabelAnalysisRequestState
 
 from database.models.staticanalysis import (
     StaticAnalysisSingleFileSnapshot,
@@ -24,6 +25,7 @@ class StaticAnalysisSingleFileSnapshotFactory(factory.Factory):
     repository = factory.SubFactory(RepositoryFactory)
     file_hash = factory.LazyFunction(lambda: uuid4().hex)
     content_location = factory.Faker("file_path", depth=3)
+    state_id = LabelAnalysisRequestState.CREATED.db_id
 
 
 class StaticAnalysisSuiteFilepathFactory(factory.Factory):

--- a/django_scaffold/settings.py
+++ b/django_scaffold/settings.py
@@ -19,14 +19,7 @@ GCS_BUCKET_NAME = get_config("services", "minio", "bucket", default="codecov")
 
 # Application definition
 INSTALLED_APPS = [
-    "shared.django_apps.legacy_migrations",
-    "shared.django_apps.codecov_auth",
-    "shared.django_apps.core",
-    "shared.django_apps.reports",
-    "shared.django_apps.pg_telemetry",
-    "shared.django_apps.rollouts",
-    "shared.django_apps.user_measurements",
-    "shared.django_apps.bundle_analysis",
+    # dependencies
     "psqlextra",
     # Needed to install legacy migrations
     "django.contrib.admin",
@@ -34,6 +27,19 @@ INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.messages",
     "django.contrib.sessions",
+    # Shared apps:
+    "shared.django_apps.legacy_migrations",
+    "shared.django_apps.pg_telemetry",
+    "shared.django_apps.rollouts",
+    "shared.django_apps.user_measurements",
+    "shared.django_apps.bundle_analysis",
+    "shared.django_apps.codecov_auth",
+    "shared.django_apps.compare",
+    "shared.django_apps.core",
+    "shared.django_apps.labelanalysis",
+    "shared.django_apps.profiling",
+    "shared.django_apps.reports",
+    "shared.django_apps.staticanalysis",
 ]
 
 TELEMETRY_VANILLA_DB = "default"

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/996ecb2aaf7767bf4c2944c75835c1ee1eb2b566.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/609e56d2aa30b26d44cddaba0e1ebd79ba954ac9.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/de4b37bc5a736317c6e7c93f9c58e9ae07f8c96b.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -372,7 +372,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.7.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/609e56d2aa30b26d44cddaba0e1ebd79ba954ac9.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/de4b37bc5a736317c6e7c93f9c58e9ae07f8c96b.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
This pulls in the following newly moved to `shared.django_apps`: `compare`, `labelanalysis`, `profiling` and `staticanalysis`

---

Depends on https://github.com/codecov/shared/pull/469