### PR TITLE
Failed check and status messaging in comment, part I

### DIFF
--- a/database/enums.py
+++ b/database/enums.py
@@ -26,6 +26,16 @@ class Notification(Enum):
     codecov_slack_app = "codecov_slack_app"
 
 
+notification_type_status_or_checks = {
+    Notification.status_changes,
+    Notification.status_patch,
+    Notification.status_project,
+    Notification.checks_changes,
+    Notification.checks_patch,
+    Notification.checks_project,
+}
+
+
 class NotificationState(Enum):
     pending = "pending"
     success = "success"

--- a/services/notification/__init__.py
+++ b/services/notification/__init__.py
@@ -37,10 +37,7 @@ from services.notification.notifiers.checks.checks_with_fallback import (
     ChecksWithFallback,
 )
 from services.notification.notifiers.codecov_slack_app import CodecovSlackAppNotifier
-from services.notification.notifiers.mixins.status import (
-    StatusState,
-    custom_target_helper_text,
-)
+from services.notification.notifiers.mixins.status import StatusState
 from services.yaml import read_yaml_field
 from services.yaml.reader import get_components_from_yaml
 
@@ -261,7 +258,7 @@ class NotificationService(object):
         )
 
         results = []
-        add_custom_target_helper_text_to_pr_comment = False
+        status_or_checks_helper_text = {}
         notifiers_to_notify = [
             notifier
             for notifier in self.get_notifiers_instances()
@@ -280,34 +277,33 @@ class NotificationService(object):
             if notifier.notification_type not in notification_type_status_or_checks
         ]
 
-        if status_or_checks_notifiers and all_other_notifiers:
+        status_or_checks_results = [
+            self.notify_individual_notifier(notifier, comparison)
+            for notifier in status_or_checks_notifiers
+        ]
+
+        if status_or_checks_results and all_other_notifiers:
             # if the status/check fails, sometimes we want to add helper text to the message of the other notifications,
             # to better surface that the status/check failed.
             # so if there are status_and_checks_notifiers and all_other_notifiers, do the status_and_checks_notifiers first,
             # look at the results of the checks, if any failed AND they are the type we have helper text for,
             # add that text onto the other notifiers messages.
-            status_or_checks_results = [
-                self.notify_individual_notifier(notifier, comparison)
-                for notifier in status_or_checks_notifiers
-            ]
-
             for result in status_or_checks_results:
                 notification_result = result["result"]
                 if (
                     notification_result is not None
                     and notification_result.data_sent.get("state")
                     == StatusState.failure.value
-                ):
-                    if custom_target_helper_text in notification_result.data_sent.get(
-                        "message"
-                    ):
-                        add_custom_target_helper_text_to_pr_comment = True
-            results = results + status_or_checks_results
+                ) and notification_result.data_sent.get("included_helper_text"):
+                    status_or_checks_helper_text.update(
+                        notification_result.data_sent["included_helper_text"]
+                    )
+                    # TODO: pass status_or_checks_helper_text to all_other_notifiers,
+                    #  where they can integrate the helper text into their messages
+        results = results + status_or_checks_results
 
         results = results + [
-            self.notify_individual_notifier(
-                notifier, comparison, add_custom_target_helper_text_to_pr_comment
-            )
+            self.notify_individual_notifier(notifier, comparison)
             for notifier in all_other_notifiers
         ]
         return results
@@ -316,7 +312,6 @@ class NotificationService(object):
         self,
         notifier: AbstractBaseNotifier,
         comparison: ComparisonProxy,
-        add_custom_target_helper_text_to_pr_comment: bool = False,
     ) -> IndividualResult:
         commit = comparison.head.commit
         base_commit = comparison.project_coverage_base.commit
@@ -337,9 +332,7 @@ class NotificationService(object):
             notifier=notifier.name, title=notifier.title, result=None
         )
         try:
-            res = notifier.notify(
-                comparison, add_custom_target_helper_text_to_pr_comment
-            )
+            res = notifier.notify(comparison)
             individual_result["result"] = res
 
             notifier.store_results(comparison, res)

--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -1,6 +1,7 @@
 import logging
 from decimal import Decimal, InvalidOperation
 from enum import Enum
+from typing import Literal, TypedDict
 
 from services.comparison import ComparisonProxy, FilteredComparison
 from services.yaml.reader import round_number
@@ -13,10 +14,35 @@ class StatusState(Enum):
     failure = "failure"
 
 
