### PR TITLE
Fix problems discovered in Repository Deletion

### DIFF
--- a/services/cleanup/owner.py
+++ b/services/cleanup/owner.py
@@ -14,13 +14,13 @@ CLEAR_ARRAY_FIELDS = ["plan_activated_users", "organizations", "admins"]
 
 
 def cleanup_owner(owner_id: int) -> CleanupSummary:
-    log.info("Started/Continuing Owner cleanup", extra={"owner_id": owner_id})
+    log.info("Started/Continuing Owner cleanup")
 
     clear_owner_references(owner_id)
     owner_query = Owner.objects.filter(ownerid=owner_id)
     summary = run_cleanup(owner_query)
 
-    log.info("Owner cleanup finished", extra={"owner_id": owner_id, "summary": summary})
+    log.info("Owner cleanup finished", extra={"summary": summary})
     return summary
 
 
@@ -30,6 +30,8 @@ def clear_owner_references(owner_id: int):
     This clears the `ownerid` from various DB arrays where it is being referenced.
     """
 
+    # TODO: Some of these UPDATEs are horribly slow because of missing indices.
+    # In particular, filtering by `Commit.author` takes an incredibly long time.
     OwnerProfile.objects.filter(default_org=owner_id).update(default_org=None)
     Owner.objects.filter(bot=owner_id).update(bot=None)
     Repository.objects.filter(bot=owner_id).update(bot=None)

--- a/tasks/delete_owner.py
+++ b/tasks/delete_owner.py
@@ -1,5 +1,6 @@
 import logging
 
+from celery.exceptions import SoftTimeLimitExceeded
 from shared.celery_config import delete_owner_task_name
 
 from app import celery_app
@@ -15,7 +16,10 @@ class DeleteOwnerTask(BaseCodecovTask, name=delete_owner_task_name):
     max_retries = None  # aka, no limit on retries
 
     def run_impl(self, _db_session, ownerid: int) -> CleanupSummary:
-        return cleanup_owner(ownerid)
+        try:
+            return cleanup_owner(ownerid)
+        except SoftTimeLimitExceeded:
+            raise self.retry()
 
 
 RegisteredDeleteOwnerTask = celery_app.register_task(DeleteOwnerTask())


### PR DESCRIPTION
- Deleting non-existing files can raise, so catch and ignore such errors
- Switch "Shadow Owner" to a `raw_delete` to avoid expensive django `SET NULL` / `CASCADE` queries
- Use a `SELECT FOR UPDATE NOWAIT` when starting deletions to make this more resilient to conflicting tasks:
  - This also catches "not found" when the repo does not exist, and "integrity" errors on duplicate shadow owner inserts.
- Last but not least, this makes the task explicitly retry on timeouts.