### PR TITLE
redo: Failed check and status messaging in comment, part I

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,12 @@ codecov:
   notify:
     wait_for_ci: false
 
+coverage:
+  status:
+    patch:
+      default:
+        target: 99
+
 component_management:
   default_rules:
     statuses:

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,17 +3,11 @@ codecov:
   notify:
     wait_for_ci: false
 
-coverage:
-  status:
-    patch:
-      default:
-        target: 99
-
 component_management:
   default_rules:
     statuses:
-      - type: patch
-        target: 99
+      - type: project
+        target: auto
   individual_components:
     - component_id: actual_code
       name: NonTestCode

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,8 +6,8 @@ codecov:
 component_management:
   default_rules:
     statuses:
-      - type: project
-        target: auto
+      - type: patch
+        target: 99
   individual_components:
     - component_id: actual_code
       name: NonTestCode

--- a/database/enums.py
+++ b/database/enums.py
@@ -26,6 +26,16 @@ class Notification(Enum):
     codecov_slack_app = "codecov_slack_app"
 
 
+notification_type_status_or_checks = {
+    Notification.status_changes,
+    Notification.status_patch,
+    Notification.status_project,
+    Notification.checks_changes,
+    Notification.checks_patch,
+    Notification.checks_project,
+}
+
+
 class NotificationState(Enum):
     pending = "pending"
     success = "success"

--- a/services/notification/__init__.py
+++ b/services/notification/__init__.py
@@ -37,10 +37,7 @@ from services.notification.notifiers.checks.checks_with_fallback import (
     ChecksWithFallback,
 )
 from services.notification.notifiers.codecov_slack_app import CodecovSlackAppNotifier
-from services.notification.notifiers.mixins.status import (
-    StatusState,
-    custom_target_helper_text,
-)
+from services.notification.notifiers.mixins.status import StatusState
 from services.yaml import read_yaml_field
 from services.yaml.reader import get_components_from_yaml
 
@@ -261,7 +258,7 @@ class NotificationService(object):
         )
 
         results = []
-        add_custom_target_helper_text_to_pr_comment = False
+        status_or_checks_helper_text = {}
         notifiers_to_notify = [
             notifier
             for notifier in self.get_notifiers_instances()
@@ -280,34 +277,33 @@ class NotificationService(object):
             if notifier.notification_type not in notification_type_status_or_checks
         ]
 
-        if status_or_checks_notifiers and all_other_notifiers:
+        status_or_checks_results = [
+            self.notify_individual_notifier(notifier, comparison)
+            for notifier in status_or_checks_notifiers
+        ]
+
+        if status_or_checks_results and all_other_notifiers:
             # if the status/check fails, sometimes we want to add helper text to the message of the other notifications,
             # to better surface that the status/check failed.
             # so if there are status_and_checks_notifiers and all_other_notifiers, do the status_and_checks_notifiers first,
             # look at the results of the checks, if any failed AND they are the type we have helper text for,
             # add that text onto the other notifiers messages.
-            status_or_checks_results = [
-                self.notify_individual_notifier(notifier, comparison)
-                for notifier in status_or_checks_notifiers
-            ]
-
             for result in status_or_checks_results:
                 notification_result = result["result"]
                 if (
                     notification_result is not None
                     and notification_result.data_sent.get("state")
                     == StatusState.failure.value
-                ):
-                    if custom_target_helper_text in notification_result.data_sent.get(
-                        "message"
-                    ):
-                        add_custom_target_helper_text_to_pr_comment = True
-            results = results + status_or_checks_results
+                ) and notification_result.data_sent.get("included_helper_text"):
+                    status_or_checks_helper_text.update(
+                        notification_result.data_sent["included_helper_text"]
+                    )
+                    # TODO: pass status_or_checks_helper_text to all_other_notifiers,
+                    #  where they can integrate the helper text into their messages
+        results = results + status_or_checks_results
 
         results = results + [
-            self.notify_individual_notifier(
-                notifier, comparison, add_custom_target_helper_text_to_pr_comment
-            )
+            self.notify_individual_notifier(notifier, comparison)
             for notifier in all_other_notifiers
         ]
         return results
@@ -316,7 +312,6 @@ class NotificationService(object):
         self,
         notifier: AbstractBaseNotifier,
         comparison: ComparisonProxy,
-        add_custom_target_helper_text_to_pr_comment: bool = False,
     ) -> IndividualResult:
         commit = comparison.head.commit
         base_commit = comparison.project_coverage_base.commit
@@ -337,9 +332,7 @@ class NotificationService(object):
             notifier=notifier.name, title=notifier.title, result=None
         )
         try:
-            res = notifier.notify(
-                comparison, add_custom_target_helper_text_to_pr_comment
-            )
+            res = notifier.notify(comparison)
             individual_result["result"] = res
 
             notifier.store_results(comparison, res)