-custom_target_helper_text = "Your project check has failed because the patch coverage is below the target coverage. You can increase the patch coverage or adjust the [target](https://docs.codecov.com/docs/commit-status#target) coverage."
+class StatusResult(TypedDict):
+    """
+    The mixins in this file do the calculations and decide the SuccessState for all Status and Checks Notifiers.
+    Checks have different fields than Statuses, so Checks are converted to the CheckResult type later.
+    """
+
+    state: Literal["success", "failure"]  # StatusState values
+    message: str
+    included_helper_text: dict[str, str]
+
+
+CUSTOM_TARGET_TEXT_PATCH_KEY = "custom_target_helper_text_patch"
+CUSTOM_TARGET_TEXT_PROJECT_KEY = "custom_target_helper_text_project"
+CUSTOM_TARGET_TEXT_VALUE = (
+    "Your {context} {notification_type} has failed because the patch coverage is below the target coverage. "
+    "You can increase the patch coverage or adjust the "
+    "[target](https://docs.codecov.com/docs/commit-status#target) coverage."
+)
+
+
+HELPER_TEXT_MAP = {
+    CUSTOM_TARGET_TEXT_PATCH_KEY: CUSTOM_TARGET_TEXT_VALUE,
+    CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE,
+}
 
 
 class StatusPatchMixin(object):
