### PR TITLE
dev: Add Ruff Print Rules to Worker (T20)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -107,7 +107,7 @@ def engine(request, sqlalchemy_db, sqlalchemy_connect_url, app_config):
 
     yield engine
 
-    print("Disposing engine")
+    print("Disposing engine")  # noqa: T201
     engine.dispose()
 
 

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ def mark_process_dead(pid, exitcode, **kwargs):
 
 
 def setup_worker():
-    print(initialization_text.format(version=get_current_version()))
+    print(initialization_text.format(version=get_current_version()))  # noqa: T201
 
     if getattr(sys, "frozen", False):
         # Only for enterprise builds

--- a/ruff.toml
+++ b/ruff.toml
@@ -37,8 +37,8 @@ target-version = "py313"
 
 [lint]
 # Currently only enabled for most F (Pyflakes), Pycodestyle (Error), PERF (Perflint),
-# PyLint (Convention, Error), and I (isort) rules: https://docs.astral.sh/ruff/rules/
-select = ["F", "E", "I", "PLC", "PLE", "PERF"]
+# PyLint (Convention, Error), I (isort), and T20 (flake8-print) rules: https://docs.astral.sh/ruff/rules/
+select = ["F", "E", "I", "PLC", "PLE", "PERF", "T20"]
 ignore = ["F841", "F405", "F403", "E501", "E712"]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/services/comparison/tests/unit/overlay/test_critical_path.py
+++ b/services/comparison/tests/unit/overlay/test_critical_path.py
@@ -274,8 +274,6 @@ class TestCriticalPathOverlay(object):
         }
         mock_storage.write_file("bucket", url, sample_open_telemetry_collected_as_str)
         a = CriticalPathOverlay(sample_comparison, None)
