### PR TITLE
Failed check and status messaging in comment, part III

### DIFF
--- a/services/notification/notifiers/checks/base.py
+++ b/services/notification/notifiers/checks/base.py
@@ -1,6 +1,6 @@
 import logging
 from contextlib import nullcontext
-from typing import Optional
+from typing import Any, Optional, TypedDict
 
 import sentry_sdk
 from asgiref.sync import async_to_sync
@@ -8,6 +8,7 @@ from shared.torngit.exceptions import TorngitClientError, TorngitError
 
 from services.comparison import ComparisonProxy, FilteredComparison
 from services.notification.notifiers.base import NotificationResult
+from services.notification.notifiers.mixins.status import StatusState
 from services.notification.notifiers.status.base import StatusNotifier
 from services.urls import (
     append_tracking_params_to_urls,
@@ -18,6 +19,19 @@ from services.urls import (
 from services.yaml.reader import get_paths_from_flags
 
 log = logging.getLogger(__name__)
+
+
+class CheckOutput(TypedDict):
+    title: str
+    summary: str
+    annotations: list[Any]
+    text: Optional[str]
+
+
+class CheckResult(TypedDict):
+    state: StatusState
+    output: CheckOutput
+    included_helper_text: dict[str, str]
 
 
 class ChecksNotifier(StatusNotifier):

--- a/services/notification/notifiers/checks/patch.py
+++ b/services/notification/notifiers/checks/patch.py
@@ -1,22 +1,12 @@
-from typing import Any, TypedDict
-
 from database.enums import Notification
 from services.comparison import ComparisonProxy, FilteredComparison
-from services.notification.notifiers.checks.base import ChecksNotifier
-from services.notification.notifiers.mixins.status import StatusPatchMixin, StatusState
+from services.notification.notifiers.checks.base import (
+    CheckOutput,
+    CheckResult,
+    ChecksNotifier,
+)
+from services.notification.notifiers.mixins.status import StatusPatchMixin
 from services.yaml import read_yaml_field
-
-
-class CheckOutput(TypedDict):
-    title: str
-    summary: str
-    annotations: list[Any]
-
-
-class CheckResult(TypedDict):
-    state: StatusState
-    output: CheckOutput
-    included_helper_text: dict[str, str]
 
 
 class PatchChecksNotifier(StatusPatchMixin, ChecksNotifier):

--- a/services/notification/notifiers/checks/project.py
+++ b/services/notification/notifiers/checks/project.py
@@ -1,6 +1,12 @@
+from typing import Optional
+
 from database.enums import Notification
 from services.comparison import ComparisonProxy, FilteredComparison
-from services.notification.notifiers.checks.base import ChecksNotifier
+from services.notification.notifiers.checks.base import (
+    CheckOutput,
+    CheckResult,
+    ChecksNotifier,
+)
 from services.notification.notifiers.mixins.message import MessageMixin
 from services.notification.notifiers.mixins.status import StatusProjectMixin
 from services.yaml.reader import read_yaml_field
@@ -8,18 +14,29 @@ from services.yaml.reader import read_yaml_field
 
 class ProjectChecksNotifier(MessageMixin, StatusProjectMixin, ChecksNotifier):
     context = "project"
+    notification_type_display_name = "check"
 
     @property
     def notification_type(self) -> Notification:
         return Notification.checks_project
 
     def get_message(
-        self, comparison: ComparisonProxy | FilteredComparison, yaml_comment_settings
+        self,
+        comparison: ComparisonProxy | FilteredComparison,
+        yaml_comment_settings,
+        status_or_checks_helper_text: Optional[dict[str, str]] = None,
     ):
         pull_dict = comparison.enriched_pull.provider_pull
-        return self.create_message(comparison, pull_dict, yaml_comment_settings)
+        return self.create_message(
+            comparison,
+            pull_dict,
+            yaml_comment_settings,
+            status_or_checks_helper_text=status_or_checks_helper_text,
+        )
 
-    def build_payload(self, comparison: ComparisonProxy | FilteredComparison) -> dict:
+    def build_payload(
+        self, comparison: ComparisonProxy | FilteredComparison
+    ) -> CheckResult:
         """
         This method build the paylod of the project github checks.
 
@@ -28,23 +45,28 @@ class ProjectChecksNotifier(MessageMixin, StatusProjectMixin, ChecksNotifier):
         """
         if self.is_empty_upload():
             state, message = self.get_status_check_for_empty_upload()
-            return {
-                "state": state,
-                "output": {
-                    "title": "Empty Upload",
-                    "summary": message,
-                },
-            }
+            result = CheckResult(
+                state=state,
+                output=CheckOutput(
+                    title="Empty Upload", summary=message, annotations=[]
+                ),
+                included_helper_text={},
+            )
+            return result
 
-        state, summary = self.get_project_status(comparison)
+        status_result = self.get_project_status(
+            comparison, notification_type=self.notification_type_display_name
+        )
         codecov_link = self.get_codecov_pr_link(comparison)
 
-        title = summary
+        title = status_result["message"]
+        summary = status_result["message"]
 
         should_use_upgrade = self.should_use_upgrade_decoration()
         if should_use_upgrade:
-            summary = self.get_upgrade_message(comparison)
             title = "Codecov Report"
+            summary = self.get_upgrade_message(comparison)
+
         flags = self.notifier_yaml_settings.get("flags")
         paths = self.notifier_yaml_settings.get("paths")
         yaml_comment_settings = read_yaml_field(self.current_yaml, ("comment",)) or {}
@@ -63,20 +85,30 @@ class ProjectChecksNotifier(MessageMixin, StatusProjectMixin, ChecksNotifier):
             or should_use_upgrade
             or not settings_to_be_used
         ):
-            return {
-                "state": state,
-                "output": {
-                    "title": f"{title}",
-                    "summary": "\n\n".join([codecov_link, summary]),
-                },
-            }
+            result = CheckResult(
+                state=status_result["state"],
+                output=CheckOutput(
+                    title=title,
+                    summary="\n\n".join([codecov_link, summary]),
+                    annotations=[],
+                ),
+                included_helper_text=status_result["included_helper_text"],
+            )
+            return result
 
-        message = self.get_message(comparison, settings_to_be_used)
-        return {
-            "state": state,
-            "output": {
-                "title": f"{title}",
-                "summary": "\n\n".join([codecov_link, summary]),
-                "text": "\n".join(message),
-            },
-        }
+        message = self.get_message(
+            comparison,
+            settings_to_be_used,
+            status_or_checks_helper_text=status_result["included_helper_text"],
+        )
+        result = CheckResult(
+            state=status_result["state"],
+            output=CheckOutput(
+                title=title,
+                summary="\n\n".join([codecov_link, summary]),
+                annotations=[],
+                text="\n".join(message),
+            ),
+            included_helper_text=status_result["included_helper_text"],
+        )
+        return result

--- a/services/notification/notifiers/mixins/message/sections.py
+++ b/services/notification/notifiers/mixins/message/sections.py
@@ -739,8 +739,11 @@ class ComponentsSectionWriter(BaseSectionWriter):
 class HelperTextSectionWriter(BaseSectionWriter):
     def do_write_section(self, comparison: ComparisonProxy, *args, **kwargs):
         helper_template = ":x: {helper_text}"
-        for helper_text in self.status_or_checks_helper_text.values():
-            yield helper_template.format(helper_text=helper_text)
+        sorted_helper_text_keys = sorted(self.status_or_checks_helper_text.keys())
+        for helper_text_key in sorted_helper_text_keys:
+            yield helper_template.format(
+                helper_text=self.status_or_checks_helper_text[helper_text_key]
+            )
 
 
 class MessagesToUserSectionWriter(BaseSectionWriter):

--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -28,8 +28,8 @@ class StatusResult(TypedDict):
 CUSTOM_TARGET_TEXT_PATCH_KEY = "custom_target_helper_text_patch"
 CUSTOM_TARGET_TEXT_PROJECT_KEY = "custom_target_helper_text_project"
 CUSTOM_TARGET_TEXT_VALUE = (
-    "Your {context} {notification_type} has failed because the patch coverage ({coverage}%) is below the target coverage ({target}%). "
-    "You can increase the patch coverage or adjust the "
+    "Your {context} {notification_type} has failed because the {point_of_comparison} coverage ({coverage}%) is below the target coverage ({target}%). "
+    "You can increase the {point_of_comparison} coverage or adjust the "
     "[target](https://docs.codecov.com/docs/commit-status#target) coverage."
 )
 
@@ -118,6 +118,7 @@ class StatusPatchMixin(object):
                     helper_text = HELPER_TEXT_MAP[CUSTOM_TARGET_TEXT_PATCH_KEY].format(
                         context=self.context,
                         notification_type=notification_type,
+                        point_of_comparison=self.context,
                         coverage=coverage_rounded,
                         target=target_rounded,
                     )
@@ -191,6 +192,7 @@ class StatusChangesMixin(object):
 class StatusProjectMixin(object):
     DEFAULT_REMOVED_CODE_BEHAVIOR = "adjust_base"
     context = "project"
+    point_of_comparison = "head"
 
     def _apply_removals_only_behavior(
         self, comparison: ComparisonProxy | FilteredComparison
@@ -386,7 +388,6 @@ class StatusProjectMixin(object):
             # Possibly change status
             if removed_code_result:
                 removed_code_state, removed_code_message = removed_code_result
-                print(removed_code_state, removed_code_message)
                 if removed_code_state == StatusState.success.value:
                     # the status was failure, has been changed to success through RCB settings
                     # since the status is no longer failing, remove any included_helper_text
@@ -486,6 +487,7 @@ class StatusProjectMixin(object):
                 helper_text = HELPER_TEXT_MAP[CUSTOM_TARGET_TEXT_PROJECT_KEY].format(
                     context=self.context,
                     notification_type=notification_type,
+                    point_of_comparison=self.point_of_comparison,
                     coverage=head_coverage_rounded,
                     target=target_rounded,
                 )

--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -335,6 +335,11 @@ class StatusNotifier(AbstractBaseNotifier):
             "message": message,
         }
 
+        if payload.get("included_helper_text"):
+            notification_result_data_sent["included_helper_text"] = payload[
+                "included_helper_text"
+            ]
+
         all_shas_to_notify = [head_commit_sha] + list(
             comparison.context.gitlab_extra_shas or set()
         )

--- a/services/notification/notifiers/status/project.py
+++ b/services/notification/notifiers/status/project.py
@@ -2,7 +2,10 @@ import logging
 
 from database.enums import Notification
 from services.comparison import ComparisonProxy, FilteredComparison
-from services.notification.notifiers.mixins.status import StatusProjectMixin
+from services.notification.notifiers.mixins.status import (
+    StatusProjectMixin,
+    StatusResult,
+)
 from services.notification.notifiers.status.base import StatusNotifier
 
 log = logging.getLogger(__name__)
@@ -25,17 +28,22 @@ class ProjectStatusNotifier(StatusProjectMixin, StatusNotifier):
     """
 
     context = "project"
+    notification_type_display_name = "status"
 
     @property
     def notification_type(self) -> Notification:
         return Notification.status_project
 
-    def build_payload(self, comparison: ComparisonProxy | FilteredComparison) -> dict:
+    def build_payload(
+        self, comparison: ComparisonProxy | FilteredComparison
+    ) -> StatusResult:
         if self.is_empty_upload():
             state, message = self.get_status_check_for_empty_upload()
-            return {"state": state, "message": message}
+            return StatusResult(state=state, message=message, included_helper_text={})
 
-        state, message = self.get_project_status(comparison)
+        result = self.get_project_status(
+            comparison, notification_type=self.notification_type_display_name
+        )
         if self.should_use_upgrade_decoration():
-            message = self.get_upgrade_message()
-        return {"state": state, "message": message}
+            result["message"] = self.get_upgrade_message()
+        return result

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -798,6 +798,7 @@ class TestPatchChecksNotifier(object):
                 CUSTOM_TARGET_TEXT_PATCH_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
                     context="patch",
                     notification_type="check",
+                    point_of_comparison="patch",
                     coverage=66.67,
                     target="70.00",
                 )

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -1491,7 +1491,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": f"60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_flag_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         assert result == expected_result
         assert notifier.notification_type.value == "checks_project"
@@ -1517,7 +1519,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": "Codecov Report",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_upgrade_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nThe author of this PR, codecov-test-user, is not an activated member of this organization on Codecov.\nPlease [activate this user on Codecov](test.example.br/members/gh/test_build_upgrade_payload) to display a detailed status check.\nCoverage data is still being uploaded to Codecov.io for purposes of overall coverage calculations.\nPlease don't hesitate to email us at support@codecov.io with any questions.",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -1543,7 +1547,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": "Empty Upload",
                 "summary": "Non-testable files changed.",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -1588,7 +1594,9 @@ class TestProjectChecksNotifier(object):
                         "",
                     ]
                 ),
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         assert expected_result["output"]["text"].split("\n") == result["output"][
             "text"
@@ -1635,7 +1643,9 @@ class TestProjectChecksNotifier(object):
                         "",
                     ]
                 ),
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         assert expected_result["output"]["text"].split("\n") == result["output"][
             "text"
@@ -1689,7 +1699,9 @@ class TestProjectChecksNotifier(object):
                         "",
                     ],
                 ),
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         assert expected_result["output"]["text"].split("\n") == result["output"][
             "text"
@@ -1716,7 +1728,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": f"60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_default_payload_comment_off/{repo.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         assert expected_result == result
 
@@ -1740,7 +1754,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": f"50.00% (-10.00%) compared to {base_commit.commitid[:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_default_payload_negative_change_comment_off/{repo.name}/pull/{sample_comparison_negative_change.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n50.00% (-10.00%) compared to {base_commit.commitid[:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         assert expected_result == result
 
@@ -1762,7 +1778,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": "60.00% (target 57.00%)",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_not_auto/{repo.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n60.00% (target 57.00%)",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -1789,7 +1807,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": "No report found to compare against",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_no_base_report/{repo.name}/pull/{sample_comparison_without_base_report.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo report found to compare against",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison)
         assert expected_result == result
@@ -1819,7 +1839,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": "No coverage information found on head",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_check_notify_no_path_match/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo coverage information found on head",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_check_notify_no_path_match/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
         }
 
@@ -1850,7 +1872,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": f"62.50% (+12.50%) compared to {base_commit.commitid[0:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_check_notify_single_path_match/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n62.50% (+12.50%) compared to {base_commit.commitid[0:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_check_notify_single_path_match/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
         }
         assert result.data_sent["state"] == expected_result["state"]
@@ -1887,7 +1911,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": f"60.00% (+10.00%) compared to {base_commit.commitid[0:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_check_notify_multiple_path_match/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n60.00% (+10.00%) compared to {base_commit.commitid[0:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_check_notify_multiple_path_match/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
         }
 
@@ -1921,7 +1947,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": f"60.00% (+10.00%) compared to {base_commit.commitid[0:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_check_notify_with_paths/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n60.00% (+10.00%) compared to {base_commit.commitid[0:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
             "url": f"test.example.br/gh/test_check_notify_with_paths/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
         }
 
@@ -1960,7 +1988,9 @@ class TestProjectChecksNotifier(object):
                 "output": {
                     "title": f"25.00% (+0.00%) compared to {base_commit.commitid[:7]}",
                     "summary": f"[View this Pull Request on Codecov](test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n25.00% (+0.00%) compared to {base_commit.commitid[:7]} [Auto passed due to carriedforward or missing coverage]",
+                    "annotations": [],
                 },
+                "included_helper_text": {},
                 "url": f"test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}",
             },
         )
@@ -2006,7 +2036,9 @@ class TestProjectChecksNotifier(object):
                 "output": {
                     "title": f"25.00% (+0.00%) compared to {base_commit.commitid[:7]}",
                     "summary": f"[View this Pull Request on Codecov](test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n25.00% (+0.00%) compared to {base_commit.commitid[:7]}",
+                    "annotations": [],
                 },
+                "included_helper_text": {},
                 "url": f"test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}",
             },
         )
@@ -2048,7 +2080,9 @@ class TestProjectChecksNotifier(object):
                 "output": {
                     "title": f"36.17% (+0.00%) compared to {base_commit.commitid[:7]}",
                     "summary": f"[View this Pull Request on Codecov](test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n36.17% (+0.00%) compared to {base_commit.commitid[:7]}",
+                    "annotations": [],
                 },
+                "included_helper_text": {},
                 "url": f"test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}",
             },
         )
@@ -2121,7 +2155,9 @@ class TestProjectChecksNotifier(object):
                 "output": {
                     "title": f"25.00% (+0.00%) compared to {base_commit.commitid[:7]}",
                     "summary": f"[View this Pull Request on Codecov](test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n25.00% (+0.00%) compared to {base_commit.commitid[:7]}",
+                    "annotations": [],
                 },
+                "included_helper_text": {},
                 "url": f"test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}",
             },
         )
@@ -2167,7 +2203,9 @@ class TestProjectChecksNotifier(object):
                 "output": {
                     "title": f"36.17% (+0.00%) compared to {base_commit.commitid[:7]}",
                     "summary": f"[View this Pull Request on Codecov](test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n36.17% (+0.00%) compared to {base_commit.commitid[:7]}",
+                    "annotations": [],
                 },
+                "included_helper_text": {},
                 "url": f"test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}",
             },
         )
@@ -2210,7 +2248,9 @@ class TestProjectChecksNotifier(object):
                 "output": {
                     "title": f"65.38% (+0.00%) compared to {base_commit.commitid[:7]}",
                     "summary": f"[View this Pull Request on Codecov](test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n65.38% (+0.00%) compared to {base_commit.commitid[:7]}",
+                    "annotations": [],
                 },
+                "included_helper_text": {},
                 "url": f"test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison_coverage_carriedforward.pull.pullid}",
             },
         )
@@ -2241,7 +2281,9 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": f"60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
 
     def test_build_payload_comments_false(self, sample_comparison, mock_configuration):
@@ -2262,5 +2304,7 @@ class TestProjectChecksNotifier(object):
             "output": {
                 "title": f"60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/{head_commit.repository.owner.username}/{head_commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -22,6 +22,7 @@ from services.decoration import Decoration
 from services.notification.notifiers.base import NotificationResult
 from services.notification.notifiers.mixins.status import (
     CUSTOM_TARGET_TEXT_PATCH_KEY,
+    CUSTOM_TARGET_TEXT_PROJECT_KEY,
     CUSTOM_TARGET_TEXT_VALUE,
 )
 from services.notification.notifiers.status import (
@@ -917,6 +918,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": f"60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -937,6 +939,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "state": "success",
             "message": "Non-testable files changed.",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -957,6 +960,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "state": "failure",
             "message": "Testable files changed",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -978,6 +982,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": "Please activate this user to display a detailed status check",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -997,7 +1002,11 @@ class TestProjectStatusNotifier(object):
             current_yaml=UserYaml({}),
             repository_service=mock_repo_provider,
         )
-        expected_result = {"message": "60.00% (target 57.00%)", "state": "success"}
+        expected_result = {
+            "message": "60.00% (target 57.00%)",
+            "state": "success",
+            "included_helper_text": {},
+        }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
 
@@ -1013,7 +1022,11 @@ class TestProjectStatusNotifier(object):
             current_yaml=UserYaml({}),
             repository_service=mock_repo_provider,
         )
-        expected_result = {"message": "60.00% (target 57.00%)", "state": "success"}
+        expected_result = {
+            "message": "60.00% (target 57.00%)",
+            "state": "success",
+            "included_helper_text": {},
+        }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
 
@@ -1036,6 +1049,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": "No report found to compare against",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison)
         assert expected_result == result
@@ -1096,6 +1110,7 @@ class TestProjectStatusNotifier(object):
                 "message": f"60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
                 "state": "success",
                 "url": f"test.example.br/gh/{repo.slug}/pull/{sample_comparison.pull.pullid}",
+                "included_helper_text": {},
             },
             data_received=None,
         )
@@ -1129,6 +1144,7 @@ class TestProjectStatusNotifier(object):
                 "message": f"60.00% (+10.00%) compared to {base_commit.commitid[:7]}",
                 "state": "success",
                 "url": f"test.example.br/gh/{repo.slug}/pull/{sample_comparison.pull.pullid}",
+                "included_helper_text": {},
             },
             data_received=None,
         )
@@ -1384,6 +1400,7 @@ class TestProjectStatusNotifier(object):
             "message": f"62.50% (+12.50%) compared to {base_commit.commitid[:7]}",
             "state": "success",
             "url": f"test.example.br/gh/{sample_comparison.head.commit.repository.slug}/pull/{sample_comparison.pull.pullid}",
+            "included_helper_text": {},
         }
         result = notifier.notify(sample_comparison)
         assert result == mocked_send_notification.return_value
@@ -1409,6 +1426,7 @@ class TestProjectStatusNotifier(object):
             "message": "No coverage information found on base report",
             "state": "success",
             "url": f"test.example.br/gh/{sample_comparison.head.commit.repository.slug}/pull/{sample_comparison.pull.pullid}",
+            "included_helper_text": {},
         }
         result = notifier.notify(sample_comparison)
         assert result == mocked_send_notification.return_value
@@ -1439,6 +1457,7 @@ class TestProjectStatusNotifier(object):
             "message": f"100.00% (+0.00%) compared to {base_commit.commitid[:7]}",
             "state": "success",
             "url": f"test.example.br/gh/{sample_comparison_matching_flags.head.commit.repository.slug}/pull/{sample_comparison_matching_flags.pull.pullid}",
+            "included_helper_text": {},
         }
         result = notifier.notify(sample_comparison_matching_flags)
         assert result == mocked_send_notification.return_value
@@ -1487,6 +1506,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": "60.00% (target 80.00%), passed because this change only removed code",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert result == expected_result
@@ -1647,6 +1667,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": f"50.00% (-10.00%) compared to {sample_comparison.project_coverage_base.commit.commitid[:7]}, passed because coverage increased by 0% when compared to adjusted base (50.00%)",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert result == expected_result
@@ -1694,6 +1715,14 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": "60.00% (target 80.00%)",
             "state": "failure",
+            "included_helper_text": {
+                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                    context="project",
+                    notification_type="status",
+                    coverage="60.00",
+                    target="80.00",
+                )
+            },
         }
         result = notifier.build_payload(sample_comparison)
         assert result == expected_result
@@ -1738,6 +1767,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": f"50.00% (-10.00%) compared to {sample_comparison.project_coverage_base.commit.commitid[:7]}",
             "state": "failure",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert result == expected_result
@@ -1765,6 +1795,14 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": "50.00% (target 80.00%)",
             "state": "failure",
+            "included_helper_text": {
+                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                    context="project",
+                    notification_type="status",
+                    coverage="50.00",
+                    target="80.00",
+                )
+            },
         }
         result = notifier.build_payload(sample_comparison)
         assert result == expected_result
@@ -1788,6 +1826,14 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": "60.00% (target 80.00%)",
             "state": "failure",
+            "included_helper_text": {
+                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                    context="project",
+                    notification_type="status",
+                    coverage="60.00",
+                    target="80.00",
+                )
+            },
         }
         result = notifier.build_payload(sample_comparison)
         assert result == expected_result
@@ -1840,6 +1886,14 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": "50.00% (target 70.00%)",
             "state": "failure",
+            "included_helper_text": {
+                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                    context="project",
+                    notification_type="status",
+                    coverage="50.00",
+                    target="70.00",
+                )
+            },
         }
         result = notifier.build_payload(comparison_with_multiple_changes)
         assert result == expected_result
@@ -1893,6 +1947,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": "28.57% (target 70.00%), passed because patch was fully covered by tests, and no indirect coverage changes",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison_100_percent_patch)
         assert result == expected_result
@@ -2054,6 +2109,7 @@ class TestProjectStatusNotifier(object):
         expected_result = {
             "message": "60.00% (target 70.00%), passed because coverage was not affected by patch",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert result == expected_result

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -659,7 +659,12 @@ class TestBaseStatusNotifier(object):
         mock_repo_provider.set_commit_status.side_effect = TorngitClientError(
             403, "response", "message"
         )
-        payload = {"message": "something to say", "state": "success", "url": "url"}
+        payload = {
+            "message": "something to say",
+            "state": "success",
+            "url": "url",
+            "included_helper_text": "yayaya",
+        }
         result = no_settings_notifier.send_notification(comparison, payload)
         assert result.notification_attempted
         assert not result.notification_successful
@@ -668,6 +673,7 @@ class TestBaseStatusNotifier(object):
             "message": "something to say",
             "state": "success",
             "title": "codecov/fake/title",
+            "included_helper_text": "yayaya",
         }
         assert result.data_sent == expected_data_sent
         assert result.data_received is None
@@ -1719,6 +1725,7 @@ class TestProjectStatusNotifier(object):
                 CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
                     context="project",
                     notification_type="status",
+                    point_of_comparison="head",
                     coverage="60.00",
                     target="80.00",
                 )
@@ -1799,6 +1806,7 @@ class TestProjectStatusNotifier(object):
                 CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
                     context="project",
                     notification_type="status",
+                    point_of_comparison="head",
                     coverage="50.00",
                     target="80.00",
                 )
@@ -1830,6 +1838,7 @@ class TestProjectStatusNotifier(object):
                 CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
                     context="project",
                     notification_type="status",
+                    point_of_comparison="head",
                     coverage="60.00",
                     target="80.00",
                 )
@@ -1890,6 +1899,7 @@ class TestProjectStatusNotifier(object):
                 CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
                     context="project",
                     notification_type="status",
+                    point_of_comparison="head",
                     coverage="50.00",
                     target="70.00",
                 )
@@ -2177,6 +2187,7 @@ class TestPatchStatusNotifier(object):
                 CUSTOM_TARGET_TEXT_PATCH_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
                     context="patch",
                     notification_type="status",
+                    point_of_comparison="patch",
                     coverage=66.67,
                     target="70.00",
                 )

--- a/services/notification/tests/unit/test_notification_service.py
+++ b/services/notification/tests/unit/test_notification_service.py
@@ -32,6 +32,7 @@ from services.notification.notifiers.checks.checks_with_fallback import (
 )
 from services.notification.notifiers.mixins.status import (
     CUSTOM_TARGET_TEXT_PATCH_KEY,
+    CUSTOM_TARGET_TEXT_PROJECT_KEY,
     CUSTOM_TARGET_TEXT_VALUE,
 )
 
@@ -641,7 +642,7 @@ class TestNotificationService(object):
             ),
         }
 
-    def test_notify_individual_checks_patch_notifier_included_helper_text(
+    def test_notify_individual_checks_patch_and_project_notifier_included_helper_text(
         self,
         mocker,
         sample_comparison,
@@ -664,10 +665,10 @@ class TestNotificationService(object):
         mock_repo_provider.post_comment.return_value = {"id": 9865}
         mock_configuration._params["setup"] = {"codecov_dashboard_url": "test"}
         current_yaml = {
-            "coverage": {"status": {"patch": True}},
+            "coverage": {"status": {"patch": True, "project": True}},
             "comment": {"layout": "condensed_header"},
             "slack_app": False,
-            "github_checks": True,
+            "github_checks": {"annotations": False},
         }
         commit = sample_comparison.head.commit
         report = Report()
@@ -682,6 +683,18 @@ class TestNotificationService(object):
         mock_repo_provider.create_check_run.return_value = 2234563
         mock_repo_provider.update_check_run.return_value = "success"
         patch_check = PatchChecksNotifier(
+            repository=sample_comparison.head.commit.repository,
+            title="title",
+            notifier_yaml_settings={
+                "target": "70%",
+                "paths": ["pathone"],
+                "layout": "reach, diff, flags, files, footer",
+            },
+            notifier_site_settings=True,
+            current_yaml=UserYaml({}),
+            repository_service=mock_repo_provider,
+        )
+        proj_check = ProjectChecksNotifier(
             repository=sample_comparison.head.commit.repository,
             title="title",
             notifier_yaml_settings={
@@ -710,6 +723,7 @@ class TestNotificationService(object):
             "get_notifiers_instances",
             return_value=[
                 patch_check,
+                proj_check,
                 comment,
             ],
         )
@@ -720,20 +734,21 @@ class TestNotificationService(object):
         instances = list(service.get_notifiers_instances())
         names = sorted([instance.name for instance in instances])
         types = sorted(instance.notification_type.value for instance in instances)
-        assert names == ["checks-patch", "comment"]
-        assert types == ["checks_patch", "comment"]
+        assert names == ["checks-patch", "checks-project", "comment"]
+        assert types == ["checks_patch", "checks_project", "comment"]
 
         checks_patch_result = {
             "state": "failure",
             "output": {
                 "title": "66.67% of diff hit (target 70.00%)",
-                "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_target_coverage_failure/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n66.67% of diff hit (target 70.00%)",
+                "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_notify_individual_checks_patch_and_project_notifier_included_helper_text/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n66.67% of diff hit (target 70.00%)",
                 "annotations": [],
             },
             "included_helper_text": {
                 CUSTOM_TARGET_TEXT_PATCH_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
                     context="patch",
                     notification_type="check",
+                    point_of_comparison="patch",
                     coverage=66.67,
                     target="70.00",
                 )
@@ -744,6 +759,30 @@ class TestNotificationService(object):
             "services.notification.notifiers.checks.patch.PatchChecksNotifier.build_payload",
             return_value=checks_patch_result,
         )
+
+        checks_proj_result = {
+            "state": "failure",
+            "output": {
+                "title": "50.00% (target 70.00%)",
+                "summary": f"[View this Pull Request on Codecov](test/gh/test_notify_individual_checks_patch_and_project_notifier_included_helper_text/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo coverage information found on head",
+                "annotations": [],
+            },
+            "included_helper_text": {
+                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                    context="project",
+                    notification_type="check",
+                    point_of_comparison="head",
+                    coverage="50.00",
+                    target="70.00",
+                )
+            },
+        }
+        # forcing this outcome from project check notifier to test how that affects comment notifier
+        mocker.patch(
+            "services.notification.notifiers.checks.project.ProjectChecksNotifier.build_payload",
+            return_value=checks_proj_result,
+        )
+
         mocker.patch(
             "services.comparison.ComparisonProxy.get_behind_by",
             return_value=None,
@@ -776,26 +815,33 @@ class TestNotificationService(object):
             "services.comparison.ComparisonProxy.get_changes", return_value=mock_changes
         )
 
-        # this gets the patched result from PatchChecksNotifier, with included_helper_text
+        # this gets the patched results from PatchChecksNotifier and ProjectChecksNotifier, with included_helper_text
         # CommentNotifier is called next, and should have the included_helper_text in the payload
         res = service.notify(sample_comparison)
 
-        assert len(res) == 2
+        assert len(res) == 3
         for r in res:
             if r["notifier"] == "checks-patch":
                 assert (
-                    checks_patch_result["included_helper_text"][
-                        CUSTOM_TARGET_TEXT_PATCH_KEY
-                    ]
-                    in r["result"].data_sent["included_helper_text"][
-                        CUSTOM_TARGET_TEXT_PATCH_KEY
-                    ]
+                    r["result"].data_sent["included_helper_text"]
+                    == checks_patch_result["included_helper_text"]
                 )
+
+            if r["notifier"] == "checks-project":
+                assert (
+                    r["result"].data_sent["included_helper_text"]
+                    == checks_proj_result["included_helper_text"]
+                )
+
             if r["notifier"] == "comment":
                 assert (
                     ":x: "
                     + checks_patch_result["included_helper_text"][
                         CUSTOM_TARGET_TEXT_PATCH_KEY
+                    ]
+                    and ":x: "
+                    + checks_proj_result["included_helper_text"][
+                        CUSTOM_TARGET_TEXT_PROJECT_KEY
                     ]
                     in r["result"].data_sent["message"]
                 )

--- a/services/notification/tests/unit/test_notification_service.py
+++ b/services/notification/tests/unit/test_notification_service.py
@@ -632,7 +632,9 @@ class TestNotificationService(object):
                     "output": {
                         "title": "No coverage information found on head",
                         "summary": f"[View this Pull Request on Codecov](test/gh/test_notify_individual_checks_project_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo coverage information found on head",
+                        "annotations": [],
                     },
+                    "included_helper_text": {},
                     "url": f"test/gh/test_notify_individual_checks_project_notifier/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}",
                 },
                 data_received=None,


### PR DESCRIPTION
This is the same as the last one (https://github.com/codecov/worker/pull/1023) but for *project* rather than *patch* status and checks.

when user has:
project checks notifier OR project status notifier
AND
comment notifier
AND
has defined a target in their codecov yml
AND
the project check/status fails
THEN
add some helper text to the comment notifier to point out that the check/status failed and that they can change their target.

https://github.com/codecov/engineering-team/issues/1605