+    context = "patch"
+
     def _get_threshold(self) -> Decimal:
         """
         Threshold can be configured by user, default is 0.0
@@ -54,11 +80,12 @@ class StatusPatchMixin(object):
         return target_coverage, is_custom_target
 
     def get_patch_status(
-        self, comparison: ComparisonProxy | FilteredComparison
-    ) -> tuple[str, str]:
+        self, comparison: ComparisonProxy | FilteredComparison, notification_type: str
+    ) -> StatusResult:
         threshold = self._get_threshold()
         target_coverage, is_custom_target = self._get_target(comparison)
         totals = comparison.get_patch_totals()
+        included_helper_text = {}
 
         # coverage affected
         if totals and totals.lines > 0:
@@ -89,9 +116,16 @@ class StatusPatchMixin(object):
                     message = (
                         f"{coverage_rounded}% of diff hit (target {target_rounded}%)"
                     )
-                if state == StatusState.failure.value and is_custom_target:
-                    message = message + " - " + custom_target_helper_text
-            return state, message
+                # TODO:
+                # if state == StatusState.failure.value and is_custom_target:
+                #     helper_text = HELPER_TEXT_MAP[CUSTOM_TARGET_TEXT_PATCH_KEY].format(
+                #         context=self.context, notification_type=notification_type
+                #     )
+                #     included_helper_text[CUSTOM_TARGET_TEXT_PATCH_KEY] = helper_text
+                #     message = message + " - " + helper_text
+            return StatusResult(
+                state=state, message=message, included_helper_text=included_helper_text
+            )
 
         # coverage not affected
         if comparison.project_coverage_base.commit:
@@ -101,10 +135,16 @@ class StatusPatchMixin(object):
             )
         else:
             description = "Coverage not affected"
-        return StatusState.success.value, description
+        return StatusResult(
+            state=StatusState.success.value,
+            message=description,
+            included_helper_text=included_helper_text,
+        )
 
 
 class StatusChangesMixin(object):
+    context = "changes"
+
     def is_a_change_worth_noting(self, change) -> bool:
         if not change.new and not change.deleted:
             # has totals and not -10m => 10h
@@ -151,6 +191,7 @@ class StatusChangesMixin(object):
 
 class StatusProjectMixin(object):
     DEFAULT_REMOVED_CODE_BEHAVIOR = "adjust_base"
+    context = "project"
 
     def _apply_removals_only_behavior(
         self, comparison: ComparisonProxy | FilteredComparison
@@ -427,8 +468,11 @@ class StatusProjectMixin(object):
             # use rounded numbers for messages
             target_rounded = round_number(self.current_yaml, target_coverage)
             message = f"{head_coverage_rounded}% (target {target_rounded}%)"
-            if state == StatusState.failure.value:
-                message = message + " - " + custom_target_helper_text
+            # TODO:
+            # helper_text = HELPER_TEXT_MAP[CUSTOM_TARGET_TEXT].format(
+            # context=self.context, notification_type=notification_type)
+            # included_helper_text[CUSTOM_TARGET_TEXT] = helper_text
+            # message = message + " - " + helper_text
             return state, message
 
         # use rounded numbers for messages

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -703,7 +703,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "66.67% of diff hit (target 50.00%)",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_flag_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n66.67% of diff hit (target 50.00%)",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -729,7 +731,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "Codecov Report",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_upgrade_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nThe author of this PR, codecov-test-user, is not an activated member of this organization on Codecov.\nPlease [activate this user on Codecov](test.example.br/members/gh/test_build_upgrade_payload) to display a detailed status check.\nCoverage data is still being uploaded to Codecov.io for purposes of overall coverage calculations.\nPlease don't hesitate to email us at support@codecov.io with any questions.",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -761,6 +765,7 @@ class TestPatchChecksNotifier(object):
                     }
                 ],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result["output"]["summary"] == result["output"]["summary"]
@@ -783,7 +788,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "66.67% of diff hit (target 70.00%)",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_target_coverage_failure/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n66.67% of diff hit (target 70.00%)",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -819,6 +826,7 @@ class TestPatchChecksNotifier(object):
                     }
                 ],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison)
         assert expected_result == result
@@ -856,6 +864,7 @@ class TestPatchChecksNotifier(object):
                     }
                 ],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result["state"] == result["state"]
@@ -898,6 +907,7 @@ class TestPatchChecksNotifier(object):
                     }
                 ],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison_with_multiple_changes)
         assert expected_result["state"] == result["state"]
@@ -959,7 +969,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": f"Coverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_no_diff/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nCoverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert notifier.notification_type.value == "checks_patch"
@@ -1052,10 +1064,6 @@ class TestPatchChecksNotifier(object):
         mock_repo_provider.get_commit_statuses.return_value = Status([])
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
         comparison = sample_comparison
-        payload = {
-            "state": "success",
-            "output": {"title": "Codecov Report", "summary": "Summary"},
-        }
         mock_repo_provider.create_check_run.return_value = 2234563
         mock_repo_provider.update_check_run.return_value = "success"
         notifier = PatchChecksNotifier(
@@ -1076,7 +1084,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": f"Coverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_notify/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nCoverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_notify/{sample_comparison.head.commit.repository.name}/pull/{comparison.pull.pullid}",
         }
 
@@ -1105,7 +1115,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "Empty Upload",
                 "summary": "Non-testable files changed.",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_notify_passing_empty_upload/{sample_comparison.head.commit.repository.name}/pull/{comparison.pull.pullid}",
         }
 
@@ -1134,7 +1146,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "Empty Upload",
                 "summary": "Testable files changed",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_notify_failing_empty_upload/{sample_comparison.head.commit.repository.name}/pull/{comparison.pull.pullid}",
         }
 

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -2072,6 +2072,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (target 50.00%)",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2092,6 +2093,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "Please activate this user to display a detailed status check",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2111,6 +2113,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (target 70.00%)",
             "state": "failure",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2130,6 +2133,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (target 57.00%)",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2155,6 +2159,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (within 5.00% threshold of 70.00%)",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2180,6 +2185,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (target 70.00%)",
             "state": "failure",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2207,6 +2213,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (within 5.00% threshold of 70.00%)",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2257,6 +2264,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": f"Coverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2306,7 +2314,11 @@ class TestPatchStatusNotifier(object):
             current_yaml=UserYaml({}),
             repository_service=mock_repo_provider,
         )
-        expected_result = {"message": "Coverage not affected", "state": "success"}
+        expected_result = {
+            "message": "Coverage not affected",
+            "state": "success",
+            "included_helper_text": {},
+        }
         result = notifier.build_payload(comparison)
         assert expected_result == result
 
@@ -2329,6 +2341,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "No report found to compare against",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison)
         assert expected_result == result
@@ -2355,6 +2368,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "50.00% of diff hit (target 76.92%)",
             "state": "failure",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison_with_multiple_changes)
         assert expected_result == result

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -1257,9 +1257,16 @@ class TestNotifyTask(object):
             assert expected["result"].data_received == actual["result"].data_received
             assert expected["result"] == actual["result"]
             assert expected == actual
-        assert sorted(result["notifications"], key=lambda x: x["notifier"]) == sorted(
+
+        sorted_result = sorted(result["notifications"], key=lambda x: x["notifier"])
+        sorted_expected_result = sorted(
             expected_result["notifications"], key=lambda x: x["notifier"]
         )
+        assert len(sorted_result) == len(sorted_expected_result) == 7
+        assert sorted_result == sorted_expected_result
+
+        result["notifications"] = sorted_result
+        expected_result["notifications"] = sorted_expected_result
         assert result == expected_result
 
         pull = dbsession.query(Pull).filter_by(pullid=9, repoid=commit.repoid).first()


### PR DESCRIPTION
The goal of this epic is to communicate details about check or status failures in the other notifiers, like pr comment.

This is part 1, which is mostly new data structures and variables, and handling of notifications.

Right now we collect all notifications and execute them in any order, they are all independent and they don't know about each other. In this pr, I split notifications into 2 categories (checks/status notifications, or other notifications). Now the check/status notifications go first, because their outcome will impact the messaging in the other types of notifications.

The specific condition I will tackle next: add custom helper text for users that have specified a `target` in their `yaml`. If their check/status fails, we will add a message to the pr comment telling them that the check/status failed, with advice that mentions `target` and links them to the `target` docs. There are screenshots in the tix linked below.


What are check/status notifications? Check out [the best stack overflow answer I've ever seen](https://stackoverflow.com/questions/67919168/github-checks-api-vs-check-runs-vs-check-suites)

https://github.com/codecov/engineering-team/issues/1605
https://github.com/codecov/engineering-team/issues/1626
Epic here: https://github.com/codecov/engineering-team/issues/1133