### PR TITLE
fix: persist has_failed status on upload

### DIFF
--- a/tasks/test_results_processor.py
+++ b/tasks/test_results_processor.py
@@ -402,6 +402,7 @@ class TestResultsProcessorTask(BaseCodecovTask, name=test_results_processor_task
                     commitid=upload.report.commit_id,
                     uploadid=upload.id,
                     parser_err_msg=str(exc),
+                    upload_state=upload.state,
                 ),
             )
             sentry_sdk.capture_exception(exc, tags={"upload_state": upload.state})


### PR DESCRIPTION
we want to commit this change as soon as we know it in order to make sure the upload state is consistent