### PR TITLE
fix: Handle disabled shelter signals

### DIFF
--- a/database/events.py
+++ b/database/events.py
@@ -8,7 +8,6 @@ from sqlalchemy import event, inspect
 from database.models.core import Repository
 from helpers.environment import is_enterprise
 
-
 _pubsub_publisher = None
 
 log = logging.getLogger(__name__)

--- a/database/events.py
+++ b/database/events.py
@@ -1,7 +1,6 @@
 import json
 import logging
 
-from django.conf import settings
 from google.cloud import pubsub_v1
 from helpers.environment import is_enterprise
 from shared.config import get_config
@@ -12,6 +11,7 @@ from database.models.core import Repository
 _pubsub_publisher = None
 
 log = logging.getLogger(__name__)
+
 
 def _is_pubsub_enabled():
     try:

--- a/database/events.py
+++ b/database/events.py
@@ -13,21 +13,15 @@ _pubsub_publisher = None
 log = logging.getLogger(__name__)
 
 
-def _is_pubsub_enabled():
-    try:
-        return get_config(
-            "setup", "shelter", "enabled", default=False if is_enterprise() else True
-        )
-    except Exception as e:
-        log.warning(
-            "Failed to get shelter pubsub enabled config", extra=dict(error=str(e))
-        )
-        return False
+def _is_shelter_enabled():
+    return get_config(
+        "setup", "shelter", "enabled", default=False if is_enterprise() else True
+    )
 
 
 def _get_pubsub_publisher():
     global _pubsub_publisher
-    if not _pubsub_publisher and _is_pubsub_enabled():
+    if not _pubsub_publisher and _is_shelter_enabled():
         _pubsub_publisher = pubsub_v1.PublisherClient()
     return _pubsub_publisher
 
@@ -38,7 +32,7 @@ def _sync_repo(repository: Repository):
         pubsub_project_id = get_config("setup", "shelter", "pubsub_project_id")
         pubsub_topic_id = get_config("setup", "shelter", "sync_repo_topic_id")
 
-        if _is_pubsub_enabled() and pubsub_project_id and pubsub_topic_id:
+        if _is_shelter_enabled() and pubsub_project_id and pubsub_topic_id:
             publisher = _get_pubsub_publisher()
             topic_path = publisher.topic_path(pubsub_project_id, pubsub_topic_id)
             publisher.publish(

--- a/database/tests/unit/test_events.py
+++ b/database/tests/unit/test_events.py
@@ -55,6 +55,7 @@ def test_shelter_repo_sync(dbsession, mock_configuration, mocker):
         b'{"type": "repo", "sync": "one", "id": 91728376}',
     )
 
+
 def test_repo_sync_when_shelter_disabled(dbsession, mock_configuration, mocker):
     # this prevents the pubsub SDK from trying to load credentials
     os.environ["PUBSUB_EMULATOR_HOST"] = "localhost"


### PR DESCRIPTION
In self-hosted / enterprise, our customers may not always have shelter deployed. Add a check for those signals that call shelter to confirm first that shelter is enabled.

This PR is paired with a similar fix done in api [here](https://github.com/codecov/codecov-api/pull/1093) to fix `regenerateOrgUploadToken` when shelter disabled.

Closes https://github.com/codecov/engineering-team/issues/3212