--- a/services/notification/__init__.py
+++ b/services/notification/__init__.py
@@ -292,14 +292,17 @@ class NotificationService(object):
                 notification_result = result["result"]
                 if (
                     notification_result is not None
-                    and notification_result.data_sent.get("state")
-                    == StatusState.failure.value
-                ) and notification_result.data_sent.get("included_helper_text"):
-                    status_or_checks_helper_text.update(
-                        notification_result.data_sent["included_helper_text"]
-                    )
-                    # TODO: pass status_or_checks_helper_text to all_other_notifiers,
-                    #  where they can integrate the helper text into their messages
+                    and notification_result.data_sent is not None
+                ):
+                    if (
+                        notification_result.data_sent.get("state")
+                        == StatusState.failure.value
+                    ) and notification_result.data_sent.get("included_helper_text"):
+                        status_or_checks_helper_text.update(
+                            notification_result.data_sent["included_helper_text"]
+                        )
+                        # TODO: pass status_or_checks_helper_text to all_other_notifiers,
+                        #  where they can integrate the helper text into their messages
         results = results + status_or_checks_results
 
         results = results + [

--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -1,6 +1,7 @@
 import logging
 from decimal import Decimal, InvalidOperation
 from enum import Enum
+from typing import Literal, TypedDict
 
 from services.comparison import ComparisonProxy, FilteredComparison
 from services.yaml.reader import round_number
@@ -13,10 +14,35 @@ class StatusState(Enum):
     failure = "failure"
 
 
-custom_target_helper_text = "Your project check has failed because the patch coverage is below the target coverage. You can increase the patch coverage or adjust the [target](https://docs.codecov.com/docs/commit-status#target) coverage."
+class StatusResult(TypedDict):
+    """
+    The mixins in this file do the calculations and decide the SuccessState for all Status and Checks Notifiers.
+    Checks have different fields than Statuses, so Checks are converted to the CheckResult type later.
+    """
+
+    state: Literal["success", "failure"]  # StatusState values
+    message: str
+    included_helper_text: dict[str, str]
+
+
+CUSTOM_TARGET_TEXT_PATCH_KEY = "custom_target_helper_text_patch"
+CUSTOM_TARGET_TEXT_PROJECT_KEY = "custom_target_helper_text_project"
+CUSTOM_TARGET_TEXT_VALUE = (
+    "Your {context} {notification_type} has failed because the patch coverage is below the target coverage. "
+    "You can increase the patch coverage or adjust the "
+    "[target](https://docs.codecov.com/docs/commit-status#target) coverage."
+)
+
+
+HELPER_TEXT_MAP = {
+    CUSTOM_TARGET_TEXT_PATCH_KEY: CUSTOM_TARGET_TEXT_VALUE,
+    CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE,
+}
 
 
 class StatusPatchMixin(object):
+    context = "patch"
+
     def _get_threshold(self) -> Decimal:
         """
         Threshold can be configured by user, default is 0.0
@@ -54,11 +80,12 @@ class StatusPatchMixin(object):
         return target_coverage, is_custom_target
 
     def get_patch_status(
-        self, comparison: ComparisonProxy | FilteredComparison
-    ) -> tuple[str, str]:
+        self, comparison: ComparisonProxy | FilteredComparison, notification_type: str
+    ) -> StatusResult:
         threshold = self._get_threshold()
         target_coverage, is_custom_target = self._get_target(comparison)
         totals = comparison.get_patch_totals()
+        included_helper_text = {}
 
         # coverage affected
         if totals and totals.lines > 0:
@@ -89,9 +116,16 @@ class StatusPatchMixin(object):
                     message = (
                         f"{coverage_rounded}% of diff hit (target {target_rounded}%)"
                     )
-                if state == StatusState.failure.value and is_custom_target:
-                    message = message + " - " + custom_target_helper_text
-            return state, message
+                # TODO:
+                # if state == StatusState.failure.value and is_custom_target:
+                #     helper_text = HELPER_TEXT_MAP[CUSTOM_TARGET_TEXT_PATCH_KEY].format(
+                #         context=self.context, notification_type=notification_type
+                #     )
+                #     included_helper_text[CUSTOM_TARGET_TEXT_PATCH_KEY] = helper_text
+                #     message = message + " - " + helper_text
+            return StatusResult(
+                state=state, message=message, included_helper_text=included_helper_text
+            )
 
         # coverage not affected
         if comparison.project_coverage_base.commit:
@@ -101,10 +135,16 @@ class StatusPatchMixin(object):
             )
         else:
             description = "Coverage not affected"
-        return StatusState.success.value, description
+        return StatusResult(
+            state=StatusState.success.value,
+            message=description,
+            included_helper_text=included_helper_text,
+        )
 
 
 class StatusChangesMixin(object):
+    context = "changes"
+
     def is_a_change_worth_noting(self, change) -> bool:
         if not change.new and not change.deleted:
             # has totals and not -10m => 10h
@@ -151,6 +191,7 @@ class StatusChangesMixin(object):
 
 class StatusProjectMixin(object):
     DEFAULT_REMOVED_CODE_BEHAVIOR = "adjust_base"
+    context = "project"
 
     def _apply_removals_only_behavior(
         self, comparison: ComparisonProxy | FilteredComparison
@@ -427,8 +468,11 @@ class StatusProjectMixin(object):
             # use rounded numbers for messages
             target_rounded = round_number(self.current_yaml, target_coverage)
             message = f"{head_coverage_rounded}% (target {target_rounded}%)"
-            if state == StatusState.failure.value:
-                message = message + " - " + custom_target_helper_text
+            # TODO:
+            # helper_text = HELPER_TEXT_MAP[CUSTOM_TARGET_TEXT].format(
+            # context=self.context, notification_type=notification_type)
+            # included_helper_text[CUSTOM_TARGET_TEXT] = helper_text
+            # message = message + " - " + helper_text
             return state, message
 
         # use rounded numbers for messages

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -703,7 +703,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "66.67% of diff hit (target 50.00%)",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_flag_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n66.67% of diff hit (target 50.00%)",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -729,7 +731,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "Codecov Report",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_upgrade_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nThe author of this PR, codecov-test-user, is not an activated member of this organization on Codecov.\nPlease [activate this user on Codecov](test.example.br/members/gh/test_build_upgrade_payload) to display a detailed status check.\nCoverage data is still being uploaded to Codecov.io for purposes of overall coverage calculations.\nPlease don't hesitate to email us at support@codecov.io with any questions.",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -761,6 +765,7 @@ class TestPatchChecksNotifier(object):
                     }
                 ],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result["output"]["summary"] == result["output"]["summary"]
@@ -783,7 +788,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "66.67% of diff hit (target 70.00%)",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_target_coverage_failure/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n66.67% of diff hit (target 70.00%)",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -819,6 +826,7 @@ class TestPatchChecksNotifier(object):
                     }
                 ],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison)
         assert expected_result == result
@@ -856,6 +864,7 @@ class TestPatchChecksNotifier(object):
                     }
                 ],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result["state"] == result["state"]
@@ -898,6 +907,7 @@ class TestPatchChecksNotifier(object):
                     }
                 ],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison_with_multiple_changes)
         assert expected_result["state"] == result["state"]
@@ -959,7 +969,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": f"Coverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_no_diff/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nCoverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert notifier.notification_type.value == "checks_patch"
@@ -1052,10 +1064,6 @@ class TestPatchChecksNotifier(object):
         mock_repo_provider.get_commit_statuses.return_value = Status([])
         mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
         comparison = sample_comparison
-        payload = {
-            "state": "success",
-            "output": {"title": "Codecov Report", "summary": "Summary"},
-        }
         mock_repo_provider.create_check_run.return_value = 2234563
         mock_repo_provider.update_check_run.return_value = "success"
         notifier = PatchChecksNotifier(
@@ -1076,7 +1084,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": f"Coverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_notify/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nCoverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_notify/{sample_comparison.head.commit.repository.name}/pull/{comparison.pull.pullid}",
         }
 
@@ -1105,7 +1115,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "Empty Upload",
                 "summary": "Non-testable files changed.",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_notify_passing_empty_upload/{sample_comparison.head.commit.repository.name}/pull/{comparison.pull.pullid}",
         }
 
@@ -1134,7 +1146,9 @@ class TestPatchChecksNotifier(object):
             "output": {
                 "title": "Empty Upload",
                 "summary": "Testable files changed",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_notify_failing_empty_upload/{sample_comparison.head.commit.repository.name}/pull/{comparison.pull.pullid}",
         }
 

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -2072,6 +2072,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (target 50.00%)",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2092,6 +2093,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "Please activate this user to display a detailed status check",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2111,6 +2113,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (target 70.00%)",
             "state": "failure",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2130,6 +2133,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (target 57.00%)",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2155,6 +2159,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (within 5.00% threshold of 70.00%)",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2180,6 +2185,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (target 70.00%)",
             "state": "failure",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2207,6 +2213,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "66.67% of diff hit (within 5.00% threshold of 70.00%)",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2257,6 +2264,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": f"Coverage not affected when comparing {base_commit.commitid[:7]}...{head_commit.commitid[:7]}",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2306,7 +2314,11 @@ class TestPatchStatusNotifier(object):
             current_yaml=UserYaml({}),
             repository_service=mock_repo_provider,
         )
-        expected_result = {"message": "Coverage not affected", "state": "success"}
+        expected_result = {
+            "message": "Coverage not affected",
+            "state": "success",
+            "included_helper_text": {},
+        }
         result = notifier.build_payload(comparison)
         assert expected_result == result
 
@@ -2329,6 +2341,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "No report found to compare against",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison)
         assert expected_result == result
@@ -2355,6 +2368,7 @@ class TestPatchStatusNotifier(object):
         expected_result = {
             "message": "50.00% of diff hit (target 76.92%)",
             "state": "failure",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison_with_multiple_changes)
         assert expected_result == result

--- a/services/notification/tests/unit/test_notification_service.py
+++ b/services/notification/tests/unit/test_notification_service.py
@@ -1,922 +1,912 @@
-# import os
-# from asyncio import CancelledError
-# from asyncio import TimeoutError as AsyncioTimeoutError
-#
-# import mock
-# import pytest
-# from celery.exceptions import SoftTimeLimitExceeded
-# from shared.plan.constants import PlanName
-# from shared.reports.resources import Report, ReportFile, ReportLine
-# from shared.torngit.status import Status
-# from shared.yaml import UserYaml
-#
-# from database.enums import Decoration, Notification, NotificationState
-# from database.models.core import (
-#     GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-#     GithubAppInstallation,
-# )
-# from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
-# from services.comparison import ComparisonProxy
-# from services.comparison.types import Comparison, EnrichedPull, FullCommit
-# from services.notification import NotificationService
-# from services.notification.notifiers import StatusType
-# from services.notification.notifiers.base import NotificationResult
-# from services.notification.notifiers.checks import ProjectChecksNotifier
-# from services.notification.notifiers.checks.checks_with_fallback import (
-#     ChecksWithFallback,
-# )
-#
-#
-# @pytest.fixture
-# def sample_comparison(dbsession, request):
-#     repository = RepositoryFactory.create(
-#         owner__username=request.node.name, owner__service="github"
-#     )
-#     dbsession.add(repository)
-#     dbsession.flush()
-#     base_commit = CommitFactory.create(repository=repository)
-#     head_commit = CommitFactory.create(repository=repository, branch="new_branch")
-#     pull = PullFactory.create(
-#         repository=repository, base=base_commit.commitid, head=head_commit.commitid
-#     )
-#     dbsession.add(base_commit)
-#     dbsession.add(head_commit)
-#     dbsession.add(pull)
-#     dbsession.flush()
-#     repository = base_commit.repository
-#     base_full_commit = FullCommit(commit=base_commit, report=None)
-#     head_full_commit = FullCommit(commit=head_commit, report=None)
-#     return ComparisonProxy(
-#         Comparison(
-#             head=head_full_commit,
-#             project_coverage_base=base_full_commit,
-#             patch_coverage_base_commitid=base_commit.commitid,
-#             enriched_pull=EnrichedPull(database_pull=pull, provider_pull={}),
-#         )
-#     )
-#
-#
-# class TestNotificationService(object):
-#     def test_should_use_checks_notifier_yaml_field_false(self, dbsession):
-#         repository = RepositoryFactory.create()
-#         current_yaml = {"github_checks": False}
-#         service = NotificationService(repository, current_yaml, None)
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-#             == False
-#         )
-#
-#     @pytest.mark.parametrize(
-#         "repo_data,outcome",
-#         [
-#             (
-#                 dict(
-#                     using_integration=True,
-#                     owner__integration_id=12341234,
-#                     owner__service="github",
-#                 ),
-#                 True,
-#             ),
-#             (
-#                 dict(
-#                     using_integration=True,
-#                     owner__integration_id=12341234,
-#                     owner__service="gitlab",
-#                 ),
-#                 False,
-#             ),
-#             (
-#                 dict(
-#                     using_integration=True,
-#                     owner__integration_id=12341234,
-#                     owner__service="github_enterprise",
-#                 ),
-#                 True,
-#             ),
-#             (
-#                 dict(
-#                     using_integration=False,
-#                     owner__integration_id=None,
-#                     owner__service="github",
-#                 ),
-#                 False,
-#             ),
-#         ],
-#     )
-#     def test_should_use_checks_notifier_deprecated_flow(
-#         self, repo_data, outcome, dbsession
-#     ):
-#         repository = RepositoryFactory.create(**repo_data)
-#         current_yaml = {"github_checks": True}
-#         assert repository.owner.github_app_installations == []
-#         service = NotificationService(repository, current_yaml, None)
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-#             == outcome
-#         )
-#
-#     def test_should_use_checks_notifier_ghapp_all_repos_covered(self, dbsession):
-#         repository = RepositoryFactory.create(owner__service="github")
-#         ghapp_installation = GithubAppInstallation(
-#             name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-#             installation_id=456789,
-#             owner=repository.owner,
-#             repository_service_ids=None,
-#         )
-#         dbsession.add(ghapp_installation)
-#         dbsession.flush()
-#         current_yaml = {"github_checks": True}
-#         assert repository.owner.github_app_installations == [ghapp_installation]
-#         service = NotificationService(repository, current_yaml, None)
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-#             == True
-#         )
-#
-#     def test_use_checks_notifier_for_team_plan(self, dbsession):
-#         repository = RepositoryFactory.create(
-#             owner__service="github", owner__plan=PlanName.TEAM_MONTHLY.value
-#         )
-#         ghapp_installation = GithubAppInstallation(
-#             name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-#             installation_id=456789,
-#             owner=repository.owner,
-#             repository_service_ids=None,
-#         )
-#         dbsession.add(ghapp_installation)
-#         dbsession.flush()
-#         current_yaml = {"github_checks": True}
-#         assert repository.owner.github_app_installations == [ghapp_installation]
-#         service = NotificationService(repository, current_yaml, None)
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-#             == False
-#         )
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
-#             == False
-#         )
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
-#             == True
-#         )
-#
-#     def test_use_status_notifier_for_team_plan(self, dbsession):
-#         repository = RepositoryFactory.create(
-#             owner__service="github", owner__plan=PlanName.TEAM_MONTHLY.value
-#         )
-#         ghapp_installation = GithubAppInstallation(
-#             name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-#             installation_id=456789,
-#             owner=repository.owner,
-#             repository_service_ids=None,
-#         )
-#         dbsession.add(ghapp_installation)
-#         dbsession.flush()
-#         current_yaml = {"github_checks": True}
-#         assert repository.owner.github_app_installations == [ghapp_installation]
-#         service = NotificationService(repository, current_yaml, None)
-#         assert (
-#             service._should_use_status_notifier(status_type=StatusType.PROJECT.value)
-#             == False
-#         )
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
-#             == False
-#         )
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
-#             == True
-#         )
-#
-#     def test_use_status_notifier_for_non_team_plan(self, dbsession):
-#         repository = RepositoryFactory.create(
-#             owner__service="github", owner__plan=PlanName.CODECOV_PRO_MONTHLY.value
-#         )
-#         ghapp_installation = GithubAppInstallation(
-#             name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-#             installation_id=456789,
-#             owner=repository.owner,
-#             repository_service_ids=None,
-#         )
-#         dbsession.add(ghapp_installation)
-#         dbsession.flush()
-#         current_yaml = {"github_checks": True}
-#         assert repository.owner.github_app_installations == [ghapp_installation]
-#         service = NotificationService(repository, current_yaml, None)
-#         assert (
-#             service._should_use_status_notifier(status_type=StatusType.PROJECT.value)
-#             == True
-#         )
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
-#             == True
-#         )
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
-#             == True
-#         )
-#
-#     @pytest.mark.parametrize(
-#         "gh_installation_name",
-#         [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
-#     )
-#     def test_should_use_checks_notifier_ghapp_some_repos_covered(
-#         self, dbsession, gh_installation_name
-#     ):
-#         repository = RepositoryFactory.create(owner__service="github")
-#         other_repo_same_owner = RepositoryFactory.create(owner=repository.owner)
-#         ghapp_installation = GithubAppInstallation(
-#             name=gh_installation_name,
-#             installation_id=456789,
-#             owner=repository.owner,
-#             repository_service_ids=[repository.service_id],
-#             app_id=123123,
-#             pem_path="path_to_pem_file",
-#         )
-#         dbsession.add(ghapp_installation)
-#         dbsession.flush()
-#         current_yaml = {"github_checks": True}
-#         assert repository.owner.github_app_installations == [ghapp_installation]
-#         service = NotificationService(
-#             repository,
-#             current_yaml,
-#             None,
-#             gh_installation_name_to_use=gh_installation_name,
-#         )
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-#             == True
-#         )
-#         service = NotificationService(other_repo_same_owner, current_yaml, None)
-#         assert (
-#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-#             == False
-#         )
-#
-#     def test_get_notifiers_instances_only_third_party(
-#         self, dbsession, mock_configuration
-#     ):
-#         mock_configuration.params["services"] = {
-#             "notifications": {"slack": ["slack.com"]}
-#         }
-#         repository = RepositoryFactory.create(
-#             owner__unencrypted_oauth_token="testlln8sdeec57lz83oe3l8y9qq4lhqat2f1kzm",
-#             owner__username="ThiagoCodecov",
-#             yaml={"codecov": {"max_report_age": "1y ago"}},
-#             name="example-python",
-#         )
-#         dbsession.add(repository)
-#         dbsession.flush()
-#         current_yaml = {
-#             "coverage": {"notify": {"slack": {"default": {"field": "1y ago"}}}}
-#         }
-#         service = NotificationService(repository, current_yaml, None)
-#         instances = list(service.get_notifiers_instances())
-#         assert len(instances) == 2
-#         instance = instances[0]
-#         assert instance.repository == repository
-#         assert instance.title == "default"
-#         assert instance.notifier_yaml_settings == {"field": "1y ago"}
-#         assert instance.site_settings == ["slack.com"]
-#         assert instance.current_yaml == current_yaml
-#
-#     def test_get_notifiers_instances_checks(
-#         self, dbsession, mock_configuration, mocker
-#     ):
-#         repository = RepositoryFactory.create(
-#             owner__integration_id=123,
-#             owner__service="github",
-#             yaml={"codecov": {"max_report_age": "1y ago"}},
-#             name="example-python",
-#             using_integration=True,
-#         )
-#
-#         dbsession.add(repository)
-#         dbsession.flush()
-#         current_yaml = {
-#             "coverage": {"status": {"project": True, "patch": True, "changes": True}}
-#         }
-#         mocker.patch.dict(
-#             os.environ, {"CHECKS_WHITELISTED_OWNERS": f"0,{repository.owner.ownerid}"}
-#         )
-#         service = NotificationService(repository, current_yaml, None)
-#         instances = list(service.get_notifiers_instances())
-#         names = sorted([instance.name for instance in instances])
-#         assert names == [
-#             "checks-changes-with-fallback",
-#             "checks-patch-with-fallback",
-#             "checks-project-with-fallback",
-#             "codecov-slack-app",
-#         ]
-#
-#     def test_get_notifiers_instances_slack_app_false(
-#         self, dbsession, mock_configuration, mocker
-#     ):
-#         mocker.patch("services.notification.get_config", return_value=False)
-#         repository = RepositoryFactory.create(
-#             owner__integration_id=123,
-#             owner__service="github",
-#             yaml={"codecov": {"max_report_age": "1y ago"}},
-#             name="example-python",
-#             using_integration=True,
-#         )
-#
-#         dbsession.add(repository)
-#         dbsession.flush()
-#         current_yaml = {
-#             "coverage": {"status": {"project": True, "patch": True, "changes": True}}
-#         }
-#         mocker.patch.dict(
-#             os.environ, {"CHECKS_WHITELISTED_OWNERS": f"0,{repository.owner.ownerid}"}
-#         )
-#         service = NotificationService(repository, current_yaml, None)
-#         instances = list(service.get_notifiers_instances())
-#         names = sorted([instance.name for instance in instances])
-#         assert names == [
-#             "checks-changes-with-fallback",
-#             "checks-patch-with-fallback",
-#             "checks-project-with-fallback",
-#         ]
-#
-#     @pytest.mark.parametrize(
-#         "gh_installation_name",
-#         [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
-#     )
-#     def test_get_notifiers_instances_checks_percentage_whitelist(
-#         self, dbsession, mock_configuration, mocker, gh_installation_name
-#     ):
-#         repository = RepositoryFactory.create(
-#             owner__integration_id=123,
-#             owner__service="github",
-#             owner__ownerid=1234,
-#             yaml={"codecov": {"max_report_age": "1y ago"}},
-#             name="example-python",
-#             using_integration=True,
-#         )
-#         dbsession.add(repository)
-#         dbsession.flush()
-#         current_yaml = {
-#             "coverage": {"status": {"project": True, "patch": True, "changes": True}}
-#         }
-#         mocker.patch.dict(
-#             os.environ,
-#             {
-#                 "CHECKS_WHITELISTED_OWNERS": "0,1",
-#                 "CHECKS_WHITELISTED_PERCENTAGE": "35",
-#             },
-#         )
-#         service = NotificationService(
-#             repository,
-#             current_yaml,
-#             gh_installation_name,
-#         )
-#         instances = list(service.get_notifiers_instances())
-#         # we don't need that for slack-app notifier
-#         names = [
-#             instance._checks_notifier.name
-#             for instance in instances
-#             if instance.name != "codecov-slack-app"
-#         ]
-#         assert names == ["checks-project", "checks-patch", "checks-changes"]
-#         for instance in instances:
-#             if isinstance(instance, ChecksWithFallback):
-#                 assert (
-#                     instance._checks_notifier.repository_service == gh_installation_name
-#                 )
-#                 assert (
-#                     instance._status_notifier.repository_service == gh_installation_name
-#                 )
-#             else:
-#                 assert instance.repository_service == gh_installation_name
-#
-#     @pytest.mark.parametrize(
-#         "gh_installation_name",
-#         [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
-#     )
-#     def test_get_notifiers_instances_comment(
-#         self, dbsession, mock_configuration, mocker, gh_installation_name
-#     ):
-#         repository = RepositoryFactory.create(
-#             owner__integration_id=123,
-#             owner__service="github",
-#             owner__ownerid=1234,
-#             yaml={"codecov": {"max_report_age": "1y ago"}},
-#             name="example-python",
-#             using_integration=True,
-#         )
-#         dbsession.add(repository)
-#         dbsession.flush()
-#         current_yaml = {"comment": {"layout": "condensed_header"}, "slack_app": False}
-#         service = NotificationService(
-#             repository,
-#             current_yaml,
-#             gh_installation_name,
-#         )
-#         instances = list(service.get_notifiers_instances())
-#         assert len(instances) == 1
-#         assert instances[0].repository_service == gh_installation_name
-#
-#     def test_notify_general_exception(self, mocker, dbsession, sample_comparison):
-#         current_yaml = {}
-#         commit = sample_comparison.head.commit
-#         good_notifier = mocker.MagicMock(
-#             is_enabled=mocker.MagicMock(return_value=True),
-#             title="good_notifier",
-#             notification_type=Notification.comment,
-#             decoration_type=Decoration.standard,
-#             notify=mock.Mock(),
-#         )
-#         bad_notifier = mocker.MagicMock(
-#             is_enabled=mocker.MagicMock(return_value=True),
-#             title="bad_notifier",
-#             notification_type=Notification.status_project,
-#             decoration_type=Decoration.standard,
-#         )
-#         disabled_notifier = mocker.MagicMock(
-#             is_enabled=mocker.MagicMock(return_value=False),
-#             title="disabled_notifier",
-#             notification_type=Notification.status_patch,
-#             decoration_type=Decoration.standard,
-#             notify=mock.Mock(),
-#         )
-#         good_notifier.notify.return_value = NotificationResult(
-#             notification_attempted=True,
-#             notification_successful=True,
-#             explanation="",
-#             data_sent={"some": "data"},
-#         )
-#         good_notifier.name = "good_name"
-#         bad_notifier.name = "bad_name"
-#         disabled_notifier.name = "disabled_notifier_name"
-#         bad_notifier.notify.side_effect = Exception("This is bad")
-#         mocker.patch.object(
-#             NotificationService,
-#             "get_notifiers_instances",
-#             return_value=[bad_notifier, good_notifier, disabled_notifier],
-#         )
-#         notifications_service = NotificationService(
-#             commit.repository, current_yaml, None
-#         )
-#         expected_result = [
-#             {"notifier": "bad_name", "title": "bad_notifier", "result": None},
-#             {
-#                 "notifier": "good_name",
-#                 "title": "good_notifier",
-#                 "result": NotificationResult(
-#                     notification_attempted=True,
-#                     notification_successful=True,
-#                     explanation="",
-#                     data_sent={"some": "data"},
-#                     data_received=None,
-#                 ),
-#             },
-#         ]
-#         res = notifications_service.notify(sample_comparison)
-#         assert expected_result == res
-#
-#     def test_notify_data_sent_None(self, mocker, dbsession, sample_comparison):
-#         current_yaml = {}
-#         commit = sample_comparison.head.commit
-#         good_notifier = mocker.MagicMock(
-#             is_enabled=mocker.MagicMock(return_value=True),
-#             title="good_notifier",
-#             notification_type=Notification.comment,
-#             decoration_type=Decoration.standard,
-#             notify=mock.Mock(),
-#         )
-#         skipped_notifier = mocker.MagicMock(
-#             is_enabled=mocker.MagicMock(return_value=True),
-#             title="skippy_notifier",
-#             notification_type=Notification.status_project,
-#             decoration_type=Decoration.standard,
-#         )
-#         good_notifier.notify.return_value = NotificationResult(
-#             notification_attempted=True,
-#             notification_successful=True,
-#             explanation="",
-#             data_sent={"some": "data"},
-#         )
-#         skipped_expected_return = NotificationResult(
-#             notification_attempted=False,
-#             notification_successful=None,
-#             explanation="exclude_flag_coverage_not_uploaded_checks",
-#             data_sent=None,
-#             data_received=None,
-#             github_app_used=None,
-#         )
-#         skipped_notifier.notify.return_value = skipped_expected_return
-#         good_notifier.name = "good_name"
-#         skipped_notifier.name = "skippy"
-#
-#         mocker.patch.object(
-#             NotificationService,
-#             "get_notifiers_instances",
-#             return_value=[skipped_notifier, good_notifier],
-#         )
-#
-#         notifications_service = NotificationService(
-#             commit.repository, current_yaml, None
-#         )
-#         expected_result = [
-#             {
-#                 "notifier": "skippy",
-#                 "title": "skippy_notifier",
-#                 "result": skipped_expected_return,
-#             },
-#             {
-#                 "notifier": "good_name",
-#                 "title": "good_notifier",
-#                 "result": NotificationResult(
-#                     notification_attempted=True,
-#                     notification_successful=True,
-#                     explanation="",
-#                     data_sent={"some": "data"},
-#                     data_received=None,
-#                 ),
-#             },
-#         ]
-#         res = notifications_service.notify(sample_comparison)
-#         assert expected_result == res
-#
-#     def test_notify_individual_notifier_timeout(self, mocker, sample_comparison):
-#         current_yaml = {}
-#         commit = sample_comparison.head.commit
-#         notifier = mocker.MagicMock(
-#             title="fake_notifier",
-#             notify=mock.Mock(),
-#             notification_type=Notification.comment,
-#             decoration_type=Decoration.standard,
-#         )
-#         notifier.notify.side_effect = AsyncioTimeoutError
-#         notifications_service = NotificationService(
-#             commit.repository, current_yaml, None
-#         )
-#         res = notifications_service.notify_individual_notifier(
-#             notifier, sample_comparison
-#         )
-#         assert res == {
-#             "notifier": notifier.name,
-#             "result": None,
-#             "title": "fake_notifier",
-#         }
-#
-#     def test_notify_individual_checks_notifier(
-#         self, mocker, sample_comparison, mock_repo_provider, mock_configuration
-#     ):
-#         mock_repo_provider.get_commit_statuses.return_value = Status([])
-#         mock_configuration._params["setup"] = {"codecov_dashboard_url": "test"}
-#         current_yaml = {}
-#         commit = sample_comparison.head.commit
-#         report = Report()
-#         first_deleted_file = ReportFile("file_1.go")
-#         first_deleted_file.append(1, ReportLine.create(coverage=0, sessions=[]))
-#         first_deleted_file.append(2, ReportLine.create(coverage=0, sessions=[]))
-#         first_deleted_file.append(3, ReportLine.create(coverage=0, sessions=[]))
-#         first_deleted_file.append(5, ReportLine.create(coverage=0, sessions=[]))
-#         report.append(first_deleted_file)
-#         sample_comparison.head.report = report
-#         mock_repo_provider.create_check_run.return_value = 2234563
-#         mock_repo_provider.update_check_run.return_value = "success"
-#         notifier = ProjectChecksNotifier(
-#             repository=sample_comparison.head.commit.repository,
-#             title="title",
-#             notifier_yaml_settings={"flags": ["flagone"]},
-#             notifier_site_settings=True,
-#             current_yaml=UserYaml({}),
-#             repository_service=mock_repo_provider,
-#         )
-#         notifications_service = NotificationService(
-#             commit.repository, current_yaml, mock_repo_provider
-#         )
-#         res = notifications_service.notify_individual_notifier(
-#             notifier, sample_comparison
-#         )
-#
-#         assert res == {
-#             "notifier": "checks-project",
-#             "title": "title",
-#             "result": NotificationResult(
-#                 notification_attempted=True,
-#                 notification_successful=True,
-#                 explanation=None,
-#                 data_sent={
-#                     "state": "success",
-#                     "output": {
-#                         "title": "No coverage information found on head",
-#                         "summary": f"[View this Pull Request on Codecov](test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo coverage information found on head",
-#                     },
-#                     "url": f"test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
-#                 },
-#                 data_received=None,
-#             ),
-#         }
-#
-#     def test_notify_individual_notifier_timeout_notification_created(
-#         self, mocker, dbsession, sample_comparison
-#     ):
-#         current_yaml = {}
-#         commit = sample_comparison.head.commit
-#         notifier = mocker.MagicMock(
-#             title="fake_notifier",
-#             notify=mock.Mock(),
-#             notification_type=Notification.comment,
-#             decoration_type=Decoration.standard,
-#         )
-#         notifier.notify.side_effect = AsyncioTimeoutError
-#         notifications_service = NotificationService(
-#             commit.repository, current_yaml, None
-#         )
-#         res = notifications_service.notify_individual_notifier(
-#             notifier, sample_comparison
-#         )
-#         assert res == {
-#             "notifier": notifier.name,
-#             "result": None,
-#             "title": "fake_notifier",
-#         }
-#         dbsession.flush()
-#         pull = sample_comparison.enriched_pull.database_pull
-#         pull_commit_notifications = pull.get_head_commit_notifications()
-#         assert len(pull_commit_notifications) == 1
-#
-#         pull_commit_notification = pull_commit_notifications[0]
-#         assert pull_commit_notification is not None
-#         assert pull_commit_notification.notification_type == notifier.notification_type
-#         assert pull_commit_notification.decoration_type == notifier.decoration_type
-#         assert pull_commit_notification.state == NotificationState.error
-#
-#     def test_notify_individual_notifier_notification_created_then_updated(
-#         self, mocker, dbsession, sample_comparison
-#     ):
-#         current_yaml = {}
-#         commit = sample_comparison.head.commit
-#         notifier = mocker.MagicMock(
-#             title="fake_notifier",
-#             notify=mock.Mock(),
-#             notification_type=Notification.comment,
-#             decoration_type=Decoration.standard,
-#         )
-#         # first attempt not successful
-#         notifier.notify.side_effect = AsyncioTimeoutError
-#         notifications_service = NotificationService(
-#             commit.repository, current_yaml, None
-#         )
-#         res = notifications_service.notify_individual_notifier(
-#             notifier, sample_comparison
-#         )
-#         assert res == {
-#             "notifier": notifier.name,
-#             "result": None,
-#             "title": "fake_notifier",
-#         }
-#         dbsession.flush()
-#         pull = sample_comparison.enriched_pull.database_pull
-#         pull_commit_notifications = pull.get_head_commit_notifications()
-#         assert len(pull_commit_notifications) == 1
-#
-#         pull_commit_notification = pull_commit_notifications[0]
-#         assert pull_commit_notification is not None
-#         assert pull_commit_notification.decoration_type == notifier.decoration_type
-#         assert pull_commit_notification.state == NotificationState.error
-#
-#         # second attempt successful
-#         notifier.notify.side_effect = [
-#             NotificationResult(
-#                 notification_attempted=True,
-#                 notification_successful=True,
-#                 explanation="",
-#                 data_sent={"some": "data"},
-#             )
-#         ]
-#         res = notifications_service.notify_individual_notifier(
-#             notifier, sample_comparison
-#         )
-#         dbsession.commit()
-#         assert pull_commit_notification.state == NotificationState.success
-#
-#     def test_notify_individual_notifier_cancellation(self, mocker, sample_comparison):
-#         current_yaml = {}
-#         commit = sample_comparison.head.commit
-#         notifier = mocker.MagicMock(
-#             title="fake_notifier",
-#             notify=mock.Mock(),
-#             notification_type=Notification.comment,
-#             decoration_type=Decoration.standard,
-#         )
-#         notifier.notify.side_effect = CancelledError()
-#         notifications_service = NotificationService(
-#             commit.repository, current_yaml, None
-#         )
-#         with pytest.raises(CancelledError):
-#             notifications_service.notify_individual_notifier(
-#                 notifier, sample_comparison
-#             )
-#
-#     def test_notify_timeout_exception(self, mocker, dbsession, sample_comparison):
-#         current_yaml = {}
-#         commit = sample_comparison.head.commit
-#         good_notifier = mocker.MagicMock(
-#             is_enabled=mocker.MagicMock(return_value=True),
-#             notify=mock.Mock(),
-#             title="good_notifier",
-#             notification_type=Notification.comment,
-#             decoration_type=Decoration.standard,
-#         )
-#         no_attempt_notifier = mocker.MagicMock(
-#             is_enabled=mocker.MagicMock(return_value=True),
-#             notify=mock.Mock(),
-#             title="no_attempt_notifier",
-#             notification_type=Notification.status_project,
-#             decoration_type=Decoration.standard,
-#         )
-#         bad_notifier = mocker.MagicMock(
-#             is_enabled=mocker.MagicMock(return_value=True),
-#             notify=mock.Mock(),
-#             title="bad_notifier",
-#             notification_type=Notification.status_patch,
-#             decoration_type=Decoration.standard,
-#         )
-#         disabled_notifier = mocker.MagicMock(
-#             is_enabled=mocker.MagicMock(return_value=False),
-#             title="disabled_notifier",
-#             notification_type=Notification.status_changes,
-#             decoration_type=Decoration.standard,
-#         )
-#         good_notifier.notify.return_value = NotificationResult(
-#             notification_attempted=True,
-#             notification_successful=True,
-#             explanation="",
-#             data_sent={"some": "data"},
-#         )
-#         no_attempt_notifier.notify.return_value = NotificationResult(
-#             notification_attempted=False,
-#             notification_successful=None,
-#             explanation="no_need_to_send",
-#             data_sent=None,
-#         )
-#         good_notifier.name = "good_name"
-#         bad_notifier.name = "bad_name"
-#         disabled_notifier.name = "disabled_notifier_name"
-#         bad_notifier.notify.side_effect = SoftTimeLimitExceeded()
-#         mocker.patch.object(
-#             NotificationService,
-#             "get_notifiers_instances",
-#             return_value=[
-#                 bad_notifier,
-#                 good_notifier,
-#                 disabled_notifier,
-#                 no_attempt_notifier,
-#             ],
-#         )
-#         notifications_service = NotificationService(
-#             commit.repository, current_yaml, None
-#         )
-#         with pytest.raises(SoftTimeLimitExceeded):
-#             notifications_service.notify(sample_comparison)
-#
-#         dbsession.flush()
-#         pull_commit_notifications = sample_comparison.enriched_pull.database_pull.get_head_commit_notifications()
-#         assert len(pull_commit_notifications) == 1
-#         for commit_notification in pull_commit_notifications:
-#             assert commit_notification.state in (
-#                 NotificationState.success,
-#                 NotificationState.error,
-#             )
-#             assert commit_notification.decoration_type == Decoration.standard
-#             assert commit_notification.notification_type in (
-#                 Notification.comment,
-#                 Notification.status_patch,
-#             )
-#
-#     def test_not_licensed_enterprise(self, mocker, dbsession, sample_comparison):
-#         mocker.patch("services.notification.is_properly_licensed", return_value=False)
-#         mock_notify_individual_notifier = mocker.patch.object(
-#             NotificationService, "notify_individual_notifier"
-#         )
-#         current_yaml = {}
-#         commit = sample_comparison.head.commit
-#         notifications_service = NotificationService(
-#             commit.repository, current_yaml, None
-#         )
-#         expected_result = []
-#         res = notifications_service.notify(sample_comparison)
-#         assert expected_result == res
-#         assert not mock_notify_individual_notifier.called
-#
-#     def test_get_statuses(self, mocker, dbsession, sample_comparison):
-#         current_yaml = {
-#             "coverage": {"status": {"project": True, "patch": True, "changes": True}},
-#             "flags": {"banana": {"carryforward": False}},
-#             "flag_management": {
-#                 "default_rules": {"carryforward": False},
-#                 "individual_flags": [
-#                     {
-#                         "name": "strawberry",
-#                         "carryforward": True,
-#                         "statuses": [{"name_prefix": "haha", "type": "patch"}],
-#                     }
-#                 ],
-#             },
-#         }
-#         commit = sample_comparison.head.commit
-#         notifications_service = NotificationService(
-#             commit.repository, UserYaml(current_yaml), None
-#         )
-#         expected_result = [
-#             ("project", "default", {}),
-#             ("patch", "default", {}),
-#             ("changes", "default", {}),
-#             (
-#                 "patch",
-#                 "hahastrawberry",
-#                 {"flags": ["strawberry"], "name_prefix": "haha", "type": "patch"},
-#             ),
-#         ]
-#         res = list(notifications_service.get_statuses(["unit", "banana", "strawberry"]))
-#         assert expected_result == res
-#
-#     def test_get_component_statuses(self, mocker, dbsession, sample_comparison):
-#         current_yaml = {
-#             "component_management": {
-#                 "default_rules": {
-#                     "paths": [r"src/important/.*\.cpp"],
-#                     "flag_regexes": [r"critical.*"],
-#                     "statuses": [
-#                         {"name_prefix": "important/", "type": "project"},
-#                         {
-#                             "name_prefix": "legacy/",
-#                             "type": "project",
-#                             "enabled": False,
-#                         },  # this won't be in the results because it's not enabled
-#                     ],
-#                 },
-#                 "individual_components": [
-#                     {
-#                         "component_id": "my-special-component",
-#                         "flag_regexes": [r"special.*"],
-#                         "statuses": [
-#                             {"name_prefix": "special/", "type": "patch"},
-#                             {"name_prefix": "legacy/", "type": "project"},
-#                         ],
-#                     },
-#                     {
-#                         "component_id": "inner-app",
-#                         "paths": [r"src/inner_app/.*"],
-#                         "statuses": [{"type": "patch"}],
-#                     },
-#                     {"component_id": "from_default"},
-#                 ],
-#             }
-#         }
-#         commit = sample_comparison.head.commit
-#         notifications_service = NotificationService(
-#             commit.repository, UserYaml(current_yaml), None
-#         )
-#         expected_result = [
-#             (
-#                 "patch",
-#                 "special/my-special-component",
-#                 {
-#                     "flags": ["special_flag"],
-#                     "paths": [r"src/important/.*\.cpp"],
-#                     "type": "patch",
-#                     "name_prefix": "special/",
-#                 },
-#             ),
-#             (
-#                 "project",
-#                 "legacy/my-special-component",
-#                 {
-#                     "flags": ["special_flag"],
-#                     "paths": [r"src/important/.*\.cpp"],
-#                     "type": "project",
-#                     "name_prefix": "legacy/",
-#                 },
-#             ),
-#             (
-#                 "patch",
-#                 "inner-app",
-#                 {
-#                     "flags": ["critical_files"],
-#                     "paths": [r"src/inner_app/.*"],
-#                     "type": "patch",
-#                 },
-#             ),
-#             (
-#                 "project",
-#                 "important/from_default",
-#                 {
-#                     "flags": ["critical_files"],
-#                     "name_prefix": "important/",
-#                     "type": "project",
-#                     "paths": [r"src/important/.*\.cpp"],
-#                 },
-#             ),
-#         ]
-#         res = list(
-#             notifications_service.get_statuses(
-#                 ["special_flag", "critical_files", "banana"]
-#             )
-#         )
-#         assert expected_result == res
+import os
+
+import pytest
+from shared.plan.constants import PlanName
+
+from database.models.core import (
+    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+    GithubAppInstallation,
+)
+from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
+from services.comparison import ComparisonProxy
+from services.comparison.types import Comparison, EnrichedPull, FullCommit
+from services.notification import NotificationService
+from services.notification.notifiers import StatusType
+from services.notification.notifiers.checks.checks_with_fallback import (
+    ChecksWithFallback,
+)
+
+
+@pytest.fixture
+def sample_comparison(dbsession, request):
+    repository = RepositoryFactory.create(
+        owner__username=request.node.name, owner__service="github"
+    )
+    dbsession.add(repository)
+    dbsession.flush()
+    base_commit = CommitFactory.create(repository=repository)
+    head_commit = CommitFactory.create(repository=repository, branch="new_branch")
+    pull = PullFactory.create(
+        repository=repository, base=base_commit.commitid, head=head_commit.commitid
+    )
+    dbsession.add(base_commit)
+    dbsession.add(head_commit)
+    dbsession.add(pull)
+    dbsession.flush()
+    repository = base_commit.repository
+    base_full_commit = FullCommit(commit=base_commit, report=None)
+    head_full_commit = FullCommit(commit=head_commit, report=None)
+    return ComparisonProxy(
+        Comparison(
+            head=head_full_commit,
+            project_coverage_base=base_full_commit,
+            patch_coverage_base_commitid=base_commit.commitid,
+            enriched_pull=EnrichedPull(database_pull=pull, provider_pull={}),
+        )
+    )
+
+
+class TestNotificationService(object):
+    def test_should_use_checks_notifier_yaml_field_false(self, dbsession):
+        repository = RepositoryFactory.create()
+        current_yaml = {"github_checks": False}
+        service = NotificationService(repository, current_yaml, None)
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+            == False
+        )
+
+    @pytest.mark.parametrize(
+        "repo_data,outcome",
+        [
+            (
+                dict(
+                    using_integration=True,
+                    owner__integration_id=12341234,
+                    owner__service="github",
+                ),
+                True,
+            ),
+            (
+                dict(
+                    using_integration=True,
+                    owner__integration_id=12341234,
+                    owner__service="gitlab",
+                ),
+                False,
+            ),
+            (
+                dict(
+                    using_integration=True,
+                    owner__integration_id=12341234,
+                    owner__service="github_enterprise",
+                ),
+                True,
+            ),
+            (
+                dict(
+                    using_integration=False,
+                    owner__integration_id=None,
+                    owner__service="github",
+                ),
+                False,
+            ),
+        ],
+    )
+    def test_should_use_checks_notifier_deprecated_flow(
+        self, repo_data, outcome, dbsession
+    ):
+        repository = RepositoryFactory.create(**repo_data)
+        current_yaml = {"github_checks": True}
+        assert repository.owner.github_app_installations == []
+        service = NotificationService(repository, current_yaml, None)
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+            == outcome
+        )
+
+    def test_should_use_checks_notifier_ghapp_all_repos_covered(self, dbsession):
+        repository = RepositoryFactory.create(owner__service="github")
+        ghapp_installation = GithubAppInstallation(
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+            installation_id=456789,
+            owner=repository.owner,
+            repository_service_ids=None,
+        )
+        dbsession.add(ghapp_installation)
+        dbsession.flush()
+        current_yaml = {"github_checks": True}
+        assert repository.owner.github_app_installations == [ghapp_installation]
+        service = NotificationService(repository, current_yaml, None)
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+            == True
+        )
+
+    def test_use_checks_notifier_for_team_plan(self, dbsession):
+        repository = RepositoryFactory.create(
+            owner__service="github", owner__plan=PlanName.TEAM_MONTHLY.value
+        )
+        ghapp_installation = GithubAppInstallation(
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+            installation_id=456789,
+            owner=repository.owner,
+            repository_service_ids=None,
+        )
+        dbsession.add(ghapp_installation)
+        dbsession.flush()
+        current_yaml = {"github_checks": True}
+        assert repository.owner.github_app_installations == [ghapp_installation]
+        service = NotificationService(repository, current_yaml, None)
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+            == False
+        )
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
+            == False
+        )
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
+            == True
+        )
+
+    def test_use_status_notifier_for_team_plan(self, dbsession):
+        repository = RepositoryFactory.create(
+            owner__service="github", owner__plan=PlanName.TEAM_MONTHLY.value
+        )
+        ghapp_installation = GithubAppInstallation(
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+            installation_id=456789,
+            owner=repository.owner,
+            repository_service_ids=None,
+        )
+        dbsession.add(ghapp_installation)
+        dbsession.flush()
+        current_yaml = {"github_checks": True}
+        assert repository.owner.github_app_installations == [ghapp_installation]
+        service = NotificationService(repository, current_yaml, None)
+        assert (
+            service._should_use_status_notifier(status_type=StatusType.PROJECT.value)
+            == False
+        )
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
+            == False
+        )
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
+            == True
+        )
+
+    def test_use_status_notifier_for_non_team_plan(self, dbsession):
+        repository = RepositoryFactory.create(
+            owner__service="github", owner__plan=PlanName.CODECOV_PRO_MONTHLY.value
+        )
+        ghapp_installation = GithubAppInstallation(
+            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+            installation_id=456789,
+            owner=repository.owner,
+            repository_service_ids=None,
+        )
+        dbsession.add(ghapp_installation)
+        dbsession.flush()
+        current_yaml = {"github_checks": True}
+        assert repository.owner.github_app_installations == [ghapp_installation]
+        service = NotificationService(repository, current_yaml, None)
+        assert (
+            service._should_use_status_notifier(status_type=StatusType.PROJECT.value)
+            == True
+        )
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
+            == True
+        )
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
+            == True
+        )
+
+    @pytest.mark.parametrize(
+        "gh_installation_name",
+        [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
+    )
+    def test_should_use_checks_notifier_ghapp_some_repos_covered(
+        self, dbsession, gh_installation_name
+    ):
+        repository = RepositoryFactory.create(owner__service="github")
+        other_repo_same_owner = RepositoryFactory.create(owner=repository.owner)
+        ghapp_installation = GithubAppInstallation(
+            name=gh_installation_name,
+            installation_id=456789,
+            owner=repository.owner,
+            repository_service_ids=[repository.service_id],
+            app_id=123123,
+            pem_path="path_to_pem_file",
+        )
+        dbsession.add(ghapp_installation)
+        dbsession.flush()
+        current_yaml = {"github_checks": True}
+        assert repository.owner.github_app_installations == [ghapp_installation]
+        service = NotificationService(
+            repository,
+            current_yaml,
+            None,
+            gh_installation_name_to_use=gh_installation_name,
+        )
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+            == True
+        )
+        service = NotificationService(other_repo_same_owner, current_yaml, None)
+        assert (
+            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+            == False
+        )
+
+    def test_get_notifiers_instances_only_third_party(
+        self, dbsession, mock_configuration
+    ):
+        mock_configuration.params["services"] = {
+            "notifications": {"slack": ["slack.com"]}
+        }
+        repository = RepositoryFactory.create(
+            owner__unencrypted_oauth_token="testlln8sdeec57lz83oe3l8y9qq4lhqat2f1kzm",
+            owner__username="ThiagoCodecov",
+            yaml={"codecov": {"max_report_age": "1y ago"}},
+            name="example-python",
+        )
+        dbsession.add(repository)
+        dbsession.flush()
+        current_yaml = {
+            "coverage": {"notify": {"slack": {"default": {"field": "1y ago"}}}}
+        }
+        service = NotificationService(repository, current_yaml, None)
+        instances = list(service.get_notifiers_instances())
+        assert len(instances) == 2
+        instance = instances[0]
+        assert instance.repository == repository
+        assert instance.title == "default"
+        assert instance.notifier_yaml_settings == {"field": "1y ago"}
+        assert instance.site_settings == ["slack.com"]
+        assert instance.current_yaml == current_yaml
+
+    def test_get_notifiers_instances_checks(
+        self, dbsession, mock_configuration, mocker
+    ):
+        repository = RepositoryFactory.create(
+            owner__integration_id=123,
+            owner__service="github",
+            yaml={"codecov": {"max_report_age": "1y ago"}},
+            name="example-python",
+            using_integration=True,
+        )
+
+        dbsession.add(repository)
+        dbsession.flush()
+        current_yaml = {
+            "coverage": {"status": {"project": True, "patch": True, "changes": True}}
+        }
+        mocker.patch.dict(
+            os.environ, {"CHECKS_WHITELISTED_OWNERS": f"0,{repository.owner.ownerid}"}
+        )
+        service = NotificationService(repository, current_yaml, None)
+        instances = list(service.get_notifiers_instances())
+        names = sorted([instance.name for instance in instances])
+        assert names == [
+            "checks-changes-with-fallback",
+            "checks-patch-with-fallback",
+            "checks-project-with-fallback",
+            "codecov-slack-app",
+        ]
+
+    def test_get_notifiers_instances_slack_app_false(
+        self, dbsession, mock_configuration, mocker
+    ):
+        mocker.patch("services.notification.get_config", return_value=False)
+        repository = RepositoryFactory.create(
+            owner__integration_id=123,
+            owner__service="github",
+            yaml={"codecov": {"max_report_age": "1y ago"}},
+            name="example-python",
+            using_integration=True,
+        )
+
+        dbsession.add(repository)
+        dbsession.flush()
+        current_yaml = {
+            "coverage": {"status": {"project": True, "patch": True, "changes": True}}
+        }
+        mocker.patch.dict(
+            os.environ, {"CHECKS_WHITELISTED_OWNERS": f"0,{repository.owner.ownerid}"}
+        )
+        service = NotificationService(repository, current_yaml, None)
+        instances = list(service.get_notifiers_instances())
+        names = sorted([instance.name for instance in instances])
+        assert names == [
+            "checks-changes-with-fallback",
+            "checks-patch-with-fallback",
+            "checks-project-with-fallback",
+        ]
+
+    @pytest.mark.parametrize(
+        "gh_installation_name",
+        [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
+    )
+    def test_get_notifiers_instances_checks_percentage_whitelist(
+        self, dbsession, mock_configuration, mocker, gh_installation_name
+    ):
+        repository = RepositoryFactory.create(
+            owner__integration_id=123,
+            owner__service="github",
+            owner__ownerid=1234,
+            yaml={"codecov": {"max_report_age": "1y ago"}},
+            name="example-python",
+            using_integration=True,
+        )
+        dbsession.add(repository)
+        dbsession.flush()
+        current_yaml = {
+            "coverage": {"status": {"project": True, "patch": True, "changes": True}}
+        }
+        mocker.patch.dict(
+            os.environ,
+            {
+                "CHECKS_WHITELISTED_OWNERS": "0,1",
+                "CHECKS_WHITELISTED_PERCENTAGE": "35",
+            },
+        )
+        service = NotificationService(
+            repository,
+            current_yaml,
+            gh_installation_name,
+        )
+        instances = list(service.get_notifiers_instances())
+        # we don't need that for slack-app notifier
+        names = [
+            instance._checks_notifier.name
+            for instance in instances
+            if instance.name != "codecov-slack-app"
+        ]
+        assert names == ["checks-project", "checks-patch", "checks-changes"]
+        for instance in instances:
+            if isinstance(instance, ChecksWithFallback):
+                assert (
+                    instance._checks_notifier.repository_service == gh_installation_name
+                )
+                assert (
+                    instance._status_notifier.repository_service == gh_installation_name
+                )
+            else:
+                assert instance.repository_service == gh_installation_name
+
+    # @pytest.mark.parametrize(
+    #     "gh_installation_name",
+    #     [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
+    # )
+    # def test_get_notifiers_instances_comment(
+    #     self, dbsession, mock_configuration, mocker, gh_installation_name
+    # ):
+    #     repository = RepositoryFactory.create(
+    #         owner__integration_id=123,
+    #         owner__service="github",
+    #         owner__ownerid=1234,
+    #         yaml={"codecov": {"max_report_age": "1y ago"}},
+    #         name="example-python",
+    #         using_integration=True,
+    #     )
+    #     dbsession.add(repository)
+    #     dbsession.flush()
+    #     current_yaml = {"comment": {"layout": "condensed_header"}, "slack_app": False}
+    #     service = NotificationService(
+    #         repository,
+    #         current_yaml,
+    #         gh_installation_name,
+    #     )
+    #     instances = list(service.get_notifiers_instances())
+    #     assert len(instances) == 1
+    #     assert instances[0].repository_service == gh_installation_name
+    #
+    # def test_notify_general_exception(self, mocker, dbsession, sample_comparison):
+    #     current_yaml = {}
+    #     commit = sample_comparison.head.commit
+    #     good_notifier = mocker.MagicMock(
+    #         is_enabled=mocker.MagicMock(return_value=True),
+    #         title="good_notifier",
+    #         notification_type=Notification.comment,
+    #         decoration_type=Decoration.standard,
+    #         notify=mock.Mock(),
+    #     )
+    #     bad_notifier = mocker.MagicMock(
+    #         is_enabled=mocker.MagicMock(return_value=True),
+    #         title="bad_notifier",
+    #         notification_type=Notification.status_project,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     disabled_notifier = mocker.MagicMock(
+    #         is_enabled=mocker.MagicMock(return_value=False),
+    #         title="disabled_notifier",
+    #         notification_type=Notification.status_patch,
+    #         decoration_type=Decoration.standard,
+    #         notify=mock.Mock(),
+    #     )
+    #     good_notifier.notify.return_value = NotificationResult(
+    #         notification_attempted=True,
+    #         notification_successful=True,
+    #         explanation="",
+    #         data_sent={"some": "data"},
+    #     )
+    #     good_notifier.name = "good_name"
+    #     bad_notifier.name = "bad_name"
+    #     disabled_notifier.name = "disabled_notifier_name"
+    #     bad_notifier.notify.side_effect = Exception("This is bad")
+    #     mocker.patch.object(
+    #         NotificationService,
+    #         "get_notifiers_instances",
+    #         return_value=[bad_notifier, good_notifier, disabled_notifier],
+    #     )
+    #     notifications_service = NotificationService(
+    #         commit.repository, current_yaml, None
+    #     )
+    #     expected_result = [
+    #         {"notifier": "bad_name", "title": "bad_notifier", "result": None},
+    #         {
+    #             "notifier": "good_name",
+    #             "title": "good_notifier",
+    #             "result": NotificationResult(
+    #                 notification_attempted=True,
+    #                 notification_successful=True,
+    #                 explanation="",
+    #                 data_sent={"some": "data"},
+    #                 data_received=None,
+    #             ),
+    #         },
+    #     ]
+    #     res = notifications_service.notify(sample_comparison)
+    #     assert expected_result == res
+    #
+    # def test_notify_data_sent_None(self, mocker, dbsession, sample_comparison):
+    #     current_yaml = {}
+    #     commit = sample_comparison.head.commit
+    #     good_notifier = mocker.MagicMock(
+    #         is_enabled=mocker.MagicMock(return_value=True),
+    #         title="good_notifier",
+    #         notification_type=Notification.comment,
+    #         decoration_type=Decoration.standard,
+    #         notify=mock.Mock(),
+    #     )
+    #     skipped_notifier = mocker.MagicMock(
+    #         is_enabled=mocker.MagicMock(return_value=True),
+    #         title="skippy_notifier",
+    #         notification_type=Notification.status_project,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     good_notifier.notify.return_value = NotificationResult(
+    #         notification_attempted=True,
+    #         notification_successful=True,
+    #         explanation="",
+    #         data_sent={"some": "data"},
+    #     )
+    #     skipped_expected_return = NotificationResult(
+    #         notification_attempted=False,
+    #         notification_successful=None,
+    #         explanation="exclude_flag_coverage_not_uploaded_checks",
+    #         data_sent=None,
+    #         data_received=None,
+    #         github_app_used=None,
+    #     )
+    #     skipped_notifier.notify.return_value = skipped_expected_return
+    #     good_notifier.name = "good_name"
+    #     skipped_notifier.name = "skippy"
+    #
+    #     mocker.patch.object(
+    #         NotificationService,
+    #         "get_notifiers_instances",
+    #         return_value=[skipped_notifier, good_notifier],
+    #     )
+    #
+    #     notifications_service = NotificationService(
+    #         commit.repository, current_yaml, None
+    #     )
+    #     expected_result = [
+    #         {
+    #             "notifier": "skippy",
+    #             "title": "skippy_notifier",
+    #             "result": skipped_expected_return,
+    #         },
+    #         {
+    #             "notifier": "good_name",
+    #             "title": "good_notifier",
+    #             "result": NotificationResult(
+    #                 notification_attempted=True,
+    #                 notification_successful=True,
+    #                 explanation="",
+    #                 data_sent={"some": "data"},
+    #                 data_received=None,
+    #             ),
+    #         },
+    #     ]
+    #     res = notifications_service.notify(sample_comparison)
+    #     assert expected_result == res
+    #
+    # def test_notify_individual_notifier_timeout(self, mocker, sample_comparison):
+    #     current_yaml = {}
+    #     commit = sample_comparison.head.commit
+    #     notifier = mocker.MagicMock(
+    #         title="fake_notifier",
+    #         notify=mock.Mock(),
+    #         notification_type=Notification.comment,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     notifier.notify.side_effect = AsyncioTimeoutError
+    #     notifications_service = NotificationService(
+    #         commit.repository, current_yaml, None
+    #     )
+    #     res = notifications_service.notify_individual_notifier(
+    #         notifier, sample_comparison
+    #     )
+    #     assert res == {
+    #         "notifier": notifier.name,
+    #         "result": None,
+    #         "title": "fake_notifier",
+    #     }
+    #
+    # def test_notify_individual_checks_notifier(
+    #     self, mocker, sample_comparison, mock_repo_provider, mock_configuration
+    # ):
+    #     mock_repo_provider.get_commit_statuses.return_value = Status([])
+    #     mock_configuration._params["setup"] = {"codecov_dashboard_url": "test"}
+    #     current_yaml = {}
+    #     commit = sample_comparison.head.commit
+    #     report = Report()
+    #     first_deleted_file = ReportFile("file_1.go")
+    #     first_deleted_file.append(1, ReportLine.create(coverage=0, sessions=[]))
+    #     first_deleted_file.append(2, ReportLine.create(coverage=0, sessions=[]))
+    #     first_deleted_file.append(3, ReportLine.create(coverage=0, sessions=[]))
+    #     first_deleted_file.append(5, ReportLine.create(coverage=0, sessions=[]))
+    #     report.append(first_deleted_file)
+    #     sample_comparison.head.report = report
+    #     mock_repo_provider.create_check_run.return_value = 2234563
+    #     mock_repo_provider.update_check_run.return_value = "success"
+    #     notifier = ProjectChecksNotifier(
+    #         repository=sample_comparison.head.commit.repository,
+    #         title="title",
+    #         notifier_yaml_settings={"flags": ["flagone"]},
+    #         notifier_site_settings=True,
+    #         current_yaml=UserYaml({}),
+    #         repository_service=mock_repo_provider,
+    #     )
+    #     notifications_service = NotificationService(
+    #         commit.repository, current_yaml, mock_repo_provider
+    #     )
+    #     res = notifications_service.notify_individual_notifier(
+    #         notifier, sample_comparison
+    #     )
+    #
+    #     assert res == {
+    #         "notifier": "checks-project",
+    #         "title": "title",
+    #         "result": NotificationResult(
+    #             notification_attempted=True,
+    #             notification_successful=True,
+    #             explanation=None,
+    #             data_sent={
+    #                 "state": "success",
+    #                 "output": {
+    #                     "title": "No coverage information found on head",
+    #                     "summary": f"[View this Pull Request on Codecov](test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo coverage information found on head",
+    #                 },
+    #                 "url": f"test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
+    #             },
+    #             data_received=None,
+    #         ),
+    #     }
+    #
+    # def test_notify_individual_notifier_timeout_notification_created(
+    #     self, mocker, dbsession, sample_comparison
+    # ):
+    #     current_yaml = {}
+    #     commit = sample_comparison.head.commit
+    #     notifier = mocker.MagicMock(
+    #         title="fake_notifier",
+    #         notify=mock.Mock(),
+    #         notification_type=Notification.comment,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     notifier.notify.side_effect = AsyncioTimeoutError
+    #     notifications_service = NotificationService(
+    #         commit.repository, current_yaml, None
+    #     )
+    #     res = notifications_service.notify_individual_notifier(
+    #         notifier, sample_comparison
+    #     )
+    #     assert res == {
+    #         "notifier": notifier.name,
+    #         "result": None,
+    #         "title": "fake_notifier",
+    #     }
+    #     dbsession.flush()
+    #     pull = sample_comparison.enriched_pull.database_pull
+    #     pull_commit_notifications = pull.get_head_commit_notifications()
+    #     assert len(pull_commit_notifications) == 1
+    #
+    #     pull_commit_notification = pull_commit_notifications[0]
+    #     assert pull_commit_notification is not None
+    #     assert pull_commit_notification.notification_type == notifier.notification_type
+    #     assert pull_commit_notification.decoration_type == notifier.decoration_type
+    #     assert pull_commit_notification.state == NotificationState.error
+    #
+    # def test_notify_individual_notifier_notification_created_then_updated(
+    #     self, mocker, dbsession, sample_comparison
+    # ):
+    #     current_yaml = {}
+    #     commit = sample_comparison.head.commit
+    #     notifier = mocker.MagicMock(
+    #         title="fake_notifier",
+    #         notify=mock.Mock(),
+    #         notification_type=Notification.comment,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     # first attempt not successful
+    #     notifier.notify.side_effect = AsyncioTimeoutError
+    #     notifications_service = NotificationService(
+    #         commit.repository, current_yaml, None
+    #     )
+    #     res = notifications_service.notify_individual_notifier(
+    #         notifier, sample_comparison
+    #     )
+    #     assert res == {
+    #         "notifier": notifier.name,
+    #         "result": None,
+    #         "title": "fake_notifier",
+    #     }
+    #     dbsession.flush()
+    #     pull = sample_comparison.enriched_pull.database_pull
+    #     pull_commit_notifications = pull.get_head_commit_notifications()
+    #     assert len(pull_commit_notifications) == 1
+    #
+    #     pull_commit_notification = pull_commit_notifications[0]
+    #     assert pull_commit_notification is not None
+    #     assert pull_commit_notification.decoration_type == notifier.decoration_type
+    #     assert pull_commit_notification.state == NotificationState.error
+    #
+    #     # second attempt successful
+    #     notifier.notify.side_effect = [
+    #         NotificationResult(
+    #             notification_attempted=True,
+    #             notification_successful=True,
+    #             explanation="",
+    #             data_sent={"some": "data"},
+    #         )
+    #     ]
+    #     res = notifications_service.notify_individual_notifier(
+    #         notifier, sample_comparison
+    #     )
+    #     dbsession.commit()
+    #     assert pull_commit_notification.state == NotificationState.success
+    #
+    # def test_notify_individual_notifier_cancellation(self, mocker, sample_comparison):
+    #     current_yaml = {}
+    #     commit = sample_comparison.head.commit
+    #     notifier = mocker.MagicMock(
+    #         title="fake_notifier",
+    #         notify=mock.Mock(),
+    #         notification_type=Notification.comment,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     notifier.notify.side_effect = CancelledError()
+    #     notifications_service = NotificationService(
+    #         commit.repository, current_yaml, None
+    #     )
+    #     with pytest.raises(CancelledError):
+    #         notifications_service.notify_individual_notifier(
+    #             notifier, sample_comparison
+    #         )
+    #
+    # def test_notify_timeout_exception(self, mocker, dbsession, sample_comparison):
+    #     current_yaml = {}
+    #     commit = sample_comparison.head.commit
+    #     good_notifier = mocker.MagicMock(
+    #         is_enabled=mocker.MagicMock(return_value=True),
+    #         notify=mock.Mock(),
+    #         title="good_notifier",
+    #         notification_type=Notification.comment,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     no_attempt_notifier = mocker.MagicMock(
+    #         is_enabled=mocker.MagicMock(return_value=True),
+    #         notify=mock.Mock(),
+    #         title="no_attempt_notifier",
+    #         notification_type=Notification.status_project,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     bad_notifier = mocker.MagicMock(
+    #         is_enabled=mocker.MagicMock(return_value=True),
+    #         notify=mock.Mock(),
+    #         title="bad_notifier",
+    #         notification_type=Notification.status_patch,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     disabled_notifier = mocker.MagicMock(
+    #         is_enabled=mocker.MagicMock(return_value=False),
+    #         title="disabled_notifier",
+    #         notification_type=Notification.status_changes,
+    #         decoration_type=Decoration.standard,
+    #     )
+    #     good_notifier.notify.return_value = NotificationResult(
+    #         notification_attempted=True,
+    #         notification_successful=True,
+    #         explanation="",
+    #         data_sent={"some": "data"},
+    #     )
+    #     no_attempt_notifier.notify.return_value = NotificationResult(
+    #         notification_attempted=False,
+    #         notification_successful=None,
+    #         explanation="no_need_to_send",
+    #         data_sent=None,
+    #     )
+    #     good_notifier.name = "good_name"
+    #     bad_notifier.name = "bad_name"
+    #     disabled_notifier.name = "disabled_notifier_name"
+    #     bad_notifier.notify.side_effect = SoftTimeLimitExceeded()
+    #     mocker.patch.object(
+    #         NotificationService,
+    #         "get_notifiers_instances",
+    #         return_value=[
+    #             bad_notifier,
+    #             good_notifier,
+    #             disabled_notifier,
+    #             no_attempt_notifier,
+    #         ],
+    #     )
+    #     notifications_service = NotificationService(
+    #         commit.repository, current_yaml, None
+    #     )
+    #     with pytest.raises(SoftTimeLimitExceeded):
+    #         notifications_service.notify(sample_comparison)
+    #
+    #     dbsession.flush()
+    #     pull_commit_notifications = sample_comparison.enriched_pull.database_pull.get_head_commit_notifications()
+    #     assert len(pull_commit_notifications) == 1
+    #     for commit_notification in pull_commit_notifications:
+    #         assert commit_notification.state in (
+    #             NotificationState.success,
+    #             NotificationState.error,
+    #         )
+    #         assert commit_notification.decoration_type == Decoration.standard
+    #         assert commit_notification.notification_type in (
+    #             Notification.comment,
+    #             Notification.status_patch,
+    #         )
+    #
+    # def test_not_licensed_enterprise(self, mocker, dbsession, sample_comparison):
+    #     mocker.patch("services.notification.is_properly_licensed", return_value=False)
+    #     mock_notify_individual_notifier = mocker.patch.object(
+    #         NotificationService, "notify_individual_notifier"
+    #     )
+    #     current_yaml = {}
+    #     commit = sample_comparison.head.commit
+    #     notifications_service = NotificationService(
+    #         commit.repository, current_yaml, None
+    #     )
+    #     expected_result = []
+    #     res = notifications_service.notify(sample_comparison)
+    #     assert expected_result == res
+    #     assert not mock_notify_individual_notifier.called
+    #
+    # def test_get_statuses(self, mocker, dbsession, sample_comparison):
+    #     current_yaml = {
+    #         "coverage": {"status": {"project": True, "patch": True, "changes": True}},
+    #         "flags": {"banana": {"carryforward": False}},
+    #         "flag_management": {
+    #             "default_rules": {"carryforward": False},
+    #             "individual_flags": [
+    #                 {
+    #                     "name": "strawberry",
+    #                     "carryforward": True,
+    #                     "statuses": [{"name_prefix": "haha", "type": "patch"}],
+    #                 }
+    #             ],
+    #         },
+    #     }
+    #     commit = sample_comparison.head.commit
+    #     notifications_service = NotificationService(
+    #         commit.repository, UserYaml(current_yaml), None
+    #     )
+    #     expected_result = [
+    #         ("project", "default", {}),
+    #         ("patch", "default", {}),
+    #         ("changes", "default", {}),
+    #         (
+    #             "patch",
+    #             "hahastrawberry",
+    #             {"flags": ["strawberry"], "name_prefix": "haha", "type": "patch"},
+    #         ),
+    #     ]
+    #     res = list(notifications_service.get_statuses(["unit", "banana", "strawberry"]))
+    #     assert expected_result == res
+    #
+    # def test_get_component_statuses(self, mocker, dbsession, sample_comparison):
+    #     current_yaml = {
+    #         "component_management": {
+    #             "default_rules": {
+    #                 "paths": [r"src/important/.*\.cpp"],
+    #                 "flag_regexes": [r"critical.*"],
+    #                 "statuses": [
+    #                     {"name_prefix": "important/", "type": "project"},
+    #                     {
+    #                         "name_prefix": "legacy/",
+    #                         "type": "project",
+    #                         "enabled": False,
+    #                     },  # this won't be in the results because it's not enabled
+    #                 ],
+    #             },
+    #             "individual_components": [
+    #                 {
+    #                     "component_id": "my-special-component",
+    #                     "flag_regexes": [r"special.*"],
+    #                     "statuses": [
+    #                         {"name_prefix": "special/", "type": "patch"},
+    #                         {"name_prefix": "legacy/", "type": "project"},
+    #                     ],
+    #                 },
+    #                 {
+    #                     "component_id": "inner-app",
+    #                     "paths": [r"src/inner_app/.*"],
+    #                     "statuses": [{"type": "patch"}],
+    #                 },
+    #                 {"component_id": "from_default"},
+    #             ],
+    #         }
+    #     }
+    #     commit = sample_comparison.head.commit
+    #     notifications_service = NotificationService(
+    #         commit.repository, UserYaml(current_yaml), None
+    #     )
+    #     expected_result = [
+    #         (
+    #             "patch",
+    #             "special/my-special-component",
+    #             {
+    #                 "flags": ["special_flag"],
+    #                 "paths": [r"src/important/.*\.cpp"],
+    #                 "type": "patch",
+    #                 "name_prefix": "special/",
+    #             },
+    #         ),
+    #         (
+    #             "project",
+    #             "legacy/my-special-component",
+    #             {
+    #                 "flags": ["special_flag"],
+    #                 "paths": [r"src/important/.*\.cpp"],
+    #                 "type": "project",
+    #                 "name_prefix": "legacy/",
+    #             },
+    #         ),
+    #         (
+    #             "patch",
+    #             "inner-app",
+    #             {
+    #                 "flags": ["critical_files"],
+    #                 "paths": [r"src/inner_app/.*"],
+    #                 "type": "patch",
+    #             },
+    #         ),
+    #         (
+    #             "project",
+    #             "important/from_default",
+    #             {
+    #                 "flags": ["critical_files"],
+    #                 "name_prefix": "important/",
+    #                 "type": "project",
+    #                 "paths": [r"src/important/.*\.cpp"],
+    #             },
+    #         ),
+    #     ]
+    #     res = list(
+    #         notifications_service.get_statuses(
+    #             ["special_flag", "critical_files", "banana"]
+    #         )
+    #     )
+    #     assert expected_result == res

--- a/services/notification/tests/unit/test_notification_service.py
+++ b/services/notification/tests/unit/test_notification_service.py
@@ -1,922 +1,922 @@
-import os
-from asyncio import CancelledError
-from asyncio import TimeoutError as AsyncioTimeoutError
-
-import mock
-import pytest
-from celery.exceptions import SoftTimeLimitExceeded
-from shared.plan.constants import PlanName
-from shared.reports.resources import Report, ReportFile, ReportLine
-from shared.torngit.status import Status
-from shared.yaml import UserYaml
-
-from database.enums import Decoration, Notification, NotificationState
-from database.models.core import (
-    GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-    GithubAppInstallation,
-)
-from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
-from services.comparison import ComparisonProxy
-from services.comparison.types import Comparison, EnrichedPull, FullCommit
-from services.notification import NotificationService
-from services.notification.notifiers import StatusType
-from services.notification.notifiers.base import NotificationResult
-from services.notification.notifiers.checks import ProjectChecksNotifier
-from services.notification.notifiers.checks.checks_with_fallback import (
-    ChecksWithFallback,
-)
-
-
-@pytest.fixture
-def sample_comparison(dbsession, request):
-    repository = RepositoryFactory.create(
-        owner__username=request.node.name, owner__service="github"
-    )
-    dbsession.add(repository)
-    dbsession.flush()
-    base_commit = CommitFactory.create(repository=repository)
-    head_commit = CommitFactory.create(repository=repository, branch="new_branch")
-    pull = PullFactory.create(
-        repository=repository, base=base_commit.commitid, head=head_commit.commitid
-    )
-    dbsession.add(base_commit)
-    dbsession.add(head_commit)
-    dbsession.add(pull)
-    dbsession.flush()
-    repository = base_commit.repository
-    base_full_commit = FullCommit(commit=base_commit, report=None)
-    head_full_commit = FullCommit(commit=head_commit, report=None)
-    return ComparisonProxy(
-        Comparison(
-            head=head_full_commit,
-            project_coverage_base=base_full_commit,
-            patch_coverage_base_commitid=base_commit.commitid,
-            enriched_pull=EnrichedPull(database_pull=pull, provider_pull={}),
-        )
-    )
-
-
-class TestNotificationService(object):
-    def test_should_use_checks_notifier_yaml_field_false(self, dbsession):
-        repository = RepositoryFactory.create()
-        current_yaml = {"github_checks": False}
-        service = NotificationService(repository, current_yaml, None)
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-            == False
-        )
-
-    @pytest.mark.parametrize(
-        "repo_data,outcome",
-        [
-            (
-                dict(
-                    using_integration=True,
-                    owner__integration_id=12341234,
-                    owner__service="github",
-                ),
-                True,
-            ),
-            (
-                dict(
-                    using_integration=True,
-                    owner__integration_id=12341234,
-                    owner__service="gitlab",
-                ),
-                False,
-            ),
-            (
-                dict(
-                    using_integration=True,
-                    owner__integration_id=12341234,
-                    owner__service="github_enterprise",
-                ),
-                True,
-            ),
-            (
-                dict(
-                    using_integration=False,
-                    owner__integration_id=None,
-                    owner__service="github",
-                ),
-                False,
-            ),
-        ],
-    )
-    def test_should_use_checks_notifier_deprecated_flow(
-        self, repo_data, outcome, dbsession
-    ):
-        repository = RepositoryFactory.create(**repo_data)
-        current_yaml = {"github_checks": True}
-        assert repository.owner.github_app_installations == []
-        service = NotificationService(repository, current_yaml, None)
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-            == outcome
-        )
-
-    def test_should_use_checks_notifier_ghapp_all_repos_covered(self, dbsession):
-        repository = RepositoryFactory.create(owner__service="github")
-        ghapp_installation = GithubAppInstallation(
-            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-            installation_id=456789,
-            owner=repository.owner,
-            repository_service_ids=None,
-        )
-        dbsession.add(ghapp_installation)
-        dbsession.flush()
-        current_yaml = {"github_checks": True}
-        assert repository.owner.github_app_installations == [ghapp_installation]
-        service = NotificationService(repository, current_yaml, None)
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-            == True
-        )
-
-    def test_use_checks_notifier_for_team_plan(self, dbsession):
-        repository = RepositoryFactory.create(
-            owner__service="github", owner__plan=PlanName.TEAM_MONTHLY.value
-        )
-        ghapp_installation = GithubAppInstallation(
-            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-            installation_id=456789,
-            owner=repository.owner,
-            repository_service_ids=None,
-        )
-        dbsession.add(ghapp_installation)
-        dbsession.flush()
-        current_yaml = {"github_checks": True}
-        assert repository.owner.github_app_installations == [ghapp_installation]
-        service = NotificationService(repository, current_yaml, None)
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-            == False
-        )
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
-            == False
-        )
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
-            == True
-        )
-
-    def test_use_status_notifier_for_team_plan(self, dbsession):
-        repository = RepositoryFactory.create(
-            owner__service="github", owner__plan=PlanName.TEAM_MONTHLY.value
-        )
-        ghapp_installation = GithubAppInstallation(
-            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-            installation_id=456789,
-            owner=repository.owner,
-            repository_service_ids=None,
-        )
-        dbsession.add(ghapp_installation)
-        dbsession.flush()
-        current_yaml = {"github_checks": True}
-        assert repository.owner.github_app_installations == [ghapp_installation]
-        service = NotificationService(repository, current_yaml, None)
-        assert (
-            service._should_use_status_notifier(status_type=StatusType.PROJECT.value)
-            == False
-        )
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
-            == False
-        )
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
-            == True
-        )
-
-    def test_use_status_notifier_for_non_team_plan(self, dbsession):
-        repository = RepositoryFactory.create(
-            owner__service="github", owner__plan=PlanName.CODECOV_PRO_MONTHLY.value
-        )
-        ghapp_installation = GithubAppInstallation(
-            name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
-            installation_id=456789,
-            owner=repository.owner,
-            repository_service_ids=None,
-        )
-        dbsession.add(ghapp_installation)
-        dbsession.flush()
-        current_yaml = {"github_checks": True}
-        assert repository.owner.github_app_installations == [ghapp_installation]
-        service = NotificationService(repository, current_yaml, None)
-        assert (
-            service._should_use_status_notifier(status_type=StatusType.PROJECT.value)
-            == True
-        )
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
-            == True
-        )
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
-            == True
-        )
-
-    @pytest.mark.parametrize(
-        "gh_installation_name",
-        [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
-    )
-    def test_should_use_checks_notifier_ghapp_some_repos_covered(
-        self, dbsession, gh_installation_name
-    ):
-        repository = RepositoryFactory.create(owner__service="github")
-        other_repo_same_owner = RepositoryFactory.create(owner=repository.owner)
-        ghapp_installation = GithubAppInstallation(
-            name=gh_installation_name,
-            installation_id=456789,
-            owner=repository.owner,
-            repository_service_ids=[repository.service_id],
-            app_id=123123,
-            pem_path="path_to_pem_file",
-        )
-        dbsession.add(ghapp_installation)
-        dbsession.flush()
-        current_yaml = {"github_checks": True}
-        assert repository.owner.github_app_installations == [ghapp_installation]
-        service = NotificationService(
-            repository,
-            current_yaml,
-            None,
-            gh_installation_name_to_use=gh_installation_name,
-        )
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-            == True
-        )
-        service = NotificationService(other_repo_same_owner, current_yaml, None)
-        assert (
-            service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
-            == False
-        )
-
-    def test_get_notifiers_instances_only_third_party(
-        self, dbsession, mock_configuration
-    ):
-        mock_configuration.params["services"] = {
-            "notifications": {"slack": ["slack.com"]}
-        }
-        repository = RepositoryFactory.create(
-            owner__unencrypted_oauth_token="testlln8sdeec57lz83oe3l8y9qq4lhqat2f1kzm",
-            owner__username="ThiagoCodecov",
-            yaml={"codecov": {"max_report_age": "1y ago"}},
-            name="example-python",
-        )
-        dbsession.add(repository)
-        dbsession.flush()
-        current_yaml = {
-            "coverage": {"notify": {"slack": {"default": {"field": "1y ago"}}}}
-        }
-        service = NotificationService(repository, current_yaml, None)
-        instances = list(service.get_notifiers_instances())
-        assert len(instances) == 2
-        instance = instances[0]
-        assert instance.repository == repository
-        assert instance.title == "default"
-        assert instance.notifier_yaml_settings == {"field": "1y ago"}
-        assert instance.site_settings == ["slack.com"]
-        assert instance.current_yaml == current_yaml
-
-    def test_get_notifiers_instances_checks(
-        self, dbsession, mock_configuration, mocker
-    ):
-        repository = RepositoryFactory.create(
-            owner__integration_id=123,
-            owner__service="github",
-            yaml={"codecov": {"max_report_age": "1y ago"}},
-            name="example-python",
-            using_integration=True,
-        )
-
-        dbsession.add(repository)
-        dbsession.flush()
-        current_yaml = {
-            "coverage": {"status": {"project": True, "patch": True, "changes": True}}
-        }
-        mocker.patch.dict(
-            os.environ, {"CHECKS_WHITELISTED_OWNERS": f"0,{repository.owner.ownerid}"}
-        )
-        service = NotificationService(repository, current_yaml, None)
-        instances = list(service.get_notifiers_instances())
-        names = sorted([instance.name for instance in instances])
-        assert names == [
-            "checks-changes-with-fallback",
-            "checks-patch-with-fallback",
-            "checks-project-with-fallback",
-            "codecov-slack-app",
-        ]
-
-    def test_get_notifiers_instances_slack_app_false(
-        self, dbsession, mock_configuration, mocker
-    ):
-        mocker.patch("services.notification.get_config", return_value=False)
-        repository = RepositoryFactory.create(
-            owner__integration_id=123,
-            owner__service="github",
-            yaml={"codecov": {"max_report_age": "1y ago"}},
-            name="example-python",
-            using_integration=True,
-        )
-
-        dbsession.add(repository)
-        dbsession.flush()
-        current_yaml = {
-            "coverage": {"status": {"project": True, "patch": True, "changes": True}}
-        }
-        mocker.patch.dict(
-            os.environ, {"CHECKS_WHITELISTED_OWNERS": f"0,{repository.owner.ownerid}"}
-        )
-        service = NotificationService(repository, current_yaml, None)
-        instances = list(service.get_notifiers_instances())
-        names = sorted([instance.name for instance in instances])
-        assert names == [
-            "checks-changes-with-fallback",
-            "checks-patch-with-fallback",
-            "checks-project-with-fallback",
-        ]
-
-    @pytest.mark.parametrize(
-        "gh_installation_name",
-        [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
-    )
-    def test_get_notifiers_instances_checks_percentage_whitelist(
-        self, dbsession, mock_configuration, mocker, gh_installation_name
-    ):
-        repository = RepositoryFactory.create(
-            owner__integration_id=123,
-            owner__service="github",
-            owner__ownerid=1234,
-            yaml={"codecov": {"max_report_age": "1y ago"}},
-            name="example-python",
-            using_integration=True,
-        )
-        dbsession.add(repository)
-        dbsession.flush()
-        current_yaml = {
-            "coverage": {"status": {"project": True, "patch": True, "changes": True}}
-        }
-        mocker.patch.dict(
-            os.environ,
-            {
-                "CHECKS_WHITELISTED_OWNERS": "0,1",
-                "CHECKS_WHITELISTED_PERCENTAGE": "35",
-            },
-        )
-        service = NotificationService(
-            repository,
-            current_yaml,
-            gh_installation_name,
-        )
-        instances = list(service.get_notifiers_instances())
-        # we don't need that for slack-app notifier
-        names = [
-            instance._checks_notifier.name
-            for instance in instances
-            if instance.name != "codecov-slack-app"
-        ]
-        assert names == ["checks-project", "checks-patch", "checks-changes"]
-        for instance in instances:
-            if isinstance(instance, ChecksWithFallback):
-                assert (
-                    instance._checks_notifier.repository_service == gh_installation_name
-                )
-                assert (
-                    instance._status_notifier.repository_service == gh_installation_name
-                )
-            else:
-                assert instance.repository_service == gh_installation_name
-
-    @pytest.mark.parametrize(
-        "gh_installation_name",
-        [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
-    )
-    def test_get_notifiers_instances_comment(
-        self, dbsession, mock_configuration, mocker, gh_installation_name
-    ):
-        repository = RepositoryFactory.create(
-            owner__integration_id=123,
-            owner__service="github",
-            owner__ownerid=1234,
-            yaml={"codecov": {"max_report_age": "1y ago"}},
-            name="example-python",
-            using_integration=True,
-        )
-        dbsession.add(repository)
-        dbsession.flush()
-        current_yaml = {"comment": {"layout": "condensed_header"}, "slack_app": False}
-        service = NotificationService(
-            repository,
-            current_yaml,
-            gh_installation_name,
-        )
-        instances = list(service.get_notifiers_instances())
-        assert len(instances) == 1
-        assert instances[0].repository_service == gh_installation_name
-
-    def test_notify_general_exception(self, mocker, dbsession, sample_comparison):
-        current_yaml = {}
-        commit = sample_comparison.head.commit
-        good_notifier = mocker.MagicMock(
-            is_enabled=mocker.MagicMock(return_value=True),
-            title="good_notifier",
-            notification_type=Notification.comment,
-            decoration_type=Decoration.standard,
-            notify=mock.Mock(),
-        )
-        bad_notifier = mocker.MagicMock(
-            is_enabled=mocker.MagicMock(return_value=True),
-            title="bad_notifier",
-            notification_type=Notification.status_project,
-            decoration_type=Decoration.standard,
-        )
-        disabled_notifier = mocker.MagicMock(
-            is_enabled=mocker.MagicMock(return_value=False),
-            title="disabled_notifier",
-            notification_type=Notification.status_patch,
-            decoration_type=Decoration.standard,
-            notify=mock.Mock(),
-        )
-        good_notifier.notify.return_value = NotificationResult(
-            notification_attempted=True,
-            notification_successful=True,
-            explanation="",
-            data_sent={"some": "data"},
-        )
-        good_notifier.name = "good_name"
-        bad_notifier.name = "bad_name"
-        disabled_notifier.name = "disabled_notifier_name"
-        bad_notifier.notify.side_effect = Exception("This is bad")
-        mocker.patch.object(
-            NotificationService,
-            "get_notifiers_instances",
-            return_value=[bad_notifier, good_notifier, disabled_notifier],
-        )
-        notifications_service = NotificationService(
-            commit.repository, current_yaml, None
-        )
-        expected_result = [
-            {"notifier": "bad_name", "title": "bad_notifier", "result": None},
-            {
-                "notifier": "good_name",
-                "title": "good_notifier",
-                "result": NotificationResult(
-                    notification_attempted=True,
-                    notification_successful=True,
-                    explanation="",
-                    data_sent={"some": "data"},
-                    data_received=None,
-                ),
-            },
-        ]
-        res = notifications_service.notify(sample_comparison)
-        assert expected_result == res
-
-    def test_notify_data_sent_None(self, mocker, dbsession, sample_comparison):
-        current_yaml = {}
-        commit = sample_comparison.head.commit
-        good_notifier = mocker.MagicMock(
-            is_enabled=mocker.MagicMock(return_value=True),
-            title="good_notifier",
-            notification_type=Notification.comment,
-            decoration_type=Decoration.standard,
-            notify=mock.Mock(),
-        )
-        skipped_notifier = mocker.MagicMock(
-            is_enabled=mocker.MagicMock(return_value=True),
-            title="skippy_notifier",
-            notification_type=Notification.status_project,
-            decoration_type=Decoration.standard,
-        )
-        good_notifier.notify.return_value = NotificationResult(
-            notification_attempted=True,
-            notification_successful=True,
-            explanation="",
-            data_sent={"some": "data"},
-        )
-        skipped_expected_return = NotificationResult(
-            notification_attempted=False,
-            notification_successful=None,
-            explanation="exclude_flag_coverage_not_uploaded_checks",
-            data_sent=None,
-            data_received=None,
-            github_app_used=None,
-        )
-        skipped_notifier.notify.return_value = skipped_expected_return
-        good_notifier.name = "good_name"
-        skipped_notifier.name = "skippy"
-
-        mocker.patch.object(
-            NotificationService,
-            "get_notifiers_instances",
-            return_value=[skipped_notifier, good_notifier],
-        )
-
-        notifications_service = NotificationService(
-            commit.repository, current_yaml, None
-        )
-        expected_result = [
-            {
-                "notifier": "skippy",
-                "title": "skippy_notifier",
-                "result": skipped_expected_return,
-            },
-            {
-                "notifier": "good_name",
-                "title": "good_notifier",
-                "result": NotificationResult(
-                    notification_attempted=True,
-                    notification_successful=True,
-                    explanation="",
-                    data_sent={"some": "data"},
-                    data_received=None,
-                ),
-            },
-        ]
-        res = notifications_service.notify(sample_comparison)
-        assert expected_result == res
-
-    def test_notify_individual_notifier_timeout(self, mocker, sample_comparison):
-        current_yaml = {}
-        commit = sample_comparison.head.commit
-        notifier = mocker.MagicMock(
-            title="fake_notifier",
-            notify=mock.Mock(),
-            notification_type=Notification.comment,
-            decoration_type=Decoration.standard,
-        )
-        notifier.notify.side_effect = AsyncioTimeoutError
-        notifications_service = NotificationService(
-            commit.repository, current_yaml, None
-        )
-        res = notifications_service.notify_individual_notifier(
-            notifier, sample_comparison
-        )
-        assert res == {
-            "notifier": notifier.name,
-            "result": None,
-            "title": "fake_notifier",
-        }
-
-    def test_notify_individual_checks_notifier(
-        self, mocker, sample_comparison, mock_repo_provider, mock_configuration
-    ):
-        mock_repo_provider.get_commit_statuses.return_value = Status([])
-        mock_configuration._params["setup"] = {"codecov_dashboard_url": "test"}
-        current_yaml = {}
-        commit = sample_comparison.head.commit
-        report = Report()
-        first_deleted_file = ReportFile("file_1.go")
-        first_deleted_file.append(1, ReportLine.create(coverage=0, sessions=[]))
-        first_deleted_file.append(2, ReportLine.create(coverage=0, sessions=[]))
-        first_deleted_file.append(3, ReportLine.create(coverage=0, sessions=[]))
-        first_deleted_file.append(5, ReportLine.create(coverage=0, sessions=[]))
-        report.append(first_deleted_file)
-        sample_comparison.head.report = report
-        mock_repo_provider.create_check_run.return_value = 2234563
-        mock_repo_provider.update_check_run.return_value = "success"
-        notifier = ProjectChecksNotifier(
-            repository=sample_comparison.head.commit.repository,
-            title="title",
-            notifier_yaml_settings={"flags": ["flagone"]},
-            notifier_site_settings=True,
-            current_yaml=UserYaml({}),
-            repository_service=mock_repo_provider,
-        )
-        notifications_service = NotificationService(
-            commit.repository, current_yaml, mock_repo_provider
-        )
-        res = notifications_service.notify_individual_notifier(
-            notifier, sample_comparison
-        )
-
-        assert res == {
-            "notifier": "checks-project",
-            "title": "title",
-            "result": NotificationResult(
-                notification_attempted=True,
-                notification_successful=True,
-                explanation=None,
-                data_sent={
-                    "state": "success",
-                    "output": {
-                        "title": "No coverage information found on head",
-                        "summary": f"[View this Pull Request on Codecov](test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo coverage information found on head",
-                    },
-                    "url": f"test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
-                },
-                data_received=None,
-            ),
-        }
-
-    def test_notify_individual_notifier_timeout_notification_created(
-        self, mocker, dbsession, sample_comparison
-    ):
-        current_yaml = {}
-        commit = sample_comparison.head.commit
-        notifier = mocker.MagicMock(
-            title="fake_notifier",
-            notify=mock.Mock(),
-            notification_type=Notification.comment,
-            decoration_type=Decoration.standard,
-        )
-        notifier.notify.side_effect = AsyncioTimeoutError
-        notifications_service = NotificationService(
-            commit.repository, current_yaml, None
-        )
-        res = notifications_service.notify_individual_notifier(
-            notifier, sample_comparison
-        )
-        assert res == {
-            "notifier": notifier.name,
-            "result": None,
-            "title": "fake_notifier",
-        }
-        dbsession.flush()
-        pull = sample_comparison.enriched_pull.database_pull
-        pull_commit_notifications = pull.get_head_commit_notifications()
-        assert len(pull_commit_notifications) == 1
-
-        pull_commit_notification = pull_commit_notifications[0]
-        assert pull_commit_notification is not None
-        assert pull_commit_notification.notification_type == notifier.notification_type
-        assert pull_commit_notification.decoration_type == notifier.decoration_type
-        assert pull_commit_notification.state == NotificationState.error
-
-    def test_notify_individual_notifier_notification_created_then_updated(
-        self, mocker, dbsession, sample_comparison
-    ):
-        current_yaml = {}
-        commit = sample_comparison.head.commit
-        notifier = mocker.MagicMock(
-            title="fake_notifier",
-            notify=mock.Mock(),
-            notification_type=Notification.comment,
-            decoration_type=Decoration.standard,
-        )
-        # first attempt not successful
-        notifier.notify.side_effect = AsyncioTimeoutError
-        notifications_service = NotificationService(
-            commit.repository, current_yaml, None
-        )
-        res = notifications_service.notify_individual_notifier(
-            notifier, sample_comparison
-        )
-        assert res == {
-            "notifier": notifier.name,
-            "result": None,
-            "title": "fake_notifier",
-        }
-        dbsession.flush()
-        pull = sample_comparison.enriched_pull.database_pull
-        pull_commit_notifications = pull.get_head_commit_notifications()
-        assert len(pull_commit_notifications) == 1
-
-        pull_commit_notification = pull_commit_notifications[0]
-        assert pull_commit_notification is not None
-        assert pull_commit_notification.decoration_type == notifier.decoration_type
-        assert pull_commit_notification.state == NotificationState.error
-
-        # second attempt successful
-        notifier.notify.side_effect = [
-            NotificationResult(
-                notification_attempted=True,
-                notification_successful=True,
-                explanation="",
-                data_sent={"some": "data"},
-            )
-        ]
-        res = notifications_service.notify_individual_notifier(
-            notifier, sample_comparison
-        )
-        dbsession.commit()
-        assert pull_commit_notification.state == NotificationState.success
-
-    def test_notify_individual_notifier_cancellation(self, mocker, sample_comparison):
-        current_yaml = {}
-        commit = sample_comparison.head.commit
-        notifier = mocker.MagicMock(
-            title="fake_notifier",
-            notify=mock.Mock(),
-            notification_type=Notification.comment,
-            decoration_type=Decoration.standard,
-        )
-        notifier.notify.side_effect = CancelledError()
-        notifications_service = NotificationService(
-            commit.repository, current_yaml, None
-        )
-        with pytest.raises(CancelledError):
-            notifications_service.notify_individual_notifier(
-                notifier, sample_comparison
-            )
-
-    def test_notify_timeout_exception(self, mocker, dbsession, sample_comparison):
-        current_yaml = {}
-        commit = sample_comparison.head.commit
-        good_notifier = mocker.MagicMock(
-            is_enabled=mocker.MagicMock(return_value=True),
-            notify=mock.Mock(),
-            title="good_notifier",
-            notification_type=Notification.comment,
-            decoration_type=Decoration.standard,
-        )
-        no_attempt_notifier = mocker.MagicMock(
-            is_enabled=mocker.MagicMock(return_value=True),
-            notify=mock.Mock(),
-            title="no_attempt_notifier",
-            notification_type=Notification.status_project,
-            decoration_type=Decoration.standard,
-        )
-        bad_notifier = mocker.MagicMock(
-            is_enabled=mocker.MagicMock(return_value=True),
-            notify=mock.Mock(),
-            title="bad_notifier",
-            notification_type=Notification.status_patch,
-            decoration_type=Decoration.standard,
-        )
-        disabled_notifier = mocker.MagicMock(
-            is_enabled=mocker.MagicMock(return_value=False),
-            title="disabled_notifier",
-            notification_type=Notification.status_changes,
-            decoration_type=Decoration.standard,
-        )
-        good_notifier.notify.return_value = NotificationResult(
-            notification_attempted=True,
-            notification_successful=True,
-            explanation="",
-            data_sent={"some": "data"},
-        )
-        no_attempt_notifier.notify.return_value = NotificationResult(
-            notification_attempted=False,
-            notification_successful=None,
-            explanation="no_need_to_send",
-            data_sent=None,
-        )
-        good_notifier.name = "good_name"
-        bad_notifier.name = "bad_name"
-        disabled_notifier.name = "disabled_notifier_name"
-        bad_notifier.notify.side_effect = SoftTimeLimitExceeded()
-        mocker.patch.object(
-            NotificationService,
-            "get_notifiers_instances",
-            return_value=[
-                bad_notifier,
-                good_notifier,
-                disabled_notifier,
-                no_attempt_notifier,
-            ],
-        )
-        notifications_service = NotificationService(
-            commit.repository, current_yaml, None
-        )
-        with pytest.raises(SoftTimeLimitExceeded):
-            notifications_service.notify(sample_comparison)
-
-        dbsession.flush()
-        pull_commit_notifications = sample_comparison.enriched_pull.database_pull.get_head_commit_notifications()
-        assert len(pull_commit_notifications) == 1
-        for commit_notification in pull_commit_notifications:
-            assert commit_notification.state in (
-                NotificationState.success,
-                NotificationState.error,
-            )
-            assert commit_notification.decoration_type == Decoration.standard
-            assert commit_notification.notification_type in (
-                Notification.comment,
-                Notification.status_patch,
-            )
-
-    def test_not_licensed_enterprise(self, mocker, dbsession, sample_comparison):
-        mocker.patch("services.notification.is_properly_licensed", return_value=False)
-        mock_notify_individual_notifier = mocker.patch.object(
-            NotificationService, "notify_individual_notifier"
-        )
-        current_yaml = {}
-        commit = sample_comparison.head.commit
-        notifications_service = NotificationService(
-            commit.repository, current_yaml, None
-        )
-        expected_result = []
-        res = notifications_service.notify(sample_comparison)
-        assert expected_result == res
-        assert not mock_notify_individual_notifier.called
-
-    def test_get_statuses(self, mocker, dbsession, sample_comparison):
-        current_yaml = {
-            "coverage": {"status": {"project": True, "patch": True, "changes": True}},
-            "flags": {"banana": {"carryforward": False}},
-            "flag_management": {
-                "default_rules": {"carryforward": False},
-                "individual_flags": [
-                    {
-                        "name": "strawberry",
-                        "carryforward": True,
-                        "statuses": [{"name_prefix": "haha", "type": "patch"}],
-                    }
-                ],
-            },
-        }
-        commit = sample_comparison.head.commit
-        notifications_service = NotificationService(
-            commit.repository, UserYaml(current_yaml), None
-        )
-        expected_result = [
-            ("project", "default", {}),
-            ("patch", "default", {}),
-            ("changes", "default", {}),
-            (
-                "patch",
-                "hahastrawberry",
-                {"flags": ["strawberry"], "name_prefix": "haha", "type": "patch"},
-            ),
-        ]
-        res = list(notifications_service.get_statuses(["unit", "banana", "strawberry"]))
-        assert expected_result == res
-
-    def test_get_component_statuses(self, mocker, dbsession, sample_comparison):
-        current_yaml = {
-            "component_management": {
-                "default_rules": {
-                    "paths": [r"src/important/.*\.cpp"],
-                    "flag_regexes": [r"critical.*"],
-                    "statuses": [
-                        {"name_prefix": "important/", "type": "project"},
-                        {
-                            "name_prefix": "legacy/",
-                            "type": "project",
-                            "enabled": False,
-                        },  # this won't be in the results because it's not enabled
-                    ],
-                },
-                "individual_components": [
-                    {
-                        "component_id": "my-special-component",
-                        "flag_regexes": [r"special.*"],
-                        "statuses": [
-                            {"name_prefix": "special/", "type": "patch"},
-                            {"name_prefix": "legacy/", "type": "project"},
-                        ],
-                    },
-                    {
-                        "component_id": "inner-app",
-                        "paths": [r"src/inner_app/.*"],
-                        "statuses": [{"type": "patch"}],
-                    },
-                    {"component_id": "from_default"},
-                ],
-            }
-        }
-        commit = sample_comparison.head.commit
-        notifications_service = NotificationService(
-            commit.repository, UserYaml(current_yaml), None
-        )
-        expected_result = [
-            (
-                "patch",
-                "special/my-special-component",
-                {
-                    "flags": ["special_flag"],
-                    "paths": [r"src/important/.*\.cpp"],
-                    "type": "patch",
-                    "name_prefix": "special/",
-                },
-            ),
-            (
-                "project",
-                "legacy/my-special-component",
-                {
-                    "flags": ["special_flag"],
-                    "paths": [r"src/important/.*\.cpp"],
-                    "type": "project",
-                    "name_prefix": "legacy/",
-                },
-            ),
-            (
-                "patch",
-                "inner-app",
-                {
-                    "flags": ["critical_files"],
-                    "paths": [r"src/inner_app/.*"],
-                    "type": "patch",
-                },
-            ),
-            (
-                "project",
-                "important/from_default",
-                {
-                    "flags": ["critical_files"],
-                    "name_prefix": "important/",
-                    "type": "project",
-                    "paths": [r"src/important/.*\.cpp"],
-                },
-            ),
-        ]
-        res = list(
-            notifications_service.get_statuses(
-                ["special_flag", "critical_files", "banana"]
-            )
-        )
-        assert expected_result == res
+# import os
+# from asyncio import CancelledError
+# from asyncio import TimeoutError as AsyncioTimeoutError
+#
+# import mock
+# import pytest
+# from celery.exceptions import SoftTimeLimitExceeded
+# from shared.plan.constants import PlanName
+# from shared.reports.resources import Report, ReportFile, ReportLine
+# from shared.torngit.status import Status
+# from shared.yaml import UserYaml
+#
+# from database.enums import Decoration, Notification, NotificationState
+# from database.models.core import (
+#     GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+#     GithubAppInstallation,
+# )
+# from database.tests.factories import CommitFactory, PullFactory, RepositoryFactory
+# from services.comparison import ComparisonProxy
+# from services.comparison.types import Comparison, EnrichedPull, FullCommit
+# from services.notification import NotificationService
+# from services.notification.notifiers import StatusType
+# from services.notification.notifiers.base import NotificationResult
+# from services.notification.notifiers.checks import ProjectChecksNotifier
+# from services.notification.notifiers.checks.checks_with_fallback import (
+#     ChecksWithFallback,
+# )
+#
+#
+# @pytest.fixture
+# def sample_comparison(dbsession, request):
+#     repository = RepositoryFactory.create(
+#         owner__username=request.node.name, owner__service="github"
+#     )
+#     dbsession.add(repository)
+#     dbsession.flush()
+#     base_commit = CommitFactory.create(repository=repository)
+#     head_commit = CommitFactory.create(repository=repository, branch="new_branch")
+#     pull = PullFactory.create(
+#         repository=repository, base=base_commit.commitid, head=head_commit.commitid
+#     )
+#     dbsession.add(base_commit)
+#     dbsession.add(head_commit)
+#     dbsession.add(pull)
+#     dbsession.flush()
+#     repository = base_commit.repository
+#     base_full_commit = FullCommit(commit=base_commit, report=None)
+#     head_full_commit = FullCommit(commit=head_commit, report=None)
+#     return ComparisonProxy(
+#         Comparison(
+#             head=head_full_commit,
+#             project_coverage_base=base_full_commit,
+#             patch_coverage_base_commitid=base_commit.commitid,
+#             enriched_pull=EnrichedPull(database_pull=pull, provider_pull={}),
+#         )
+#     )
+#
+#
+# class TestNotificationService(object):
+#     def test_should_use_checks_notifier_yaml_field_false(self, dbsession):
+#         repository = RepositoryFactory.create()
+#         current_yaml = {"github_checks": False}
+#         service = NotificationService(repository, current_yaml, None)
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+#             == False
+#         )
+#
+#     @pytest.mark.parametrize(
+#         "repo_data,outcome",
+#         [
+#             (
+#                 dict(
+#                     using_integration=True,
+#                     owner__integration_id=12341234,
+#                     owner__service="github",
+#                 ),
+#                 True,
+#             ),
+#             (
+#                 dict(
+#                     using_integration=True,
+#                     owner__integration_id=12341234,
+#                     owner__service="gitlab",
+#                 ),
+#                 False,
+#             ),
+#             (
+#                 dict(
+#                     using_integration=True,
+#                     owner__integration_id=12341234,
+#                     owner__service="github_enterprise",
+#                 ),
+#                 True,
+#             ),
+#             (
+#                 dict(
+#                     using_integration=False,
+#                     owner__integration_id=None,
+#                     owner__service="github",
+#                 ),
+#                 False,
+#             ),
+#         ],
+#     )
+#     def test_should_use_checks_notifier_deprecated_flow(
+#         self, repo_data, outcome, dbsession
+#     ):
+#         repository = RepositoryFactory.create(**repo_data)
+#         current_yaml = {"github_checks": True}
+#         assert repository.owner.github_app_installations == []
+#         service = NotificationService(repository, current_yaml, None)
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+#             == outcome
+#         )
+#
+#     def test_should_use_checks_notifier_ghapp_all_repos_covered(self, dbsession):
+#         repository = RepositoryFactory.create(owner__service="github")
+#         ghapp_installation = GithubAppInstallation(
+#             name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+#             installation_id=456789,
+#             owner=repository.owner,
+#             repository_service_ids=None,
+#         )
+#         dbsession.add(ghapp_installation)
+#         dbsession.flush()
+#         current_yaml = {"github_checks": True}
+#         assert repository.owner.github_app_installations == [ghapp_installation]
+#         service = NotificationService(repository, current_yaml, None)
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+#             == True
+#         )
+#
+#     def test_use_checks_notifier_for_team_plan(self, dbsession):
+#         repository = RepositoryFactory.create(
+#             owner__service="github", owner__plan=PlanName.TEAM_MONTHLY.value
+#         )
+#         ghapp_installation = GithubAppInstallation(
+#             name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+#             installation_id=456789,
+#             owner=repository.owner,
+#             repository_service_ids=None,
+#         )
+#         dbsession.add(ghapp_installation)
+#         dbsession.flush()
+#         current_yaml = {"github_checks": True}
+#         assert repository.owner.github_app_installations == [ghapp_installation]
+#         service = NotificationService(repository, current_yaml, None)
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+#             == False
+#         )
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
+#             == False
+#         )
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
+#             == True
+#         )
+#
+#     def test_use_status_notifier_for_team_plan(self, dbsession):
+#         repository = RepositoryFactory.create(
+#             owner__service="github", owner__plan=PlanName.TEAM_MONTHLY.value
+#         )
+#         ghapp_installation = GithubAppInstallation(
+#             name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+#             installation_id=456789,
+#             owner=repository.owner,
+#             repository_service_ids=None,
+#         )
+#         dbsession.add(ghapp_installation)
+#         dbsession.flush()
+#         current_yaml = {"github_checks": True}
+#         assert repository.owner.github_app_installations == [ghapp_installation]
+#         service = NotificationService(repository, current_yaml, None)
+#         assert (
+#             service._should_use_status_notifier(status_type=StatusType.PROJECT.value)
+#             == False
+#         )
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
+#             == False
+#         )
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
+#             == True
+#         )
+#
+#     def test_use_status_notifier_for_non_team_plan(self, dbsession):
+#         repository = RepositoryFactory.create(
+#             owner__service="github", owner__plan=PlanName.CODECOV_PRO_MONTHLY.value
+#         )
+#         ghapp_installation = GithubAppInstallation(
+#             name=GITHUB_APP_INSTALLATION_DEFAULT_NAME,
+#             installation_id=456789,
+#             owner=repository.owner,
+#             repository_service_ids=None,
+#         )
+#         dbsession.add(ghapp_installation)
+#         dbsession.flush()
+#         current_yaml = {"github_checks": True}
+#         assert repository.owner.github_app_installations == [ghapp_installation]
+#         service = NotificationService(repository, current_yaml, None)
+#         assert (
+#             service._should_use_status_notifier(status_type=StatusType.PROJECT.value)
+#             == True
+#         )
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.CHANGES.value)
+#             == True
+#         )
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.PATCH.value)
+#             == True
+#         )
+#
+#     @pytest.mark.parametrize(
+#         "gh_installation_name",
+#         [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
+#     )
+#     def test_should_use_checks_notifier_ghapp_some_repos_covered(
+#         self, dbsession, gh_installation_name
+#     ):
+#         repository = RepositoryFactory.create(owner__service="github")
+#         other_repo_same_owner = RepositoryFactory.create(owner=repository.owner)
+#         ghapp_installation = GithubAppInstallation(
+#             name=gh_installation_name,
+#             installation_id=456789,
+#             owner=repository.owner,
+#             repository_service_ids=[repository.service_id],
+#             app_id=123123,
+#             pem_path="path_to_pem_file",
+#         )
+#         dbsession.add(ghapp_installation)
+#         dbsession.flush()
+#         current_yaml = {"github_checks": True}
+#         assert repository.owner.github_app_installations == [ghapp_installation]
+#         service = NotificationService(
+#             repository,
+#             current_yaml,
+#             None,
+#             gh_installation_name_to_use=gh_installation_name,
+#         )
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+#             == True
+#         )
+#         service = NotificationService(other_repo_same_owner, current_yaml, None)
+#         assert (
+#             service._should_use_checks_notifier(status_type=StatusType.PROJECT.value)
+#             == False
+#         )
+#
+#     def test_get_notifiers_instances_only_third_party(
+#         self, dbsession, mock_configuration
+#     ):
+#         mock_configuration.params["services"] = {
+#             "notifications": {"slack": ["slack.com"]}
+#         }
+#         repository = RepositoryFactory.create(
+#             owner__unencrypted_oauth_token="testlln8sdeec57lz83oe3l8y9qq4lhqat2f1kzm",
+#             owner__username="ThiagoCodecov",
+#             yaml={"codecov": {"max_report_age": "1y ago"}},
+#             name="example-python",
+#         )
+#         dbsession.add(repository)
+#         dbsession.flush()
+#         current_yaml = {
+#             "coverage": {"notify": {"slack": {"default": {"field": "1y ago"}}}}
+#         }
+#         service = NotificationService(repository, current_yaml, None)
+#         instances = list(service.get_notifiers_instances())
+#         assert len(instances) == 2
+#         instance = instances[0]
+#         assert instance.repository == repository
+#         assert instance.title == "default"
+#         assert instance.notifier_yaml_settings == {"field": "1y ago"}
+#         assert instance.site_settings == ["slack.com"]
+#         assert instance.current_yaml == current_yaml
+#
+#     def test_get_notifiers_instances_checks(
+#         self, dbsession, mock_configuration, mocker
+#     ):
+#         repository = RepositoryFactory.create(
+#             owner__integration_id=123,
+#             owner__service="github",
+#             yaml={"codecov": {"max_report_age": "1y ago"}},
+#             name="example-python",
+#             using_integration=True,
+#         )
+#
+#         dbsession.add(repository)
+#         dbsession.flush()
+#         current_yaml = {
+#             "coverage": {"status": {"project": True, "patch": True, "changes": True}}
+#         }
+#         mocker.patch.dict(
+#             os.environ, {"CHECKS_WHITELISTED_OWNERS": f"0,{repository.owner.ownerid}"}
+#         )
+#         service = NotificationService(repository, current_yaml, None)
+#         instances = list(service.get_notifiers_instances())
+#         names = sorted([instance.name for instance in instances])
+#         assert names == [
+#             "checks-changes-with-fallback",
+#             "checks-patch-with-fallback",
+#             "checks-project-with-fallback",
+#             "codecov-slack-app",
+#         ]
+#
+#     def test_get_notifiers_instances_slack_app_false(
+#         self, dbsession, mock_configuration, mocker
+#     ):
+#         mocker.patch("services.notification.get_config", return_value=False)
+#         repository = RepositoryFactory.create(
+#             owner__integration_id=123,
+#             owner__service="github",
+#             yaml={"codecov": {"max_report_age": "1y ago"}},
+#             name="example-python",
+#             using_integration=True,
+#         )
+#
+#         dbsession.add(repository)
+#         dbsession.flush()
+#         current_yaml = {
+#             "coverage": {"status": {"project": True, "patch": True, "changes": True}}
+#         }
+#         mocker.patch.dict(
+#             os.environ, {"CHECKS_WHITELISTED_OWNERS": f"0,{repository.owner.ownerid}"}
+#         )
+#         service = NotificationService(repository, current_yaml, None)
+#         instances = list(service.get_notifiers_instances())
+#         names = sorted([instance.name for instance in instances])
+#         assert names == [
+#             "checks-changes-with-fallback",
+#             "checks-patch-with-fallback",
+#             "checks-project-with-fallback",
+#         ]
+#
+#     @pytest.mark.parametrize(
+#         "gh_installation_name",
+#         [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
+#     )
+#     def test_get_notifiers_instances_checks_percentage_whitelist(
+#         self, dbsession, mock_configuration, mocker, gh_installation_name
+#     ):
+#         repository = RepositoryFactory.create(
+#             owner__integration_id=123,
+#             owner__service="github",
+#             owner__ownerid=1234,
+#             yaml={"codecov": {"max_report_age": "1y ago"}},
+#             name="example-python",
+#             using_integration=True,
+#         )
+#         dbsession.add(repository)
+#         dbsession.flush()
+#         current_yaml = {
+#             "coverage": {"status": {"project": True, "patch": True, "changes": True}}
+#         }
+#         mocker.patch.dict(
+#             os.environ,
+#             {
+#                 "CHECKS_WHITELISTED_OWNERS": "0,1",
+#                 "CHECKS_WHITELISTED_PERCENTAGE": "35",
+#             },
+#         )
+#         service = NotificationService(
+#             repository,
+#             current_yaml,
+#             gh_installation_name,
+#         )
+#         instances = list(service.get_notifiers_instances())
+#         # we don't need that for slack-app notifier
+#         names = [
+#             instance._checks_notifier.name
+#             for instance in instances
+#             if instance.name != "codecov-slack-app"
+#         ]
+#         assert names == ["checks-project", "checks-patch", "checks-changes"]
+#         for instance in instances:
+#             if isinstance(instance, ChecksWithFallback):
+#                 assert (
+#                     instance._checks_notifier.repository_service == gh_installation_name
+#                 )
+#                 assert (
+#                     instance._status_notifier.repository_service == gh_installation_name
+#                 )
+#             else:
+#                 assert instance.repository_service == gh_installation_name
+#
+#     @pytest.mark.parametrize(
+#         "gh_installation_name",
+#         [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
+#     )
+#     def test_get_notifiers_instances_comment(
+#         self, dbsession, mock_configuration, mocker, gh_installation_name
+#     ):
+#         repository = RepositoryFactory.create(
+#             owner__integration_id=123,
+#             owner__service="github",
+#             owner__ownerid=1234,
+#             yaml={"codecov": {"max_report_age": "1y ago"}},
+#             name="example-python",
+#             using_integration=True,
+#         )
+#         dbsession.add(repository)
+#         dbsession.flush()
+#         current_yaml = {"comment": {"layout": "condensed_header"}, "slack_app": False}
+#         service = NotificationService(
+#             repository,
+#             current_yaml,
+#             gh_installation_name,
+#         )
+#         instances = list(service.get_notifiers_instances())
+#         assert len(instances) == 1
+#         assert instances[0].repository_service == gh_installation_name
+#
+#     def test_notify_general_exception(self, mocker, dbsession, sample_comparison):
+#         current_yaml = {}
+#         commit = sample_comparison.head.commit
+#         good_notifier = mocker.MagicMock(
+#             is_enabled=mocker.MagicMock(return_value=True),
+#             title="good_notifier",
+#             notification_type=Notification.comment,
+#             decoration_type=Decoration.standard,
+#             notify=mock.Mock(),
+#         )
+#         bad_notifier = mocker.MagicMock(
+#             is_enabled=mocker.MagicMock(return_value=True),
+#             title="bad_notifier",
+#             notification_type=Notification.status_project,
+#             decoration_type=Decoration.standard,
+#         )
+#         disabled_notifier = mocker.MagicMock(
+#             is_enabled=mocker.MagicMock(return_value=False),
+#             title="disabled_notifier",
+#             notification_type=Notification.status_patch,
+#             decoration_type=Decoration.standard,
+#             notify=mock.Mock(),
+#         )
+#         good_notifier.notify.return_value = NotificationResult(
+#             notification_attempted=True,
+#             notification_successful=True,
+#             explanation="",
+#             data_sent={"some": "data"},
+#         )
+#         good_notifier.name = "good_name"
+#         bad_notifier.name = "bad_name"
+#         disabled_notifier.name = "disabled_notifier_name"
+#         bad_notifier.notify.side_effect = Exception("This is bad")
+#         mocker.patch.object(
+#             NotificationService,
+#             "get_notifiers_instances",
+#             return_value=[bad_notifier, good_notifier, disabled_notifier],
+#         )
+#         notifications_service = NotificationService(
+#             commit.repository, current_yaml, None
+#         )
+#         expected_result = [
+#             {"notifier": "bad_name", "title": "bad_notifier", "result": None},
+#             {
+#                 "notifier": "good_name",
+#                 "title": "good_notifier",
+#                 "result": NotificationResult(
+#                     notification_attempted=True,
+#                     notification_successful=True,
+#                     explanation="",
+#                     data_sent={"some": "data"},
+#                     data_received=None,
+#                 ),
+#             },
+#         ]
+#         res = notifications_service.notify(sample_comparison)
+#         assert expected_result == res
+#
+#     def test_notify_data_sent_None(self, mocker, dbsession, sample_comparison):
+#         current_yaml = {}
+#         commit = sample_comparison.head.commit
+#         good_notifier = mocker.MagicMock(
+#             is_enabled=mocker.MagicMock(return_value=True),
+#             title="good_notifier",
+#             notification_type=Notification.comment,
+#             decoration_type=Decoration.standard,
+#             notify=mock.Mock(),
+#         )
+#         skipped_notifier = mocker.MagicMock(
+#             is_enabled=mocker.MagicMock(return_value=True),
+#             title="skippy_notifier",
+#             notification_type=Notification.status_project,
+#             decoration_type=Decoration.standard,
+#         )
+#         good_notifier.notify.return_value = NotificationResult(
+#             notification_attempted=True,
+#             notification_successful=True,
+#             explanation="",
+#             data_sent={"some": "data"},
+#         )
+#         skipped_expected_return = NotificationResult(
+#             notification_attempted=False,
+#             notification_successful=None,
+#             explanation="exclude_flag_coverage_not_uploaded_checks",
+#             data_sent=None,
+#             data_received=None,
+#             github_app_used=None,
+#         )
+#         skipped_notifier.notify.return_value = skipped_expected_return
+#         good_notifier.name = "good_name"
+#         skipped_notifier.name = "skippy"
+#
+#         mocker.patch.object(
+#             NotificationService,
+#             "get_notifiers_instances",
+#             return_value=[skipped_notifier, good_notifier],
+#         )
+#
+#         notifications_service = NotificationService(
+#             commit.repository, current_yaml, None
+#         )
+#         expected_result = [
+#             {
+#                 "notifier": "skippy",
+#                 "title": "skippy_notifier",
+#                 "result": skipped_expected_return,
+#             },
+#             {
+#                 "notifier": "good_name",
+#                 "title": "good_notifier",
+#                 "result": NotificationResult(
+#                     notification_attempted=True,
+#                     notification_successful=True,
+#                     explanation="",
+#                     data_sent={"some": "data"},
+#                     data_received=None,
+#                 ),
+#             },
+#         ]
+#         res = notifications_service.notify(sample_comparison)
+#         assert expected_result == res
+#
+#     def test_notify_individual_notifier_timeout(self, mocker, sample_comparison):
+#         current_yaml = {}
+#         commit = sample_comparison.head.commit
+#         notifier = mocker.MagicMock(
+#             title="fake_notifier",
+#             notify=mock.Mock(),
+#             notification_type=Notification.comment,
+#             decoration_type=Decoration.standard,
+#         )
+#         notifier.notify.side_effect = AsyncioTimeoutError
+#         notifications_service = NotificationService(
+#             commit.repository, current_yaml, None
+#         )
+#         res = notifications_service.notify_individual_notifier(
+#             notifier, sample_comparison
+#         )
+#         assert res == {
+#             "notifier": notifier.name,
+#             "result": None,
+#             "title": "fake_notifier",
+#         }
+#
+#     def test_notify_individual_checks_notifier(
+#         self, mocker, sample_comparison, mock_repo_provider, mock_configuration
+#     ):
+#         mock_repo_provider.get_commit_statuses.return_value = Status([])
+#         mock_configuration._params["setup"] = {"codecov_dashboard_url": "test"}
+#         current_yaml = {}
+#         commit = sample_comparison.head.commit
+#         report = Report()
+#         first_deleted_file = ReportFile("file_1.go")
+#         first_deleted_file.append(1, ReportLine.create(coverage=0, sessions=[]))
+#         first_deleted_file.append(2, ReportLine.create(coverage=0, sessions=[]))
+#         first_deleted_file.append(3, ReportLine.create(coverage=0, sessions=[]))
+#         first_deleted_file.append(5, ReportLine.create(coverage=0, sessions=[]))
+#         report.append(first_deleted_file)
+#         sample_comparison.head.report = report
+#         mock_repo_provider.create_check_run.return_value = 2234563
+#         mock_repo_provider.update_check_run.return_value = "success"
+#         notifier = ProjectChecksNotifier(
+#             repository=sample_comparison.head.commit.repository,
+#             title="title",
+#             notifier_yaml_settings={"flags": ["flagone"]},
+#             notifier_site_settings=True,
+#             current_yaml=UserYaml({}),
+#             repository_service=mock_repo_provider,
+#         )
+#         notifications_service = NotificationService(
+#             commit.repository, current_yaml, mock_repo_provider
+#         )
+#         res = notifications_service.notify_individual_notifier(
+#             notifier, sample_comparison
+#         )
+#
+#         assert res == {
+#             "notifier": "checks-project",
+#             "title": "title",
+#             "result": NotificationResult(
+#                 notification_attempted=True,
+#                 notification_successful=True,
+#                 explanation=None,
+#                 data_sent={
+#                     "state": "success",
+#                     "output": {
+#                         "title": "No coverage information found on head",
+#                         "summary": f"[View this Pull Request on Codecov](test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo coverage information found on head",
+#                     },
+#                     "url": f"test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
+#                 },
+#                 data_received=None,
+#             ),
+#         }
+#
+#     def test_notify_individual_notifier_timeout_notification_created(
+#         self, mocker, dbsession, sample_comparison
+#     ):
+#         current_yaml = {}
+#         commit = sample_comparison.head.commit
+#         notifier = mocker.MagicMock(
+#             title="fake_notifier",
+#             notify=mock.Mock(),
+#             notification_type=Notification.comment,
+#             decoration_type=Decoration.standard,
+#         )
+#         notifier.notify.side_effect = AsyncioTimeoutError
+#         notifications_service = NotificationService(
+#             commit.repository, current_yaml, None
+#         )
+#         res = notifications_service.notify_individual_notifier(
+#             notifier, sample_comparison
+#         )
+#         assert res == {
+#             "notifier": notifier.name,
+#             "result": None,
+#             "title": "fake_notifier",
+#         }
+#         dbsession.flush()
+#         pull = sample_comparison.enriched_pull.database_pull
+#         pull_commit_notifications = pull.get_head_commit_notifications()
+#         assert len(pull_commit_notifications) == 1
+#
+#         pull_commit_notification = pull_commit_notifications[0]
+#         assert pull_commit_notification is not None
+#         assert pull_commit_notification.notification_type == notifier.notification_type
+#         assert pull_commit_notification.decoration_type == notifier.decoration_type
+#         assert pull_commit_notification.state == NotificationState.error
+#
+#     def test_notify_individual_notifier_notification_created_then_updated(
+#         self, mocker, dbsession, sample_comparison
+#     ):
+#         current_yaml = {}
+#         commit = sample_comparison.head.commit
+#         notifier = mocker.MagicMock(
+#             title="fake_notifier",
+#             notify=mock.Mock(),
+#             notification_type=Notification.comment,
+#             decoration_type=Decoration.standard,
+#         )
+#         # first attempt not successful
+#         notifier.notify.side_effect = AsyncioTimeoutError
+#         notifications_service = NotificationService(
+#             commit.repository, current_yaml, None
+#         )
+#         res = notifications_service.notify_individual_notifier(
+#             notifier, sample_comparison
+#         )
+#         assert res == {
+#             "notifier": notifier.name,
+#             "result": None,
+#             "title": "fake_notifier",
+#         }
+#         dbsession.flush()
+#         pull = sample_comparison.enriched_pull.database_pull
+#         pull_commit_notifications = pull.get_head_commit_notifications()
+#         assert len(pull_commit_notifications) == 1
+#
+#         pull_commit_notification = pull_commit_notifications[0]
+#         assert pull_commit_notification is not None
+#         assert pull_commit_notification.decoration_type == notifier.decoration_type
+#         assert pull_commit_notification.state == NotificationState.error
+#
+#         # second attempt successful
+#         notifier.notify.side_effect = [
+#             NotificationResult(
+#                 notification_attempted=True,
+#                 notification_successful=True,
+#                 explanation="",
+#                 data_sent={"some": "data"},
+#             )
+#         ]
+#         res = notifications_service.notify_individual_notifier(
+#             notifier, sample_comparison
+#         )
+#         dbsession.commit()
+#         assert pull_commit_notification.state == NotificationState.success
+#
+#     def test_notify_individual_notifier_cancellation(self, mocker, sample_comparison):
+#         current_yaml = {}
+#         commit = sample_comparison.head.commit
+#         notifier = mocker.MagicMock(
+#             title="fake_notifier",
+#             notify=mock.Mock(),
+#             notification_type=Notification.comment,
+#             decoration_type=Decoration.standard,
+#         )
+#         notifier.notify.side_effect = CancelledError()
+#         notifications_service = NotificationService(
+#             commit.repository, current_yaml, None
+#         )
+#         with pytest.raises(CancelledError):
+#             notifications_service.notify_individual_notifier(
+#                 notifier, sample_comparison
+#             )
+#
+#     def test_notify_timeout_exception(self, mocker, dbsession, sample_comparison):
+#         current_yaml = {}
+#         commit = sample_comparison.head.commit
+#         good_notifier = mocker.MagicMock(
+#             is_enabled=mocker.MagicMock(return_value=True),
+#             notify=mock.Mock(),
+#             title="good_notifier",
+#             notification_type=Notification.comment,
+#             decoration_type=Decoration.standard,
+#         )
+#         no_attempt_notifier = mocker.MagicMock(
+#             is_enabled=mocker.MagicMock(return_value=True),
+#             notify=mock.Mock(),
+#             title="no_attempt_notifier",
+#             notification_type=Notification.status_project,
+#             decoration_type=Decoration.standard,
+#         )
+#         bad_notifier = mocker.MagicMock(
+#             is_enabled=mocker.MagicMock(return_value=True),
+#             notify=mock.Mock(),
+#             title="bad_notifier",
+#             notification_type=Notification.status_patch,
+#             decoration_type=Decoration.standard,
+#         )
+#         disabled_notifier = mocker.MagicMock(
+#             is_enabled=mocker.MagicMock(return_value=False),
+#             title="disabled_notifier",
+#             notification_type=Notification.status_changes,
+#             decoration_type=Decoration.standard,
+#         )
+#         good_notifier.notify.return_value = NotificationResult(
+#             notification_attempted=True,
+#             notification_successful=True,
+#             explanation="",
+#             data_sent={"some": "data"},
+#         )
+#         no_attempt_notifier.notify.return_value = NotificationResult(
+#             notification_attempted=False,
+#             notification_successful=None,
+#             explanation="no_need_to_send",
+#             data_sent=None,
+#         )
+#         good_notifier.name = "good_name"
+#         bad_notifier.name = "bad_name"
+#         disabled_notifier.name = "disabled_notifier_name"
+#         bad_notifier.notify.side_effect = SoftTimeLimitExceeded()
+#         mocker.patch.object(
+#             NotificationService,
+#             "get_notifiers_instances",
+#             return_value=[
+#                 bad_notifier,
+#                 good_notifier,
+#                 disabled_notifier,
+#                 no_attempt_notifier,
+#             ],
+#         )
+#         notifications_service = NotificationService(
+#             commit.repository, current_yaml, None
+#         )
+#         with pytest.raises(SoftTimeLimitExceeded):
+#             notifications_service.notify(sample_comparison)
+#
+#         dbsession.flush()
+#         pull_commit_notifications = sample_comparison.enriched_pull.database_pull.get_head_commit_notifications()
+#         assert len(pull_commit_notifications) == 1
+#         for commit_notification in pull_commit_notifications:
+#             assert commit_notification.state in (
+#                 NotificationState.success,
+#                 NotificationState.error,
+#             )
+#             assert commit_notification.decoration_type == Decoration.standard
+#             assert commit_notification.notification_type in (
+#                 Notification.comment,
+#                 Notification.status_patch,
+#             )
+#
+#     def test_not_licensed_enterprise(self, mocker, dbsession, sample_comparison):
+#         mocker.patch("services.notification.is_properly_licensed", return_value=False)
+#         mock_notify_individual_notifier = mocker.patch.object(
+#             NotificationService, "notify_individual_notifier"
+#         )
+#         current_yaml = {}
+#         commit = sample_comparison.head.commit
+#         notifications_service = NotificationService(
+#             commit.repository, current_yaml, None
+#         )
+#         expected_result = []
+#         res = notifications_service.notify(sample_comparison)
+#         assert expected_result == res
+#         assert not mock_notify_individual_notifier.called
+#
+#     def test_get_statuses(self, mocker, dbsession, sample_comparison):
+#         current_yaml = {
+#             "coverage": {"status": {"project": True, "patch": True, "changes": True}},
+#             "flags": {"banana": {"carryforward": False}},
+#             "flag_management": {
+#                 "default_rules": {"carryforward": False},
+#                 "individual_flags": [
+#                     {
+#                         "name": "strawberry",
+#                         "carryforward": True,
+#                         "statuses": [{"name_prefix": "haha", "type": "patch"}],
+#                     }
+#                 ],
+#             },
+#         }
+#         commit = sample_comparison.head.commit
+#         notifications_service = NotificationService(
+#             commit.repository, UserYaml(current_yaml), None
+#         )
+#         expected_result = [
+#             ("project", "default", {}),
+#             ("patch", "default", {}),
+#             ("changes", "default", {}),
+#             (
+#                 "patch",
+#                 "hahastrawberry",
+#                 {"flags": ["strawberry"], "name_prefix": "haha", "type": "patch"},
+#             ),
+#         ]
+#         res = list(notifications_service.get_statuses(["unit", "banana", "strawberry"]))
+#         assert expected_result == res
+#
+#     def test_get_component_statuses(self, mocker, dbsession, sample_comparison):
+#         current_yaml = {
+#             "component_management": {
+#                 "default_rules": {
+#                     "paths": [r"src/important/.*\.cpp"],
+#                     "flag_regexes": [r"critical.*"],
+#                     "statuses": [
+#                         {"name_prefix": "important/", "type": "project"},
+#                         {
+#                             "name_prefix": "legacy/",
+#                             "type": "project",
+#                             "enabled": False,
+#                         },  # this won't be in the results because it's not enabled
+#                     ],
+#                 },
+#                 "individual_components": [
+#                     {
+#                         "component_id": "my-special-component",
+#                         "flag_regexes": [r"special.*"],
+#                         "statuses": [
+#                             {"name_prefix": "special/", "type": "patch"},
+#                             {"name_prefix": "legacy/", "type": "project"},
+#                         ],
+#                     },
+#                     {
+#                         "component_id": "inner-app",
+#                         "paths": [r"src/inner_app/.*"],
+#                         "statuses": [{"type": "patch"}],
+#                     },
+#                     {"component_id": "from_default"},
+#                 ],
+#             }
+#         }
+#         commit = sample_comparison.head.commit
+#         notifications_service = NotificationService(
+#             commit.repository, UserYaml(current_yaml), None
+#         )
+#         expected_result = [
+#             (
+#                 "patch",
+#                 "special/my-special-component",
+#                 {
+#                     "flags": ["special_flag"],
+#                     "paths": [r"src/important/.*\.cpp"],
+#                     "type": "patch",
+#                     "name_prefix": "special/",
+#                 },
+#             ),
+#             (
+#                 "project",
+#                 "legacy/my-special-component",
+#                 {
+#                     "flags": ["special_flag"],
+#                     "paths": [r"src/important/.*\.cpp"],
+#                     "type": "project",
+#                     "name_prefix": "legacy/",
+#                 },
+#             ),
+#             (
+#                 "patch",
+#                 "inner-app",
+#                 {
+#                     "flags": ["critical_files"],
+#                     "paths": [r"src/inner_app/.*"],
+#                     "type": "patch",
+#                 },
+#             ),
+#             (
+#                 "project",
+#                 "important/from_default",
+#                 {
+#                     "flags": ["critical_files"],
+#                     "name_prefix": "important/",
+#                     "type": "project",
+#                     "paths": [r"src/important/.*\.cpp"],
+#                 },
+#             ),
+#         ]
+#         res = list(
+#             notifications_service.get_statuses(
+#                 ["special_flag", "critical_files", "banana"]
+#             )
+#         )
+#         assert expected_result == res

--- a/services/notification/tests/unit/test_notification_service.py
+++ b/services/notification/tests/unit/test_notification_service.py
@@ -1,8 +1,16 @@
 import os
+from asyncio import CancelledError
+from asyncio import TimeoutError as AsyncioTimeoutError
 
+import mock
 import pytest
+from celery.exceptions import SoftTimeLimitExceeded
 from shared.plan.constants import PlanName
+from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.torngit.status import Status
+from shared.yaml import UserYaml
 
+from database.enums import Decoration, Notification, NotificationState
 from database.models.core import (
     GITHUB_APP_INSTALLATION_DEFAULT_NAME,
     GithubAppInstallation,
@@ -12,6 +20,8 @@ from services.comparison import ComparisonProxy
 from services.comparison.types import Comparison, EnrichedPull, FullCommit
 from services.notification import NotificationService
 from services.notification.notifiers import StatusType
+from services.notification.notifiers.base import NotificationResult
+from services.notification.notifiers.checks import ProjectChecksNotifier
 from services.notification.notifiers.checks.checks_with_fallback import (
     ChecksWithFallback,
 )
@@ -380,533 +390,533 @@ class TestNotificationService(object):
             else:
                 assert instance.repository_service == gh_installation_name
 
-    # @pytest.mark.parametrize(
-    #     "gh_installation_name",
-    #     [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
-    # )
-    # def test_get_notifiers_instances_comment(
-    #     self, dbsession, mock_configuration, mocker, gh_installation_name
-    # ):
-    #     repository = RepositoryFactory.create(
-    #         owner__integration_id=123,
-    #         owner__service="github",
-    #         owner__ownerid=1234,
-    #         yaml={"codecov": {"max_report_age": "1y ago"}},
-    #         name="example-python",
-    #         using_integration=True,
-    #     )
-    #     dbsession.add(repository)
-    #     dbsession.flush()
-    #     current_yaml = {"comment": {"layout": "condensed_header"}, "slack_app": False}
-    #     service = NotificationService(
-    #         repository,
-    #         current_yaml,
-    #         gh_installation_name,
-    #     )
-    #     instances = list(service.get_notifiers_instances())
-    #     assert len(instances) == 1
-    #     assert instances[0].repository_service == gh_installation_name
-    #
-    # def test_notify_general_exception(self, mocker, dbsession, sample_comparison):
-    #     current_yaml = {}
-    #     commit = sample_comparison.head.commit
-    #     good_notifier = mocker.MagicMock(
-    #         is_enabled=mocker.MagicMock(return_value=True),
-    #         title="good_notifier",
-    #         notification_type=Notification.comment,
-    #         decoration_type=Decoration.standard,
-    #         notify=mock.Mock(),
-    #     )
-    #     bad_notifier = mocker.MagicMock(
-    #         is_enabled=mocker.MagicMock(return_value=True),
-    #         title="bad_notifier",
-    #         notification_type=Notification.status_project,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     disabled_notifier = mocker.MagicMock(
-    #         is_enabled=mocker.MagicMock(return_value=False),
-    #         title="disabled_notifier",
-    #         notification_type=Notification.status_patch,
-    #         decoration_type=Decoration.standard,
-    #         notify=mock.Mock(),
-    #     )
-    #     good_notifier.notify.return_value = NotificationResult(
-    #         notification_attempted=True,
-    #         notification_successful=True,
-    #         explanation="",
-    #         data_sent={"some": "data"},
-    #     )
-    #     good_notifier.name = "good_name"
-    #     bad_notifier.name = "bad_name"
-    #     disabled_notifier.name = "disabled_notifier_name"
-    #     bad_notifier.notify.side_effect = Exception("This is bad")
-    #     mocker.patch.object(
-    #         NotificationService,
-    #         "get_notifiers_instances",
-    #         return_value=[bad_notifier, good_notifier, disabled_notifier],
-    #     )
-    #     notifications_service = NotificationService(
-    #         commit.repository, current_yaml, None
-    #     )
-    #     expected_result = [
-    #         {"notifier": "bad_name", "title": "bad_notifier", "result": None},
-    #         {
-    #             "notifier": "good_name",
-    #             "title": "good_notifier",
-    #             "result": NotificationResult(
-    #                 notification_attempted=True,
-    #                 notification_successful=True,
-    #                 explanation="",
-    #                 data_sent={"some": "data"},
-    #                 data_received=None,
-    #             ),
-    #         },
-    #     ]
-    #     res = notifications_service.notify(sample_comparison)
-    #     assert expected_result == res
-    #
-    # def test_notify_data_sent_None(self, mocker, dbsession, sample_comparison):
-    #     current_yaml = {}
-    #     commit = sample_comparison.head.commit
-    #     good_notifier = mocker.MagicMock(
-    #         is_enabled=mocker.MagicMock(return_value=True),
-    #         title="good_notifier",
-    #         notification_type=Notification.comment,
-    #         decoration_type=Decoration.standard,
-    #         notify=mock.Mock(),
-    #     )
-    #     skipped_notifier = mocker.MagicMock(
-    #         is_enabled=mocker.MagicMock(return_value=True),
-    #         title="skippy_notifier",
-    #         notification_type=Notification.status_project,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     good_notifier.notify.return_value = NotificationResult(
-    #         notification_attempted=True,
-    #         notification_successful=True,
-    #         explanation="",
-    #         data_sent={"some": "data"},
-    #     )
-    #     skipped_expected_return = NotificationResult(
-    #         notification_attempted=False,
-    #         notification_successful=None,
-    #         explanation="exclude_flag_coverage_not_uploaded_checks",
-    #         data_sent=None,
-    #         data_received=None,
-    #         github_app_used=None,
-    #     )
-    #     skipped_notifier.notify.return_value = skipped_expected_return
-    #     good_notifier.name = "good_name"
-    #     skipped_notifier.name = "skippy"
-    #
-    #     mocker.patch.object(
-    #         NotificationService,
-    #         "get_notifiers_instances",
-    #         return_value=[skipped_notifier, good_notifier],
-    #     )
-    #
-    #     notifications_service = NotificationService(
-    #         commit.repository, current_yaml, None
-    #     )
-    #     expected_result = [
-    #         {
-    #             "notifier": "skippy",
-    #             "title": "skippy_notifier",
-    #             "result": skipped_expected_return,
-    #         },
-    #         {
-    #             "notifier": "good_name",
-    #             "title": "good_notifier",
-    #             "result": NotificationResult(
-    #                 notification_attempted=True,
-    #                 notification_successful=True,
-    #                 explanation="",
-    #                 data_sent={"some": "data"},
-    #                 data_received=None,
-    #             ),
-    #         },
-    #     ]
-    #     res = notifications_service.notify(sample_comparison)
-    #     assert expected_result == res
-    #
-    # def test_notify_individual_notifier_timeout(self, mocker, sample_comparison):
-    #     current_yaml = {}
-    #     commit = sample_comparison.head.commit
-    #     notifier = mocker.MagicMock(
-    #         title="fake_notifier",
-    #         notify=mock.Mock(),
-    #         notification_type=Notification.comment,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     notifier.notify.side_effect = AsyncioTimeoutError
-    #     notifications_service = NotificationService(
-    #         commit.repository, current_yaml, None
-    #     )
-    #     res = notifications_service.notify_individual_notifier(
-    #         notifier, sample_comparison
-    #     )
-    #     assert res == {
-    #         "notifier": notifier.name,
-    #         "result": None,
-    #         "title": "fake_notifier",
-    #     }
-    #
-    # def test_notify_individual_checks_notifier(
-    #     self, mocker, sample_comparison, mock_repo_provider, mock_configuration
-    # ):
-    #     mock_repo_provider.get_commit_statuses.return_value = Status([])
-    #     mock_configuration._params["setup"] = {"codecov_dashboard_url": "test"}
-    #     current_yaml = {}
-    #     commit = sample_comparison.head.commit
-    #     report = Report()
-    #     first_deleted_file = ReportFile("file_1.go")
-    #     first_deleted_file.append(1, ReportLine.create(coverage=0, sessions=[]))
-    #     first_deleted_file.append(2, ReportLine.create(coverage=0, sessions=[]))
-    #     first_deleted_file.append(3, ReportLine.create(coverage=0, sessions=[]))
-    #     first_deleted_file.append(5, ReportLine.create(coverage=0, sessions=[]))
-    #     report.append(first_deleted_file)
-    #     sample_comparison.head.report = report
-    #     mock_repo_provider.create_check_run.return_value = 2234563
-    #     mock_repo_provider.update_check_run.return_value = "success"
-    #     notifier = ProjectChecksNotifier(
-    #         repository=sample_comparison.head.commit.repository,
-    #         title="title",
-    #         notifier_yaml_settings={"flags": ["flagone"]},
-    #         notifier_site_settings=True,
-    #         current_yaml=UserYaml({}),
-    #         repository_service=mock_repo_provider,
-    #     )
-    #     notifications_service = NotificationService(
-    #         commit.repository, current_yaml, mock_repo_provider
-    #     )
-    #     res = notifications_service.notify_individual_notifier(
-    #         notifier, sample_comparison
-    #     )
-    #
-    #     assert res == {
-    #         "notifier": "checks-project",
-    #         "title": "title",
-    #         "result": NotificationResult(
-    #             notification_attempted=True,
-    #             notification_successful=True,
-    #             explanation=None,
-    #             data_sent={
-    #                 "state": "success",
-    #                 "output": {
-    #                     "title": "No coverage information found on head",
-    #                     "summary": f"[View this Pull Request on Codecov](test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo coverage information found on head",
-    #                 },
-    #                 "url": f"test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
-    #             },
-    #             data_received=None,
-    #         ),
-    #     }
-    #
-    # def test_notify_individual_notifier_timeout_notification_created(
-    #     self, mocker, dbsession, sample_comparison
-    # ):
-    #     current_yaml = {}
-    #     commit = sample_comparison.head.commit
-    #     notifier = mocker.MagicMock(
-    #         title="fake_notifier",
-    #         notify=mock.Mock(),
-    #         notification_type=Notification.comment,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     notifier.notify.side_effect = AsyncioTimeoutError
-    #     notifications_service = NotificationService(
-    #         commit.repository, current_yaml, None
-    #     )
-    #     res = notifications_service.notify_individual_notifier(
-    #         notifier, sample_comparison
-    #     )
-    #     assert res == {
-    #         "notifier": notifier.name,
-    #         "result": None,
-    #         "title": "fake_notifier",
-    #     }
-    #     dbsession.flush()
-    #     pull = sample_comparison.enriched_pull.database_pull
-    #     pull_commit_notifications = pull.get_head_commit_notifications()
-    #     assert len(pull_commit_notifications) == 1
-    #
-    #     pull_commit_notification = pull_commit_notifications[0]
-    #     assert pull_commit_notification is not None
-    #     assert pull_commit_notification.notification_type == notifier.notification_type
-    #     assert pull_commit_notification.decoration_type == notifier.decoration_type
-    #     assert pull_commit_notification.state == NotificationState.error
-    #
-    # def test_notify_individual_notifier_notification_created_then_updated(
-    #     self, mocker, dbsession, sample_comparison
-    # ):
-    #     current_yaml = {}
-    #     commit = sample_comparison.head.commit
-    #     notifier = mocker.MagicMock(
-    #         title="fake_notifier",
-    #         notify=mock.Mock(),
-    #         notification_type=Notification.comment,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     # first attempt not successful
-    #     notifier.notify.side_effect = AsyncioTimeoutError
-    #     notifications_service = NotificationService(
-    #         commit.repository, current_yaml, None
-    #     )
-    #     res = notifications_service.notify_individual_notifier(
-    #         notifier, sample_comparison
-    #     )
-    #     assert res == {
-    #         "notifier": notifier.name,
-    #         "result": None,
-    #         "title": "fake_notifier",
-    #     }
-    #     dbsession.flush()
-    #     pull = sample_comparison.enriched_pull.database_pull
-    #     pull_commit_notifications = pull.get_head_commit_notifications()
-    #     assert len(pull_commit_notifications) == 1
-    #
-    #     pull_commit_notification = pull_commit_notifications[0]
-    #     assert pull_commit_notification is not None
-    #     assert pull_commit_notification.decoration_type == notifier.decoration_type
-    #     assert pull_commit_notification.state == NotificationState.error
-    #
-    #     # second attempt successful
-    #     notifier.notify.side_effect = [
-    #         NotificationResult(
-    #             notification_attempted=True,
-    #             notification_successful=True,
-    #             explanation="",
-    #             data_sent={"some": "data"},
-    #         )
-    #     ]
-    #     res = notifications_service.notify_individual_notifier(
-    #         notifier, sample_comparison
-    #     )
-    #     dbsession.commit()
-    #     assert pull_commit_notification.state == NotificationState.success
-    #
-    # def test_notify_individual_notifier_cancellation(self, mocker, sample_comparison):
-    #     current_yaml = {}
-    #     commit = sample_comparison.head.commit
-    #     notifier = mocker.MagicMock(
-    #         title="fake_notifier",
-    #         notify=mock.Mock(),
-    #         notification_type=Notification.comment,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     notifier.notify.side_effect = CancelledError()
-    #     notifications_service = NotificationService(
-    #         commit.repository, current_yaml, None
-    #     )
-    #     with pytest.raises(CancelledError):
-    #         notifications_service.notify_individual_notifier(
-    #             notifier, sample_comparison
-    #         )
-    #
-    # def test_notify_timeout_exception(self, mocker, dbsession, sample_comparison):
-    #     current_yaml = {}
-    #     commit = sample_comparison.head.commit
-    #     good_notifier = mocker.MagicMock(
-    #         is_enabled=mocker.MagicMock(return_value=True),
-    #         notify=mock.Mock(),
-    #         title="good_notifier",
-    #         notification_type=Notification.comment,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     no_attempt_notifier = mocker.MagicMock(
-    #         is_enabled=mocker.MagicMock(return_value=True),
-    #         notify=mock.Mock(),
-    #         title="no_attempt_notifier",
-    #         notification_type=Notification.status_project,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     bad_notifier = mocker.MagicMock(
-    #         is_enabled=mocker.MagicMock(return_value=True),
-    #         notify=mock.Mock(),
-    #         title="bad_notifier",
-    #         notification_type=Notification.status_patch,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     disabled_notifier = mocker.MagicMock(
-    #         is_enabled=mocker.MagicMock(return_value=False),
-    #         title="disabled_notifier",
-    #         notification_type=Notification.status_changes,
-    #         decoration_type=Decoration.standard,
-    #     )
-    #     good_notifier.notify.return_value = NotificationResult(
-    #         notification_attempted=True,
-    #         notification_successful=True,
-    #         explanation="",
-    #         data_sent={"some": "data"},
-    #     )
-    #     no_attempt_notifier.notify.return_value = NotificationResult(
-    #         notification_attempted=False,
-    #         notification_successful=None,
-    #         explanation="no_need_to_send",
-    #         data_sent=None,
-    #     )
-    #     good_notifier.name = "good_name"
-    #     bad_notifier.name = "bad_name"
-    #     disabled_notifier.name = "disabled_notifier_name"
-    #     bad_notifier.notify.side_effect = SoftTimeLimitExceeded()
-    #     mocker.patch.object(
-    #         NotificationService,
-    #         "get_notifiers_instances",
-    #         return_value=[
-    #             bad_notifier,
-    #             good_notifier,
-    #             disabled_notifier,
-    #             no_attempt_notifier,
-    #         ],
-    #     )
-    #     notifications_service = NotificationService(
-    #         commit.repository, current_yaml, None
-    #     )
-    #     with pytest.raises(SoftTimeLimitExceeded):
-    #         notifications_service.notify(sample_comparison)
-    #
-    #     dbsession.flush()
-    #     pull_commit_notifications = sample_comparison.enriched_pull.database_pull.get_head_commit_notifications()
-    #     assert len(pull_commit_notifications) == 1
-    #     for commit_notification in pull_commit_notifications:
-    #         assert commit_notification.state in (
-    #             NotificationState.success,
-    #             NotificationState.error,
-    #         )
-    #         assert commit_notification.decoration_type == Decoration.standard
-    #         assert commit_notification.notification_type in (
-    #             Notification.comment,
-    #             Notification.status_patch,
-    #         )
-    #
-    # def test_not_licensed_enterprise(self, mocker, dbsession, sample_comparison):
-    #     mocker.patch("services.notification.is_properly_licensed", return_value=False)
-    #     mock_notify_individual_notifier = mocker.patch.object(
-    #         NotificationService, "notify_individual_notifier"
-    #     )
-    #     current_yaml = {}
-    #     commit = sample_comparison.head.commit
-    #     notifications_service = NotificationService(
-    #         commit.repository, current_yaml, None
-    #     )
-    #     expected_result = []
-    #     res = notifications_service.notify(sample_comparison)
-    #     assert expected_result == res
-    #     assert not mock_notify_individual_notifier.called
-    #
-    # def test_get_statuses(self, mocker, dbsession, sample_comparison):
-    #     current_yaml = {
-    #         "coverage": {"status": {"project": True, "patch": True, "changes": True}},
-    #         "flags": {"banana": {"carryforward": False}},
-    #         "flag_management": {
-    #             "default_rules": {"carryforward": False},
-    #             "individual_flags": [
-    #                 {
-    #                     "name": "strawberry",
-    #                     "carryforward": True,
-    #                     "statuses": [{"name_prefix": "haha", "type": "patch"}],
-    #                 }
-    #             ],
-    #         },
-    #     }
-    #     commit = sample_comparison.head.commit
-    #     notifications_service = NotificationService(
-    #         commit.repository, UserYaml(current_yaml), None
-    #     )
-    #     expected_result = [
-    #         ("project", "default", {}),
-    #         ("patch", "default", {}),
-    #         ("changes", "default", {}),
-    #         (
-    #             "patch",
-    #             "hahastrawberry",
-    #             {"flags": ["strawberry"], "name_prefix": "haha", "type": "patch"},
-    #         ),
-    #     ]
-    #     res = list(notifications_service.get_statuses(["unit", "banana", "strawberry"]))
-    #     assert expected_result == res
-    #
-    # def test_get_component_statuses(self, mocker, dbsession, sample_comparison):
-    #     current_yaml = {
-    #         "component_management": {
-    #             "default_rules": {
-    #                 "paths": [r"src/important/.*\.cpp"],
-    #                 "flag_regexes": [r"critical.*"],
-    #                 "statuses": [
-    #                     {"name_prefix": "important/", "type": "project"},
-    #                     {
-    #                         "name_prefix": "legacy/",
-    #                         "type": "project",
-    #                         "enabled": False,
-    #                     },  # this won't be in the results because it's not enabled
-    #                 ],
-    #             },
-    #             "individual_components": [
-    #                 {
-    #                     "component_id": "my-special-component",
-    #                     "flag_regexes": [r"special.*"],
-    #                     "statuses": [
-    #                         {"name_prefix": "special/", "type": "patch"},
-    #                         {"name_prefix": "legacy/", "type": "project"},
-    #                     ],
-    #                 },
-    #                 {
-    #                     "component_id": "inner-app",
-    #                     "paths": [r"src/inner_app/.*"],
-    #                     "statuses": [{"type": "patch"}],
-    #                 },
-    #                 {"component_id": "from_default"},
-    #             ],
-    #         }
-    #     }
-    #     commit = sample_comparison.head.commit
-    #     notifications_service = NotificationService(
-    #         commit.repository, UserYaml(current_yaml), None
-    #     )
-    #     expected_result = [
-    #         (
-    #             "patch",
-    #             "special/my-special-component",
-    #             {
-    #                 "flags": ["special_flag"],
-    #                 "paths": [r"src/important/.*\.cpp"],
-    #                 "type": "patch",
-    #                 "name_prefix": "special/",
-    #             },
-    #         ),
-    #         (
-    #             "project",
-    #             "legacy/my-special-component",
-    #             {
-    #                 "flags": ["special_flag"],
-    #                 "paths": [r"src/important/.*\.cpp"],
-    #                 "type": "project",
-    #                 "name_prefix": "legacy/",
-    #             },
-    #         ),
-    #         (
-    #             "patch",
-    #             "inner-app",
-    #             {
-    #                 "flags": ["critical_files"],
-    #                 "paths": [r"src/inner_app/.*"],
-    #                 "type": "patch",
-    #             },
-    #         ),
-    #         (
-    #             "project",
-    #             "important/from_default",
-    #             {
-    #                 "flags": ["critical_files"],
-    #                 "name_prefix": "important/",
-    #                 "type": "project",
-    #                 "paths": [r"src/important/.*\.cpp"],
-    #             },
-    #         ),
-    #     ]
-    #     res = list(
-    #         notifications_service.get_statuses(
-    #             ["special_flag", "critical_files", "banana"]
-    #         )
-    #     )
-    #     assert expected_result == res
+    @pytest.mark.parametrize(
+        "gh_installation_name",
+        [GITHUB_APP_INSTALLATION_DEFAULT_NAME, "notifications-app"],
+    )
+    def test_get_notifiers_instances_comment(
+        self, dbsession, mock_configuration, mocker, gh_installation_name
+    ):
+        repository = RepositoryFactory.create(
+            owner__integration_id=123,
+            owner__service="github",
+            owner__ownerid=1234,
+            yaml={"codecov": {"max_report_age": "1y ago"}},
+            name="example-python",
+            using_integration=True,
+        )
+        dbsession.add(repository)
+        dbsession.flush()
+        current_yaml = {"comment": {"layout": "condensed_header"}, "slack_app": False}
+        service = NotificationService(
+            repository,
+            current_yaml,
+            gh_installation_name,
+        )
+        instances = list(service.get_notifiers_instances())
+        assert len(instances) == 1
+        assert instances[0].repository_service == gh_installation_name
+
+    def test_notify_general_exception(self, mocker, dbsession, sample_comparison):
+        current_yaml = {}
+        commit = sample_comparison.head.commit
+        good_notifier = mocker.MagicMock(
+            is_enabled=mocker.MagicMock(return_value=True),
+            title="good_notifier",
+            notification_type=Notification.comment,
+            decoration_type=Decoration.standard,
+            notify=mock.Mock(),
+        )
+        bad_notifier = mocker.MagicMock(
+            is_enabled=mocker.MagicMock(return_value=True),
+            title="bad_notifier",
+            notification_type=Notification.status_project,
+            decoration_type=Decoration.standard,
+        )
+        disabled_notifier = mocker.MagicMock(
+            is_enabled=mocker.MagicMock(return_value=False),
+            title="disabled_notifier",
+            notification_type=Notification.status_patch,
+            decoration_type=Decoration.standard,
+            notify=mock.Mock(),
+        )
+        good_notifier.notify.return_value = NotificationResult(
+            notification_attempted=True,
+            notification_successful=True,
+            explanation="",
+            data_sent={"some": "data"},
+        )
+        good_notifier.name = "good_name"
+        bad_notifier.name = "bad_name"
+        disabled_notifier.name = "disabled_notifier_name"
+        bad_notifier.notify.side_effect = Exception("This is bad")
+        mocker.patch.object(
+            NotificationService,
+            "get_notifiers_instances",
+            return_value=[bad_notifier, good_notifier, disabled_notifier],
+        )
+        notifications_service = NotificationService(
+            commit.repository, current_yaml, None
+        )
+        expected_result = [
+            {"notifier": "bad_name", "title": "bad_notifier", "result": None},
+            {
+                "notifier": "good_name",
+                "title": "good_notifier",
+                "result": NotificationResult(
+                    notification_attempted=True,
+                    notification_successful=True,
+                    explanation="",
+                    data_sent={"some": "data"},
+                    data_received=None,
+                ),
+            },
+        ]
+        res = notifications_service.notify(sample_comparison)
+        assert expected_result == res
+
+    def test_notify_data_sent_None(self, mocker, dbsession, sample_comparison):
+        current_yaml = {}
+        commit = sample_comparison.head.commit
+        good_notifier = mocker.MagicMock(
+            is_enabled=mocker.MagicMock(return_value=True),
+            title="good_notifier",
+            notification_type=Notification.comment,
+            decoration_type=Decoration.standard,
+            notify=mock.Mock(),
+        )
+        skipped_notifier = mocker.MagicMock(
+            is_enabled=mocker.MagicMock(return_value=True),
+            title="skippy_notifier",
+            notification_type=Notification.status_project,
+            decoration_type=Decoration.standard,
+        )
+        good_notifier.notify.return_value = NotificationResult(
+            notification_attempted=True,
+            notification_successful=True,
+            explanation="",
+            data_sent={"some": "data"},
+        )
+        skipped_expected_return = NotificationResult(
+            notification_attempted=False,
+            notification_successful=None,
+            explanation="exclude_flag_coverage_not_uploaded_checks",
+            data_sent=None,
+            data_received=None,
+            github_app_used=None,
+        )
+        skipped_notifier.notify.return_value = skipped_expected_return
+        good_notifier.name = "good_name"
+        skipped_notifier.name = "skippy"
+
+        mocker.patch.object(
+            NotificationService,
+            "get_notifiers_instances",
+            return_value=[skipped_notifier, good_notifier],
+        )
+
+        notifications_service = NotificationService(
+            commit.repository, current_yaml, None
+        )
+        expected_result = [
+            {
+                "notifier": "skippy",
+                "title": "skippy_notifier",
+                "result": skipped_expected_return,
+            },
+            {
+                "notifier": "good_name",
+                "title": "good_notifier",
+                "result": NotificationResult(
+                    notification_attempted=True,
+                    notification_successful=True,
+                    explanation="",
+                    data_sent={"some": "data"},
+                    data_received=None,
+                ),
+            },
+        ]
+        res = notifications_service.notify(sample_comparison)
+        assert expected_result == res
+
+    def test_notify_individual_notifier_timeout(self, mocker, sample_comparison):
+        current_yaml = {}
+        commit = sample_comparison.head.commit
+        notifier = mocker.MagicMock(
+            title="fake_notifier",
+            notify=mock.Mock(),
+            notification_type=Notification.comment,
+            decoration_type=Decoration.standard,
+        )
+        notifier.notify.side_effect = AsyncioTimeoutError
+        notifications_service = NotificationService(
+            commit.repository, current_yaml, None
+        )
+        res = notifications_service.notify_individual_notifier(
+            notifier, sample_comparison
+        )
+        assert res == {
+            "notifier": notifier.name,
+            "result": None,
+            "title": "fake_notifier",
+        }
+
+    def test_notify_individual_checks_notifier(
+        self, mocker, sample_comparison, mock_repo_provider, mock_configuration
+    ):
+        mock_repo_provider.get_commit_statuses.return_value = Status([])
+        mock_configuration._params["setup"] = {"codecov_dashboard_url": "test"}
+        current_yaml = {}
+        commit = sample_comparison.head.commit
+        report = Report()
+        first_deleted_file = ReportFile("file_1.go")
+        first_deleted_file.append(1, ReportLine.create(coverage=0, sessions=[]))
+        first_deleted_file.append(2, ReportLine.create(coverage=0, sessions=[]))
+        first_deleted_file.append(3, ReportLine.create(coverage=0, sessions=[]))
+        first_deleted_file.append(5, ReportLine.create(coverage=0, sessions=[]))
+        report.append(first_deleted_file)
+        sample_comparison.head.report = report
+        mock_repo_provider.create_check_run.return_value = 2234563
+        mock_repo_provider.update_check_run.return_value = "success"
+        notifier = ProjectChecksNotifier(
+            repository=sample_comparison.head.commit.repository,
+            title="title",
+            notifier_yaml_settings={"flags": ["flagone"]},
+            notifier_site_settings=True,
+            current_yaml=UserYaml({}),
+            repository_service=mock_repo_provider,
+        )
+        notifications_service = NotificationService(
+            commit.repository, current_yaml, mock_repo_provider
+        )
+        res = notifications_service.notify_individual_notifier(
+            notifier, sample_comparison
+        )
+
+        assert res == {
+            "notifier": "checks-project",
+            "title": "title",
+            "result": NotificationResult(
+                notification_attempted=True,
+                notification_successful=True,
+                explanation=None,
+                data_sent={
+                    "state": "success",
+                    "output": {
+                        "title": "No coverage information found on head",
+                        "summary": f"[View this Pull Request on Codecov](test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo coverage information found on head",
+                    },
+                    "url": f"test/gh/test_notify_individual_checks_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
+                },
+                data_received=None,
+            ),
+        }
+
+    def test_notify_individual_notifier_timeout_notification_created(
+        self, mocker, dbsession, sample_comparison
+    ):
+        current_yaml = {}
+        commit = sample_comparison.head.commit
+        notifier = mocker.MagicMock(
+            title="fake_notifier",
+            notify=mock.Mock(),
+            notification_type=Notification.comment,
+            decoration_type=Decoration.standard,
+        )
+        notifier.notify.side_effect = AsyncioTimeoutError
+        notifications_service = NotificationService(
+            commit.repository, current_yaml, None
+        )
+        res = notifications_service.notify_individual_notifier(
+            notifier, sample_comparison
+        )
+        assert res == {
+            "notifier": notifier.name,
+            "result": None,
+            "title": "fake_notifier",
+        }
+        dbsession.flush()
+        pull = sample_comparison.enriched_pull.database_pull
+        pull_commit_notifications = pull.get_head_commit_notifications()
+        assert len(pull_commit_notifications) == 1
+
+        pull_commit_notification = pull_commit_notifications[0]
+        assert pull_commit_notification is not None
+        assert pull_commit_notification.notification_type == notifier.notification_type
+        assert pull_commit_notification.decoration_type == notifier.decoration_type
+        assert pull_commit_notification.state == NotificationState.error
+
+    def test_notify_individual_notifier_notification_created_then_updated(
+        self, mocker, dbsession, sample_comparison
+    ):
+        current_yaml = {}
+        commit = sample_comparison.head.commit
+        notifier = mocker.MagicMock(
+            title="fake_notifier",
+            notify=mock.Mock(),
+            notification_type=Notification.comment,
+            decoration_type=Decoration.standard,
+        )
+        # first attempt not successful
+        notifier.notify.side_effect = AsyncioTimeoutError
+        notifications_service = NotificationService(
+            commit.repository, current_yaml, None
+        )
+        res = notifications_service.notify_individual_notifier(
+            notifier, sample_comparison
+        )
+        assert res == {
+            "notifier": notifier.name,
+            "result": None,
+            "title": "fake_notifier",
+        }
+        dbsession.flush()
+        pull = sample_comparison.enriched_pull.database_pull
+        pull_commit_notifications = pull.get_head_commit_notifications()
+        assert len(pull_commit_notifications) == 1
+
+        pull_commit_notification = pull_commit_notifications[0]
+        assert pull_commit_notification is not None
+        assert pull_commit_notification.decoration_type == notifier.decoration_type
+        assert pull_commit_notification.state == NotificationState.error
+
+        # second attempt successful
+        notifier.notify.side_effect = [
+            NotificationResult(
+                notification_attempted=True,
+                notification_successful=True,
+                explanation="",
+                data_sent={"some": "data"},
+            )
+        ]
+        res = notifications_service.notify_individual_notifier(
+            notifier, sample_comparison
+        )
+        dbsession.commit()
+        assert pull_commit_notification.state == NotificationState.success
+
+    def test_notify_individual_notifier_cancellation(self, mocker, sample_comparison):
+        current_yaml = {}
+        commit = sample_comparison.head.commit
+        notifier = mocker.MagicMock(
+            title="fake_notifier",
+            notify=mock.Mock(),
+            notification_type=Notification.comment,
+            decoration_type=Decoration.standard,
+        )
+        notifier.notify.side_effect = CancelledError()
+        notifications_service = NotificationService(
+            commit.repository, current_yaml, None
+        )
+        with pytest.raises(CancelledError):
+            notifications_service.notify_individual_notifier(
+                notifier, sample_comparison
+            )
+
+    def test_notify_timeout_exception(self, mocker, dbsession, sample_comparison):
+        current_yaml = {}
+        commit = sample_comparison.head.commit
+        good_notifier = mocker.MagicMock(
+            is_enabled=mocker.MagicMock(return_value=True),
+            notify=mock.Mock(),
+            title="good_notifier",
+            notification_type=Notification.comment,
+            decoration_type=Decoration.standard,
+        )
+        no_attempt_notifier = mocker.MagicMock(
+            is_enabled=mocker.MagicMock(return_value=True),
+            notify=mock.Mock(),
+            title="no_attempt_notifier",
+            notification_type=Notification.status_project,
+            decoration_type=Decoration.standard,
+        )
+        bad_notifier = mocker.MagicMock(
+            is_enabled=mocker.MagicMock(return_value=True),
+            notify=mock.Mock(),
+            title="bad_notifier",
+            notification_type=Notification.status_patch,
+            decoration_type=Decoration.standard,
+        )
+        disabled_notifier = mocker.MagicMock(
+            is_enabled=mocker.MagicMock(return_value=False),
+            title="disabled_notifier",
+            notification_type=Notification.status_changes,
+            decoration_type=Decoration.standard,
+        )
+        good_notifier.notify.return_value = NotificationResult(
+            notification_attempted=True,
+            notification_successful=True,
+            explanation="",
+            data_sent={"some": "data"},
+        )
+        no_attempt_notifier.notify.return_value = NotificationResult(
+            notification_attempted=False,
+            notification_successful=None,
+            explanation="no_need_to_send",
+            data_sent=None,
+        )
+        good_notifier.name = "good_name"
+        bad_notifier.name = "bad_name"
+        disabled_notifier.name = "disabled_notifier_name"
+        bad_notifier.notify.side_effect = SoftTimeLimitExceeded()
+        mocker.patch.object(
+            NotificationService,
+            "get_notifiers_instances",
+            return_value=[
+                bad_notifier,
+                good_notifier,
+                disabled_notifier,
+                no_attempt_notifier,
+            ],
+        )
+        notifications_service = NotificationService(
+            commit.repository, current_yaml, None
+        )
+        with pytest.raises(SoftTimeLimitExceeded):
+            notifications_service.notify(sample_comparison)
+
+        dbsession.flush()
+        pull_commit_notifications = sample_comparison.enriched_pull.database_pull.get_head_commit_notifications()
+        assert len(pull_commit_notifications) == 1
+        for commit_notification in pull_commit_notifications:
+            assert commit_notification.state in (
+                NotificationState.success,
+                NotificationState.error,
+            )
+            assert commit_notification.decoration_type == Decoration.standard
+            assert commit_notification.notification_type in (
+                Notification.comment,
+                Notification.status_patch,
+            )
+
+    def test_not_licensed_enterprise(self, mocker, dbsession, sample_comparison):
+        mocker.patch("services.notification.is_properly_licensed", return_value=False)
+        mock_notify_individual_notifier = mocker.patch.object(
+            NotificationService, "notify_individual_notifier"
+        )
+        current_yaml = {}
+        commit = sample_comparison.head.commit
+        notifications_service = NotificationService(
+            commit.repository, current_yaml, None
+        )
+        expected_result = []
+        res = notifications_service.notify(sample_comparison)
+        assert expected_result == res
+        assert not mock_notify_individual_notifier.called
+
+    def test_get_statuses(self, mocker, dbsession, sample_comparison):
+        current_yaml = {
+            "coverage": {"status": {"project": True, "patch": True, "changes": True}},
+            "flags": {"banana": {"carryforward": False}},
+            "flag_management": {
+                "default_rules": {"carryforward": False},
+                "individual_flags": [
+                    {
+                        "name": "strawberry",
+                        "carryforward": True,
+                        "statuses": [{"name_prefix": "haha", "type": "patch"}],
+                    }
+                ],
+            },
+        }
+        commit = sample_comparison.head.commit
+        notifications_service = NotificationService(
+            commit.repository, UserYaml(current_yaml), None
+        )
+        expected_result = [
+            ("project", "default", {}),
+            ("patch", "default", {}),
+            ("changes", "default", {}),
+            (
+                "patch",
+                "hahastrawberry",
+                {"flags": ["strawberry"], "name_prefix": "haha", "type": "patch"},
+            ),
+        ]
+        res = list(notifications_service.get_statuses(["unit", "banana", "strawberry"]))
+        assert expected_result == res
+
+    def test_get_component_statuses(self, mocker, dbsession, sample_comparison):
+        current_yaml = {
+            "component_management": {
+                "default_rules": {
+                    "paths": [r"src/important/.*\.cpp"],
+                    "flag_regexes": [r"critical.*"],
+                    "statuses": [
+                        {"name_prefix": "important/", "type": "project"},
+                        {
+                            "name_prefix": "legacy/",
+                            "type": "project",
+                            "enabled": False,
+                        },  # this won't be in the results because it's not enabled
+                    ],
+                },
+                "individual_components": [
+                    {
+                        "component_id": "my-special-component",
+                        "flag_regexes": [r"special.*"],
+                        "statuses": [
+                            {"name_prefix": "special/", "type": "patch"},
+                            {"name_prefix": "legacy/", "type": "project"},
+                        ],
+                    },
+                    {
+                        "component_id": "inner-app",
+                        "paths": [r"src/inner_app/.*"],
+                        "statuses": [{"type": "patch"}],
+                    },
+                    {"component_id": "from_default"},
+                ],
+            }
+        }
+        commit = sample_comparison.head.commit
+        notifications_service = NotificationService(
+            commit.repository, UserYaml(current_yaml), None
+        )
+        expected_result = [
+            (
+                "patch",
+                "special/my-special-component",
+                {
+                    "flags": ["special_flag"],
+                    "paths": [r"src/important/.*\.cpp"],
+                    "type": "patch",
+                    "name_prefix": "special/",
+                },
+            ),
+            (
+                "project",
+                "legacy/my-special-component",
+                {
+                    "flags": ["special_flag"],
+                    "paths": [r"src/important/.*\.cpp"],
+                    "type": "project",
+                    "name_prefix": "legacy/",
+                },
+            ),
+            (
+                "patch",
+                "inner-app",
+                {
+                    "flags": ["critical_files"],
+                    "paths": [r"src/inner_app/.*"],
+                    "type": "patch",
+                },
+            ),
+            (
+                "project",
+                "important/from_default",
+                {
+                    "flags": ["critical_files"],
+                    "name_prefix": "important/",
+                    "type": "project",
+                    "paths": [r"src/important/.*\.cpp"],
+                },
+            ),
+        ]
+        res = list(
+            notifications_service.get_statuses(
+                ["special_flag", "critical_files", "banana"]
+            )
+        )
+        assert expected_result == res

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -1257,9 +1257,16 @@ class TestNotifyTask(object):
             assert expected["result"].data_received == actual["result"].data_received
             assert expected["result"] == actual["result"]
             assert expected == actual
-        assert sorted(result["notifications"], key=lambda x: x["notifier"]) == sorted(
+
+        sorted_result = sorted(result["notifications"], key=lambda x: x["notifier"])
+        sorted_expected_result = sorted(
             expected_result["notifications"], key=lambda x: x["notifier"]
         )
+        assert len(sorted_result) == len(sorted_expected_result) == 7
+        assert sorted_result == sorted_expected_result
+
+        result["notifications"] = sorted_result
+        expected_result["notifications"] = sorted_expected_result
         assert result == expected_result
 
         pull = dbsession.query(Pull).filter_by(pullid=9, repoid=commit.repoid).first()


### PR DESCRIPTION
<!-- Describe your PR here. -->
this PR was missing a check and caused an error.
the check has been added and a unit test to cover the condition that broke when it was deployed.

perviously deployed and reverted version: https://github.com/codecov/worker/pull/1014