-        print(sample_comparison.head.report.files)
-        print(sample_comparison.head.report.files)
         res = a.find_impacted_endpoints()
         assert res == [
             {

--- a/services/comparison/tests/unit/test_changes.py
+++ b/services/comparison/tests/unit/test_changes.py
@@ -336,8 +336,6 @@ class TestChanges(object):
         first_old_renamed_and_missing.append(8, ReportLine.create(coverage=0))
         first_report.append(first_old_renamed_and_missing)
         res = get_changes(first_report, second_report, json_diff)
-        for r in res:
-            print(r)
         expected_result = [
             Change(
                 path="modified.py",
@@ -441,8 +439,6 @@ class TestChanges(object):
         second_report = Report()
         second_report.append(first_report_file)
         res = get_changes(first_report, second_report, json_diff)
-        for r in res:
-            print(r)
         assert res == [
             Change(
                 path="missing_file",
@@ -459,6 +455,4 @@ class TestChanges(object):
         first_report = Report()
         second_report = Report()
         res = get_changes(first_report, second_report, json_diff)
-        for r in res:
-            print(r)
         assert res == []

--- a/services/notification/notifiers/tests/unit/test_slack.py
+++ b/services/notification/notifiers/tests/unit/test_slack.py
@@ -25,7 +25,6 @@ class TestSlackNotifier(object):
             "author_name": "Codecov",
             "text": text,
         }
-        print(result["text"])
         assert result == expected_result
 
     def test_build_payload_with_attachments(
@@ -83,7 +82,6 @@ class TestSlackNotifier(object):
             "author_name": "Codecov",
             "text": "This is a sample",
         }
-        print(result["text"])
         assert result == expected_result
 
     def test_build_payload_without_pull(

--- a/services/path_fixer/tests/unit/test_user_path_includes.py
+++ b/services/path_fixer/tests/unit/test_user_path_includes.py
@@ -18,7 +18,6 @@ class TestUserPathIncludes(BaseTestCase):
     def test_user_path_regex(self):
         path_patterns = ["sample/[^/]+/to/.*"]
         upi = UserPathIncludes(path_patterns)
-        print(upi.includes)
         assert upi("sample/path/to/file.go")
         assert upi("sample/something/to/haha.cpp")
         assert not upi("any/to/file.cpp")

--- a/services/report/tests/unit/test_sessions.py
+++ b/services/report/tests/unit/test_sessions.py
@@ -241,7 +241,6 @@ class TestAdjustSession(BaseTestCase):
         assert clear_carryforward_sessions(
             sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([0], [])
-        print(self.convert_report_to_better_readable(sample_first_report))
         assert self.convert_report_to_better_readable(sample_first_report) == {
             "archive": {
                 "first_file.py": [
@@ -515,7 +514,6 @@ class TestAdjustSession(BaseTestCase):
         assert clear_carryforward_sessions(
             sample_first_report, second_report, ["enterprise"], current_yaml
         ) == SessionAdjustmentResult([], [0])
-        print(self.convert_report_to_better_readable(sample_first_report))
         assert self.convert_report_to_better_readable(sample_first_report) == {
             "archive": {
                 "first_file.py": [
@@ -811,7 +809,6 @@ class TestAdjustSession(BaseTestCase):
                 "se": {},
             },
         }
-        print(self.convert_report_to_better_readable(sample_first_report)["archive"])
         assert self.convert_report_to_better_readable(sample_first_report)[
             "archive"
         ] == {

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -307,7 +307,6 @@ def test_specific_error_message(mocker):
 """
 
     assert result == (True, "comment_posted")
-    print(mock_repo_service.mock_calls)
     mock_repo_service.edit_comment.assert_called_with(
         tn._pull.database_pull.pullid, tn._pull.database_pull.commentid, expected
     )
@@ -328,7 +327,6 @@ def test_specific_error_message_no_error(mocker):
     expected = """:x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."""
 
     assert result == (True, "comment_posted")
-    print(mock_repo_service.mock_calls)
     mock_repo_service.edit_comment.assert_called_with(
         tn._pull.database_pull.pullid, tn._pull.database_pull.commentid, expected
     )

--- a/tasks/tests/unit/test_brolly_stats_rollup.py
+++ b/tasks/tests/unit/test_brolly_stats_rollup.py
@@ -109,7 +109,6 @@ class TestBrollyStatsRollupTask(object):
 
         install_id_val = dbsession.query(Constants).get("install_id").value
         version_val = dbsession.query(Constants).get("version").value
-        print("mattmatt", install_id_val, version_val)
 
         mock_request = respx.post(DEFAULT_BROLLY_ENDPOINT).mock(
             return_value=httpx.Response(200)

--- a/tasks/tests/unit/test_notify_error_task.py
+++ b/tasks/tests/unit/test_notify_error_task.py
@@ -105,5 +105,4 @@ def test_notify_error_task_failure(mocker, dbsession, mock_repo_provider_comment
         repoid=commit.repoid,
         current_yaml={},
     )
-    print(result)
     assert result["success"] == False

--- a/tasks/tests/unit/test_profiling_collection.py
+++ b/tasks/tests/unit/test_profiling_collection.py
@@ -122,7 +122,6 @@ def test_run_impl_simple_run_no_existing_data_sample_new_uploads(
     task = ProfilingCollectionTask()
     res = task.run_impl(dbsession, profiling_id=pcf.id)
     assert res["successful"]
-    print(mock_storage.read_file("bucket", res["location"]).decode())
     assert (
         json.loads(mock_storage.read_file("bucket", res["location"]).decode())
         == sample_open_telemetry_collected
@@ -262,7 +261,6 @@ class TestProfilingCollectionTask(object):
         dbsession.add(pu)
         dbsession.flush()
         res = task.join_profiling_uploads(pcf, [pu])
-        print(res)
         assert res == {
             "groups": [
                 {
@@ -486,7 +484,6 @@ class TestProfilingCollectionTask(object):
         existing_result = {"files": []}
         res = task.merge_into(archive_service, existing_result, [pu])
         assert res is None
-        print(existing_result)
         assert existing_result == {
             "files": [
                 {"filename": "apple.py", "ln_ex_ct": [(2, 10), (101, 11)]},

--- a/tasks/tests/unit/test_profiling_normalizer.py
+++ b/tasks/tests/unit/test_profiling_normalizer.py
@@ -49,7 +49,6 @@ def test_run_impl_simple_normalizing_run(
     res = task.run_impl(dbsession, profiling_upload_id=puf.id)
     assert res["successful"]
     result = json.loads(mock_storage.read_file("bucket", res["location"]).decode())
-    print(mock_storage.read_file("bucket", res["location"]).decode())
     assert result == sample_open_telemetry_normalized
 
 

--- a/tasks/tests/unit/test_sync_teams_task.py
+++ b/tasks/tests/unit/test_sync_teams_task.py
@@ -78,9 +78,6 @@ class TestSyncTeamsTaskUnit(object):
         import logging
 
         caplog.set_level(logging.DEBUG)
-        print(codecov_vcr)
-        print(dir(codecov_vcr))
-        print(codecov_vcr.rewound)
         token = "testenll80qbqhofao65"
         user = OwnerFactory.create(
             organizations=[], service="gitlab", unencrypted_oauth_token=token

--- a/tasks/tests/unit/test_test_results_processor_task.py
+++ b/tasks/tests/unit/test_test_results_processor_task.py
@@ -150,7 +150,6 @@ api/temp/calculator/test_calculator.py:30: AssertionError</failure></testcase></
             arguments_list=redis_queue,
         )
 
-        print(caplog.text)
         assert "Error parsing file" in caplog.text
         assert result == False
 

--- a/tasks/upload.py
+++ b/tasks/upload.py
@@ -531,7 +531,6 @@ class UploadTask(BaseCodecovTask, name=upload_task_name):
 
         # Bulk insert coverage measurements
         if measurements:
-            print("test - I am here!", measurements)
             self._bulk_insert_coverage_measurements(measurements=measurements)
 
         if argument_list:


### PR DESCRIPTION
This PR aims to add the ruff print rules to worker, and either removes or ignores each print statement (I just used my best judgement)

Ruff rules can be found here: https://docs.astral.sh/ruff/rules/#flake8-print-t20

Closes https://github.com/codecov/engineering-team/issues/3278

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.