### PR TITLE
Improve TADriver interface and implementations

### DIFF
--- a/database/tests/factories/reports.py
+++ b/database/tests/factories/reports.py
@@ -7,12 +7,14 @@ from database.models.reports import (
     Flake,
     RepositoryFlag,
     Test,
+    TestInstance,
     TestResultReportTotals,
 )
 from database.tests.factories.core import (
     CompareCommitFactory,
     ReportFactory,
     RepositoryFactory,
+    UploadFactory,
 )
 
 
@@ -41,6 +43,20 @@ class TestFactory(factory.Factory):
     flags_hash = "flags_hash"
     id_ = factory.Sequence(lambda n: f"id_{n}")
     repository = factory.SubFactory(RepositoryFactory)
+
+
+class TestInstanceFactory(factory.Factory):
+    class Meta:
+        model = TestInstance
+
+    test = factory.SubFactory(TestFactory)
+    upload = factory.SubFactory(UploadFactory)
+
+    outcome = "pass"
+    duration_seconds = 1.5
+    commitid = factory.SelfAttribute("upload.report.commit.commitid")
+    branch = factory.SelfAttribute("upload.report.commit.branch")
+    repoid = factory.SelfAttribute("upload.report.commit.repository.repoid")
 
 
 class FlakeFactory(factory.Factory):

--- a/django_scaffold/settings.py
+++ b/django_scaffold/settings.py
@@ -12,11 +12,23 @@ DATABASES["default"]["AUTOCOMMIT"] = False
 if "timeseries" in DATABASES:
     DATABASES["timeseries"]["AUTOCOMMIT"] = False
 
+if "test_analytics" in DATABASES:
+    DATABASES["test_analytics"]["AUTOCOMMIT"] = False
+
 IS_DEV = os.getenv("RUN_ENV") == "DEV"
 IS_ENTERPRISE = os.getenv("RUN_ENV") == "ENTERPRISE"
 
 GCS_BUCKET_NAME = get_config("services", "minio", "bucket", default="codecov")
 
+BIGQUERY_WRITE_ENABLED = (
+    get_config("services", "bigquery", "write_enabled", default=False)
+    and "test_analytics" in DATABASES
+)
+
+BIGQUERY_READ_ENABLED = (
+    get_config("services", "bigquery", "read_enabled", default=False)
+    and "test_analytics" in DATABASES
+)
 # Application definition
 INSTALLED_APPS = [
     # dependencies
@@ -40,6 +52,7 @@ INSTALLED_APPS = [
     "shared.django_apps.profiling",
     "shared.django_apps.reports",
     "shared.django_apps.staticanalysis",
+    "shared.django_apps.test_analytics",
 ]
 
 TELEMETRY_VANILLA_DB = "default"

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/190bbc8a911099749928e13d5fe57f6027ca1e74.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/e854f50c7c534bb8ca7227fa45e8f069ff1dfe5c.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/c16e8bce398e0fdc19f7c82fef30a0613052a7bf.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -377,7 +377,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.7.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/e854f50c7c534bb8ca7227fa45e8f069ff1dfe5c.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/c16e8bce398e0fdc19f7c82fef30a0613052a7bf.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/processing/flake_processing.py
+++ b/services/processing/flake_processing.py
@@ -27,6 +27,17 @@ def process_flake_for_repo_commit(
         state__in=["processed", "v2_finished"],
     ).all()
 
+    process_flakes_for_uploads(repo_id, [upload for upload in uploads])
+
+    log.info(
+        "Successfully processed flakes",
+        extra=dict(repoid=repo_id, commit=commit_id),
+    )
+
+    return {"successful": True}
+
+
+def process_flakes_for_uploads(repo_id: int, uploads: list[ReportSession]):
     curr_flakes = fetch_curr_flakes(repo_id)
     new_flakes: dict[str, Flake] = dict()
 
@@ -91,13 +102,6 @@ def process_flake_for_repo_commit(
         upload.state = "flake_processed"
         upload.save()
         django_transaction.commit()
-
-    log.info(
-        "Successfully processed flakes",
-        extra=dict(repoid=repo_id, commit=commit_id),
-    )
-
-    return {"successful": True}
 
 
 def get_test_instances(

--- a/services/ta_utils.py
+++ b/services/ta_utils.py
@@ -1,0 +1,373 @@
+import logging
+from dataclasses import dataclass
+from hashlib import sha256
+
+from shared.plan.constants import FREE_PLAN_REPRESENTATIONS, TEAM_PLAN_REPRESENTATIONS
+from shared.yaml import UserYaml
+from sqlalchemy import desc, distinct, func
+from sqlalchemy.orm import Session, joinedload
+
+from database.models import (
+    Commit,
+    Repository,
+    TestInstance,
+    Upload,
+    UploadError,
+)
+from helpers.notifier import BaseNotifier
+from rollouts import FLAKY_TEST_DETECTION
+from services.license import requires_license
+from services.urls import get_members_url, get_test_analytics_url
+from services.yaml import read_yaml_field
+
+log = logging.getLogger(__name__)
+
+
+def generate_flags_hash(flag_names: list[str]) -> str:
+    return sha256((" ".join(sorted(flag_names))).encode("utf-8")).hexdigest()
+
+
+def generate_test_id(repoid, testsuite, name, flags_hash):
+    return sha256(
+        (" ".join([str(x) for x in [repoid, testsuite, name, flags_hash]])).encode(
+            "utf-8"
+        )
+    ).hexdigest()
+
+
+def latest_failures_for_commit(
+    db_session: Session, repo_id: int, commit_sha: str
+) -> list[TestInstance]:
+    """
+    This will result in a SQL query that looks something like this:
+
+    SELECT DISTINCT ON (rti.test_id) rti.id, ...
+    FROM reports_testinstance rti
+    JOIN reports_upload ru ON ru.id = rti.upload_id
+    LEFT OUTER JOIN reports_test rt ON rt.id = rti.test_id
+    WHERE ...
+    ORDER BY rti.test_id, ru.created_at DESC
+
+    The goal of this query is to return:
+    > the latest test instance failure for each unique test based on upload creation time
+
+    The `DISTINCT ON` test_id with the order by test_id, enforces that we are only fetching one test instance for each test.
+
+    The ordering by `upload.create_at DESC` enforces that we get the latest test instance for that unique test.
+    """
+
+    return (
+        db_session.query(TestInstance)
+        .join(TestInstance.upload)
+        .options(joinedload(TestInstance.test))
+        .filter(TestInstance.repoid == repo_id, TestInstance.commitid == commit_sha)
+        .filter(TestInstance.outcome.in_(["failure", "error"]))
+        .order_by(TestInstance.test_id)
+        .order_by(desc(Upload.created_at))
+        .distinct(TestInstance.test_id)
+        .all()
+    )
+
+
+def get_test_summary_for_commit(
+    db_session: Session, repo_id: int, commit_sha: str
+) -> dict[str, int]:
+    return dict(
+        db_session.query(
+            TestInstance.outcome, func.count(distinct(TestInstance.test_id))
+        )
+        .filter(TestInstance.repoid == repo_id, TestInstance.commitid == commit_sha)
+        .group_by(TestInstance.outcome)
+        .all()
+    )
+
+
+@dataclass
+class FlakeInfo:
+    failed: int
+    count: int
+
+
+@dataclass
+class TestFailure:
+    display_name: str
+    failure_message: str | None
+    duration_seconds: float
+    build_url: str | None
+    flake_info: FlakeInfo | None = None
+
+
+@dataclass
+class TestResultsNotificationPayload:
+    failed: int
+    passed: int
+    skipped: int
+    regular_failures: list[TestFailure] | None = None
+    flaky_failures: list[TestFailure] | None = None
+
+
+def wrap_in_details(summary: str, content: str):
+    result = f"<details><summary>{summary}</summary>\n{content}\n</details>"
+    return result
+
+
+def make_quoted(content: str) -> str:
+    lines = content.splitlines()
+    result = "\n".join("> " + line for line in lines)
+    return f"\n{result}\n"
+
+
+def properly_backtick(content: str) -> str:
+    max_backtick_count = 0
+    curr_backtick_count = 0
+    prev_char = None
+    for char in content:
+        if char == "`":
+            curr_backtick_count += 1
+        else:
+            curr_backtick_count = 0
+
+        if curr_backtick_count > max_backtick_count:
+            max_backtick_count = curr_backtick_count
+
+    backticks = "`" * (max_backtick_count + 1)
+    return f"{backticks}python\n{content}\n{backticks}"
+
+
+def wrap_in_code(content: str) -> str:
+    if "```" in content:
+        return properly_backtick(content)
+    else:
+        return f"\n```python\n{content}\n```\n"
+
+
+def display_duration(f: float) -> str:
+    before_dot, after_dot = str(f).split(".")
+    if len(before_dot) > 3:
+        return before_dot
+    else:
+        return f"{f:.3g}"
+
+
+def generate_failure_info(
+    fail: TestFailure,
+):
+    if fail.failure_message is not None:
+        failure_message = fail.failure_message
+    else:
+        failure_message = "No failure message available"
+
+    failure_message = wrap_in_code(failure_message)
+    if fail.build_url:
+        return f"{failure_message}\n[View]({fail.build_url}) the CI Build"
+    else:
+        return failure_message
+
+
+def generate_view_test_analytics_line(commit: Commit) -> str:
+    repo = commit.repository
+    test_analytics_url = get_test_analytics_url(repo, commit)
+    return f"\nTo view more test analytics, go to the [Test Analytics Dashboard]({test_analytics_url})\n:loudspeaker:  Thoughts on this report? [Let us know!](https://github.com/codecov/feedback/issues/304)"
+
+
+def messagify_failure(
+    failure: TestFailure,
+) -> str:
+    test_name = wrap_in_code(failure.display_name.replace("\x1f", " "))
+    formatted_duration = display_duration(failure.duration_seconds)
+    stack_trace_summary = f"Stack Traces | {formatted_duration}s run time"
+    stack_trace = wrap_in_details(
+        stack_trace_summary,
+        make_quoted(generate_failure_info(failure)),
+    )
+    return make_quoted(f"{test_name}\n{stack_trace}")
+
+
+def messagify_flake(
+    failure: TestFailure,
+) -> str:
+    test_name = wrap_in_code(failure.display_name.replace("\x1f", " "))
+    formatted_duration = display_duration(failure.duration_seconds)
+    assert failure.flake_info is not None
+    flake_rate = failure.flake_info.failed / failure.flake_info.count * 100
+    flake_rate_section = f"**Flake rate in main:** {flake_rate:.2f}% (Passed {failure.flake_info.count - failure.flake_info.failed} times, Failed {failure.flake_info.failed} times)"
+    stack_trace_summary = f"Stack Traces | {formatted_duration}s run time"
+    stack_trace = wrap_in_details(
+        stack_trace_summary,
+        make_quoted(generate_failure_info(failure)),
+    )
+    return make_quoted(f"{test_name}\n{flake_rate_section}\n{stack_trace}")
+
+
+def specific_error_message(upload_error: UploadError) -> str:
+    title = f"### :x: {upload_error.error_code}"
+    if upload_error.error_code == "Unsupported file format":
+        description = "\n".join(
+            [
+                "Upload processing failed due to unsupported file format. Please review the parser error message:",
+                f"`{upload_error.error_params['error_message']}`",
+                "For more help, visit our [troubleshooting guide](https://docs.codecov.com/docs/test-analytics#troubleshooting).",
+            ]
+        )
+    elif upload_error.error_code == "File not found":
+        description = "\n".join(
+            [
+                "No result to display due to the CLI not being able to find the file.",
+                "Please ensure the file contains `junit` in the name and automated file search is enabled,",
+                "or the desired file specified by the `file` and `search_dir` arguments of the CLI.",
+            ]
+        )
+    else:
+        raise ValueError("Unrecognized error code")
+    message = [
+        title,
+        make_quoted(description),
+    ]
+    return "\n".join(message)
+
+
+@dataclass
+class TestResultsNotifier(BaseNotifier):
+    payload: TestResultsNotificationPayload | None = None
+    error: UploadError | None = None
+
+    def build_message(self) -> str:
+        if self.payload is None:
+            raise ValueError("Payload passed to notifier is None, cannot build message")
+
+        message = []
+
+        if self.error:
+            message.append(specific_error_message(self.error))
+
+        if self.error and (
+            self.payload.regular_failures or self.payload.flaky_failures
+        ):
+            message.append("---")
+
+        if self.payload.regular_failures or self.payload.flaky_failures:
+            message.append(f"### :x: {self.payload.failed} Tests Failed:")
+
+            completed = self.payload.failed + self.payload.passed
+
+            message += [
+                "| Tests completed | Failed | Passed | Skipped |",
+                "|---|---|---|---|",
+                f"| {completed} | {self.payload.failed} | {self.payload.passed} | {self.payload.skipped} |",
+            ]
+
+            if self.payload.regular_failures:
+                failures = sorted(
+                    self.payload.regular_failures,
+                    key=lambda x: (x.duration_seconds, x.display_name),
+                )[:3]
+                failure_content = [
+                    f"{messagify_failure(failure)}" for failure in failures
+                ]
+
+                top_3_failed_section = wrap_in_details(
+                    f"View the top {min(3, len(failures))} failed tests by shortest run time",
+                    "\n".join(failure_content),
+                )
+
+                message.append(top_3_failed_section)
+
+            if self.payload.regular_failures and self.payload.flaky_failures:
+                message.append("---")
+
+            if self.payload.flaky_failures:
+                flaky_failures = self.payload.flaky_failures
+                if flaky_failures:
+                    flake_content = [
+                        f"{messagify_flake(failure)}" for failure in flaky_failures
+                    ]
+
+                    flaky_section = wrap_in_details(
+                        f"View the full list of {len(flaky_failures)} :snowflake: flaky tests",
+                        "\n".join(flake_content),
+                    )
+
+                    message.append(flaky_section)
+
+        message.append(generate_view_test_analytics_line(self.commit))
+        return "\n".join(message)
+
+    def error_comment(self):
+        """
+        This is no longer used in the new TA finisher task, but this is what used to display the error comment
+        """
+        message: str
+
+        if self.error is None:
+            message = ":x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."
+        else:
+            message = specific_error_message(self.error)
+
+        pull = self.get_pull()
+        if pull is None:
+            return False, "no_pull"
+
+        sent_to_provider = self.send_to_provider(pull, message)
+
+        if sent_to_provider is False:
+            return (False, "torngit_error")
+
+        return (True, "comment_posted")
+
+    def upgrade_comment(self):
+        pull = self.get_pull()
+        if pull is None:
+            return False, "no_pull"
+
+        db_pull = pull.database_pull
+        provider_pull = pull.provider_pull
+        if provider_pull is None:
+            return False, "missing_provider_pull"
+
+        link = get_members_url(db_pull)
+
+        author_username = provider_pull["author"].get("username")
+
+        if not requires_license():
+            message = "\n".join(
+                [
+                    f"The author of this PR, {author_username}, is not an activated member of this organization on Codecov.",
+                    f"Please [activate this user on Codecov]({link}) to display this PR comment.",
+                    "Coverage data is still being uploaded to Codecov.io for purposes of overall coverage calculations.",
+                    "Please don't hesitate to email us at support@codecov.io with any questions.",
+                ]
+            )
+        else:
+            message = "\n".join(
+                [
+                    f"The author of this PR, {author_username}, is not activated in your Codecov Self-Hosted installation.",
+                    f"Please [activate this user]({link}) to display this PR comment.",
+                    "Coverage data is still being uploaded to Codecov Self-Hosted for the purposes of overall coverage calculations.",
+                    "Please contact your Codecov On-Premises installation administrator with any questions.",
+                ]
+            )
+
+        sent_to_provider = self.send_to_provider(pull, message)
+        if sent_to_provider == False:
+            return (False, "torngit_error")
+
+        return (True, "comment_posted")
+
+
+def not_private_and_free_or_team(repo: Repository):
+    return not (
+        repo.private
+        and repo.owner.plan
+        in {**FREE_PLAN_REPRESENTATIONS, **TEAM_PLAN_REPRESENTATIONS}
+    )
+
+
+def should_do_flaky_detection(repo: Repository, commit_yaml: UserYaml) -> bool:
+    has_flaky_configured = read_yaml_field(
+        commit_yaml, ("test_analytics", "flake_detection"), True
+    )
+    feature_enabled = FLAKY_TEST_DETECTION.check_value(
+        identifier=repo.repoid, default=True
+    )
+    has_valid_plan_repo_or_owner = not_private_and_free_or_team(repo)
+    return has_flaky_configured and (feature_enabled or has_valid_plan_repo_or_owner)

--- a/services/tests/test_ta_utils.py
+++ b/services/tests/test_ta_utils.py
@@ -290,7 +290,6 @@ def test_specific_error_message(mocker):
 """
 
     assert result == (True, "comment_posted")
-    print(mock_repo_service.mock_calls)
     mock_repo_service.edit_comment.assert_called_with(
         tn._pull.database_pull.pullid, tn._pull.database_pull.commentid, expected
     )
@@ -311,7 +310,6 @@ def test_specific_error_message_no_error(mocker):
     expected = """:x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."""
 
     assert result == (True, "comment_posted")
-    print(mock_repo_service.mock_calls)
     mock_repo_service.edit_comment.assert_called_with(
         tn._pull.database_pull.pullid, tn._pull.database_pull.commentid, expected
     )

--- a/services/tests/test_ta_utils.py
+++ b/services/tests/test_ta_utils.py
@@ -1,0 +1,317 @@
+import mock
+import pytest
+from shared.torngit.exceptions import TorngitClientError
+
+from database.models import UploadError
+from database.tests.factories import (
+    CommitFactory,
+    OwnerFactory,
+    RepositoryFactory,
+    UploadFactory,
+)
+from helpers.notifier import NotifierResult
+from services.ta_utils import (
+    FlakeInfo,
+    TestFailure,
+    TestResultsNotificationPayload,
+    TestResultsNotifier,
+    generate_failure_info,
+    should_do_flaky_detection,
+)
+from services.urls import services_short_dict
+from services.yaml import UserYaml
+
+
+def mock_repo_service():
+    repo_service = mock.Mock(
+        post_comment=mock.AsyncMock(),
+        edit_comment=mock.AsyncMock(),
+    )
+    return repo_service
+
+
+def test_send_to_provider():
+    tn = TestResultsNotifier(CommitFactory(), None)
+    tn._pull = mock.Mock()
+    tn._pull.database_pull.commentid = None
+    tn._repo_service = mock_repo_service()
+    m = dict(id=1)
+    tn._repo_service.post_comment.return_value = m
+
+    res = tn.send_to_provider(tn._pull, "hello world")
+
+    assert res == True
+
+    tn._repo_service.post_comment.assert_called_with(
+        tn._pull.database_pull.pullid, "hello world"
+    )
+    assert tn._pull.database_pull.commentid == 1
+
+
+def test_send_to_provider_edit():
+    tn = TestResultsNotifier(CommitFactory(), None)
+    tn._pull = mock.Mock()
+    tn._pull.database_pull.commentid = 1
+    tn._repo_service = mock_repo_service()
+    m = dict(id=1)
+    tn._repo_service.edit_comment.return_value = m
+
+    res = tn.send_to_provider(tn._pull, "hello world")
+
+    assert res == True
+    tn._repo_service.edit_comment.assert_called_with(
+        tn._pull.database_pull.pullid, 1, "hello world"
+    )
+
+
+def test_send_to_provider_fail():
+    tn = TestResultsNotifier(CommitFactory(), None)
+    tn._pull = mock.Mock()
+    tn._pull.database_pull.commentid = 1
+    tn._repo_service = mock_repo_service()
+    tn._repo_service.edit_comment.side_effect = TorngitClientError
+
+    res = tn.send_to_provider(tn._pull, "hello world")
+
+    assert res == False
+
+
+def test_generate_failure_info():
+    fail = TestFailure(
+        display_name="testname",
+        failure_message="hello world",
+        duration_seconds=1.0,
+        build_url="https://example.com/build_url",
+    )
+
+    res = generate_failure_info(fail)
+
+    assert (
+        res
+        == """
+```python
+hello world
+```
+
+[View](https://example.com/build_url) the CI Build"""
+    )
+
+
+def test_build_message():
+    fail = TestFailure(
+        display_name="testname",
+        failure_message="hello world",
+        duration_seconds=1.0,
+        build_url="https://example.com/build_url",
+    )
+    payload = TestResultsNotificationPayload(1, 2, 3, regular_failures=[fail])
+    commit = CommitFactory(branch="thing/thing")
+    tn = TestResultsNotifier(commit, None, None, None, payload)
+    res = tn.build_message()
+
+    assert (
+        res
+        == f"""### :x: 1 Tests Failed:
+| Tests completed | Failed | Passed | Skipped |
+|---|---|---|---|
+| 3 | 1 | 2 | 3 |
+<details><summary>View the top 1 failed tests by shortest run time</summary>
+
+> 
+> ```python
+> testname
+> ```
+> 
+> <details><summary>Stack Traces | 1s run time</summary>
+> 
+> > 
+> > ```python
+> > hello world
+> > ```
+> > 
+> > [View](https://example.com/build_url) the CI Build
+> 
+> </details>
+
+</details>
+
+To view more test analytics, go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/thing%2Fthing)
+:loudspeaker:  Thoughts on this report? [Let us know!](https://github.com/codecov/feedback/issues/304)"""
+    )
+
+
+def test_build_message_with_flake():
+    fail = TestFailure(
+        display_name="testname",
+        failure_message="hello world",
+        duration_seconds=1.0,
+        build_url="https://example.com/build_url",
+        flake_info=FlakeInfo(1, 3),
+    )
+    payload = TestResultsNotificationPayload(1, 2, 3, flaky_failures=[fail])
+    commit = CommitFactory(branch="test_branch")
+    tn = TestResultsNotifier(commit, None, None, None, payload)
+    res = tn.build_message()
+
+    assert (
+        res
+        == f"""### :x: 1 Tests Failed:
+| Tests completed | Failed | Passed | Skipped |
+|---|---|---|---|
+| 3 | 1 | 2 | 3 |
+<details><summary>View the full list of 1 :snowflake: flaky tests</summary>
+
+> 
+> ```python
+> testname
+> ```
+> 
+> **Flake rate in main:** 33.33% (Passed 2 times, Failed 1 times)
+> <details><summary>Stack Traces | 1s run time</summary>
+> 
+> > 
+> > ```python
+> > hello world
+> > ```
+> > 
+> > [View](https://example.com/build_url) the CI Build
+> 
+> </details>
+
+</details>
+
+To view more test analytics, go to the [Test Analytics Dashboard](https://app.codecov.io/{services_short_dict.get(commit.repository.service)}/{commit.repository.owner.username}/{commit.repository.name}/tests/{commit.branch})
+:loudspeaker:  Thoughts on this report? [Let us know!](https://github.com/codecov/feedback/issues/304)"""
+    )
+
+
+def test_notify(mocker):
+    mocker.patch("helpers.notifier.get_repo_provider_service", return_value=mock.Mock())
+    mocker.patch(
+        "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
+        return_value=mock.Mock(),
+    )
+    tn = TestResultsNotifier(CommitFactory(), None)
+    tn.build_message = mock.Mock()
+    tn.send_to_provider = mock.Mock()
+
+    notification_result = tn.notify()
+
+    assert notification_result == NotifierResult.COMMENT_POSTED
+
+
+def test_notify_fail_torngit_error(
+    mocker,
+):
+    mocker.patch("helpers.notifier.get_repo_provider_service", return_value=mock.Mock())
+    mocker.patch(
+        "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
+        return_value=mock.Mock(),
+    )
+    tn = TestResultsNotifier(CommitFactory(), None)
+    tn.build_message = mock.Mock()
+    tn.send_to_provider = mock.Mock(return_value=False)
+
+    notification_result = tn.notify()
+
+    assert notification_result == NotifierResult.TORNGIT_ERROR
+
+
+def test_notify_fail_no_pull(
+    mocker,
+):
+    mocker.patch("helpers.notifier.get_repo_provider_service", return_value=mock.Mock())
+    mocker.patch(
+        "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
+        return_value=None,
+    )
+    tn = TestResultsNotifier(CommitFactory(), None)
+    tn.build_message = mock.Mock()
+    tn.send_to_provider = mock.Mock(return_value=False)
+
+    notification_result = tn.notify()
+    assert notification_result == NotifierResult.NO_PULL
+
+
+@pytest.mark.parametrize(
+    "config,feature_flag,private,plan,ex_result",
+    [
+        (False, True, False, "users-inappm", False),
+        (True, True, True, "users-basic", True),
+        (True, False, False, "users-basic", True),
+        (True, False, True, "users-basic", False),
+        (True, False, False, "users-inappm", True),
+        (True, False, True, "users-inappm", True),
+    ],
+)
+def test_should_do_flake_detection(
+    dbsession, mocker, config, feature_flag, private, plan, ex_result
+):
+    owner = OwnerFactory(plan=plan)
+    repo = RepositoryFactory(private=private, owner=owner)
+    dbsession.add(repo)
+    dbsession.flush()
+
+    mocked_feature = mocker.patch("services.ta_utils.FLAKY_TEST_DETECTION")
+    mocked_feature.check_value.return_value = feature_flag
+
+    yaml = {"test_analytics": {"flake_detection": config}}
+
+    result = should_do_flaky_detection(repo, UserYaml.from_dict(yaml))
+
+    assert result == ex_result
+
+
+def test_specific_error_message(mocker):
+    mock_repo_service = mock.AsyncMock()
+    mocker.patch(
+        "helpers.notifier.get_repo_provider_service", return_value=mock_repo_service
+    )
+    mocker.patch(
+        "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
+        return_value=mock.AsyncMock(),
+    )
+
+    upload = UploadFactory()
+    error = UploadError(
+        report_upload=upload,
+        error_code="Unsupported file format",
+        error_params={
+            "error_message": "Error parsing JUnit XML in test.xml at 4:32: ParserError: No name found"
+        },
+    )
+    tn = TestResultsNotifier(CommitFactory(), None, error=error)
+    result = tn.error_comment()
+    expected = """### :x: Unsupported file format
+
+> Upload processing failed due to unsupported file format. Please review the parser error message:
+> `Error parsing JUnit XML in test.xml at 4:32: ParserError: No name found`
+> For more help, visit our [troubleshooting guide](https://docs.codecov.com/docs/test-analytics#troubleshooting).
+"""
+
+    assert result == (True, "comment_posted")
+    print(mock_repo_service.mock_calls)
+    mock_repo_service.edit_comment.assert_called_with(
+        tn._pull.database_pull.pullid, tn._pull.database_pull.commentid, expected
+    )
+
+
+def test_specific_error_message_no_error(mocker):
+    mock_repo_service = mock.AsyncMock()
+    mocker.patch(
+        "helpers.notifier.get_repo_provider_service", return_value=mock_repo_service
+    )
+    mocker.patch(
+        "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
+        return_value=mock.AsyncMock(),
+    )
+
+    tn = TestResultsNotifier(CommitFactory(), None)
+    result = tn.error_comment()
+    expected = """:x: We are unable to process any of the uploaded JUnit XML files. Please ensure your files are in the right format."""
+
+    assert result == (True, "comment_posted")
+    print(mock_repo_service.mock_calls)
+    mock_repo_service.edit_comment.assert_called_with(
+        tn._pull.database_pull.pullid, tn._pull.database_pull.commentid, expected
+    )

--- a/ta_storage/base.py
+++ b/ta_storage/base.py
@@ -1,23 +1,68 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import Generic, TypedDict, TypeVar
 
 import test_results_parser
+from shared.django_apps.reports.models import ReportSession
 
-from database.models.reports import Upload
+from services.ta_utils import FlakeInfo
 
 
-class TADriver(ABC):
+class PRCommentAggResult(TypedDict):
+    commit_sha: str
+    passed_ct: int
+    failed_ct: int
+    skipped_ct: int
+    flaky_failed_ct: int
+
+
+T = TypeVar("T")
+
+
+class PRCommentFailResult(TypedDict, Generic[T]):
+    id: T
+    computed_name: str
+    failure_message: str | None
+    duration_seconds: float
+    upload_id: int
+
+
+class TADriver(ABC, Generic[T]):
+    def __init__(self, repo_id: int) -> None:
+        self.repo_id = repo_id
+
     @abstractmethod
     def write_testruns(
         self,
-        timestamp: int,
-        repo_id: int,
+        timestamp: int | None,
         commit_sha: str,
         branch_name: str,
-        upload: Upload,
+        upload_id: int,
+        flag_names: list[str],
         framework: str | None,
         testruns: list[test_results_parser.Testrun],
-        flaky_test_set: set[str],
-    ):
+    ) -> None:
+        pass
+
+    @abstractmethod
+    def write_flakes(self, uploads: list[ReportSession]) -> None:
+        pass
+
+    @abstractmethod
+    def cache_analytics(self, buckets: list[str], branch: str) -> None:
+        pass
+
+    @abstractmethod
+    def pr_comment_agg(self, commit_sha: str) -> PRCommentAggResult:
+        pass
+
+    @abstractmethod
+    def pr_comment_fail(self, commit_sha: str) -> list[PRCommentFailResult[T]]:
+        pass
+
+    @abstractmethod
+    def get_repo_flakes(
+        self, test_ids: tuple[T, ...] | None = None
+    ) -> dict[T, FlakeInfo]:
         pass

--- a/ta_storage/bq.py
+++ b/ta_storage/bq.py
@@ -1,17 +1,41 @@
 from __future__ import annotations
 
+import datetime as dt
 from datetime import datetime
-from typing import Literal, cast
+from functools import cached_property
+from typing import Literal, TypedDict, cast
 
+import polars as pl
+import shared.storage
 import test_results_parser
-from google.cloud.bigquery import ArrayQueryParameter, ScalarQueryParameter
+from django.db import transaction
+from google.cloud.bigquery import (
+    ArrayQueryParameter,
+    ScalarQueryParameter,
+    StructQueryParameter,
+    StructQueryParameterType,
+)
 from shared.config import get_config
+from shared.django_apps.reports.models import ReportSession
+from shared.django_apps.test_analytics.models import Flake
 
 import generated_proto.testrun.ta_testrun_pb2 as ta_testrun_pb2
-from database.models.reports import Upload
 from services.bigquery import get_bigquery_service
-from ta_storage.base import TADriver
+from services.ta_utils import FlakeInfo
+from ta_storage.base import (
+    PRCommentAggResult,
+    PRCommentFailResult,
+    TADriver,
+)
 from ta_storage.utils import calc_flags_hash, calc_test_id
+
+
+def get_live_flakes(repo_id: int) -> list[Flake]:
+    return [
+        flake
+        for flake in Flake.objects.filter(repoid=repo_id, end_date__isnull=True).all()
+    ]
+
 
 RANKED_DATA = """
 ranked_data AS (
@@ -68,7 +92,10 @@ PR_COMMENT_FAIL = """
 SELECT
     computed_name,
     failure_message,
-    flags
+    test_id,
+    flags_hash,
+    duration_seconds,
+    upload_id
 FROM
     latest_instances
 WHERE
@@ -77,10 +104,11 @@ WHERE
 
 TESTRUNS_FOR_UPLOAD = """
 SELECT
-    DATE_BUCKET(timestamp, INTERVAL 1 DAY) AS date,
+    timestamp,
     test_id,
     outcome,
     branch_name,
+    flags_hash,
 FROM
     `{PROJECT_ID}.{DATASET_NAME}.{TESTRUN_TABLE_NAME}`
 WHERE
@@ -88,7 +116,12 @@ WHERE
     AND (
         outcome = 1
         OR outcome = 3
-        OR test_id IN UNNEST(@test_ids)
+        OR EXISTS (
+            SELECT 1
+                FROM UNNEST(@flake_ids) AS flake_id
+            WHERE flake_id.candidate_test_id = test_id
+            AND IF(flake_id.candidate_flags_hash IS NULL, flags_hash IS NULL, flake_id.candidate_flags_hash = flags_hash)
+        )
     )
 """
 
@@ -135,6 +168,29 @@ GROUP BY name, classname, testsuite
 """
 
 
+class TestrunsForUploadResult(TypedDict):
+    timestamp: int
+    test_id: bytes
+    flags_hash: bytes
+    outcome: Literal["passed", "failed", "skipped", "flaky_failed"]
+    branch_name: str
+
+
+def get_storage_key(
+    repo_id: int, branch: str | None, interval_start: int, interval_end: int | None
+) -> str:
+    interval_section = (
+        f"{interval_start}"
+        if interval_end is None
+        else f"{interval_start}_{interval_end}"
+    )
+
+    if branch:
+        return f"ta_rollups/{repo_id}/{branch}/{interval_section}"
+    else:
+        return f"ta_rollups/{repo_id}/{interval_section}"
+
+
 def outcome_to_enum(
     outcome: Literal["pass", "skip", "failure", "error"],
 ) -> ta_testrun_pb2.TestRun.Outcome:
@@ -149,9 +205,9 @@ def outcome_to_enum(
             raise ValueError(f"Invalid outcome: {outcome}")
 
 
-class BQDriver(TADriver):
-    def __init__(self, flaky_test_set: set[bytes] | None = None):
-        self.flaky_test_set = flaky_test_set or {}
+class BQDriver(TADriver[tuple[bytes, bytes | None]]):
+    def __init__(self, repo_id: int) -> None:
+        super().__init__(repo_id)
         self.bq_service = get_bigquery_service()
 
         self.project_id: str = cast(
@@ -170,34 +226,44 @@ class BQDriver(TADriver):
             ),
         )
 
+    def get_live_flakes(self, repo_id: int) -> list[Flake]:
+        return [
+            flake
+            for flake in Flake.objects.filter(
+                repoid=repo_id, end_date__isnull=True
+            ).all()
+        ]
+
     def write_testruns(
         self,
         timestamp: int | None,
-        repo_id: int,
         commit_sha: str,
         branch_name: str,
-        upload: Upload,
+        upload_id: int,
+        flag_names: list[str],
         framework: str | None,
         testruns: list[test_results_parser.Testrun],
     ):
         if timestamp is None:
             timestamp = int(datetime.now().timestamp() * 1000000)
 
-        flag_names: list[str] = upload.flag_names
         testruns_pb: list[bytes] = []
 
         flags_hash = calc_flags_hash(flag_names)
 
+        flakes: list[Flake] = list(self.flake_dict.values())
+        flake_set = {(flake.test_id, flake.flags_id) for flake in flakes}
+
         for t in testruns:
             test_id = calc_test_id(t["name"], t["classname"], t["testsuite"])
-            if test_id in self.flaky_test_set and t["outcome"] == "failure":
+            if (test_id, flags_hash) in flake_set and t["outcome"] == "failure":
                 outcome = ta_testrun_pb2.TestRun.Outcome.FLAKY_FAILED
             else:
                 outcome = outcome_to_enum(t["outcome"])
 
             test_run = ta_testrun_pb2.TestRun(
                 timestamp=timestamp,
-                repoid=repo_id,
+                repoid=self.repo_id,
                 commit_sha=commit_sha,
                 framework=framework,
                 branch_name=branch_name,
@@ -205,12 +271,13 @@ class BQDriver(TADriver):
                 classname=t["classname"],
                 name=t["name"],
                 testsuite=t["testsuite"],
-                computed_name=t["computed_name"],
+                computed_name=t["computed_name"]
+                or f"{t['testsuite']}.{t['classname']}.{t['name']}",
                 outcome=outcome,
                 failure_message=t["failure_message"],
                 duration_seconds=t["duration"],
                 filename=t["filename"],
-                upload_id=upload.id_,
+                upload_id=upload_id,
                 flags_hash=flags_hash,
                 test_id=test_id,
             )
@@ -220,11 +287,7 @@ class BQDriver(TADriver):
             self.dataset_name, self.testrun_table_name, ta_testrun_pb2, testruns_pb
         )
 
-    def pr_comment_agg(
-        self,
-        repoid: int,
-        commit_sha: str,
-    ):
+    def pr_comment_agg(self, commit_sha: str) -> PRCommentAggResult:
         query = f"""
         WITH 
         {
@@ -237,15 +300,27 @@ class BQDriver(TADriver):
         {LATEST_INSTANCES}
         {PR_COMMENT_AGG}
         """
-        return self.bq_service.query(
+        query_result = self.bq_service.query(
             query,
             [
-                ScalarQueryParameter("repoid", "INT64", repoid),
+                ScalarQueryParameter("repoid", "INT64", self.repo_id),
                 ScalarQueryParameter("commit_sha", "STRING", commit_sha),
             ],
         )
 
-    def pr_comment_fail(self, repoid: int, commit_sha: str):
+        result = query_result[0]
+
+        return {
+            "commit_sha": result["commit_sha"],
+            "passed_ct": result["passed"],
+            "failed_ct": result["failed"],
+            "skipped_ct": result["skipped"],
+            "flaky_failed_ct": result["flaky_failed"],
+        }
+
+    def pr_comment_fail(
+        self, commit_sha: str
+    ) -> list[PRCommentFailResult[tuple[bytes, bytes | None]]]:
         query = f"""
         WITH 
         {
@@ -258,15 +333,28 @@ class BQDriver(TADriver):
         {LATEST_INSTANCES}
         {PR_COMMENT_FAIL}
         """
-        return self.bq_service.query(
+        query_result = self.bq_service.query(
             query,
             [
-                ScalarQueryParameter("repoid", "INT64", repoid),
+                ScalarQueryParameter("repoid", "INT64", self.repo_id),
                 ScalarQueryParameter("commit_sha", "STRING", commit_sha),
             ],
         )
 
-    def testruns_for_upload(self, upload_id: int, test_ids: list[bytes]):
+        return [
+            {
+                "computed_name": result["computed_name"],
+                "failure_message": result["failure_message"],
+                "id": (result["test_id"], result["flags_hash"]),
+                "duration_seconds": result["duration_seconds"],
+                "upload_id": result["upload_id"],
+            }
+            for result in query_result
+        ]
+
+    def testruns_for_upload(
+        self, upload_id: int, flake_set: set[tuple[bytes, bytes | None]]
+    ) -> list[TestrunsForUploadResult]:
         query = f"""
         {
             TESTRUNS_FOR_UPLOAD.format(
@@ -276,13 +364,118 @@ class BQDriver(TADriver):
             )
         }
         """
-        return self.bq_service.query(
+        # IMPORTANT: the names of these parameters actually matters or
+        # else BQ won't be able to disambiguate the test_id of the object
+        # up for comparison and the field in the struct
+        # if the name of the fields in the structs are equal to the name of the fields
+        # in the table, it will match every row
+        ids = [
+            StructQueryParameter(
+                None,
+                ScalarQueryParameter("candidate_test_id", "BYTES", test_id),
+                ScalarQueryParameter("candidate_flags_hash", "BYTES", flags_hash),
+            )
+            for (test_id, flags_hash) in flake_set
+        ]
+
+        query_result = self.bq_service.query(
             query,
             [
                 ScalarQueryParameter("upload_id", "INT64", upload_id),
-                ArrayQueryParameter("test_ids", "BYTES", test_ids),
+                ArrayQueryParameter(
+                    "flake_ids",
+                    StructQueryParameterType(
+                        ScalarQueryParameter("candidate_test_id", "BYTES", None),
+                        ScalarQueryParameter("candidate_flags_hash", "BYTES", None),
+                    ),
+                    ids,
+                ),
             ],
         )
+
+        return [
+            {
+                "branch_name": result["branch_name"],
+                "timestamp": result["timestamp"],
+                "outcome": result["outcome"],
+                "test_id": result["test_id"],
+                "flags_hash": result["flags_hash"],
+            }
+            for result in query_result
+        ]
+
+    @cached_property
+    def flake_dict(self) -> dict[tuple[bytes, bytes | None], Flake]:
+        return {
+            (
+                bytes(flake.test_id),
+                bytes(flake.flags_id) if flake.flags_id else None,
+            ): flake
+            for flake in self.get_live_flakes(self.repo_id)
+        }
+
+    def write_flakes(self, uploads: list[ReportSession]) -> None:
+        # get relevant flakes test ids:
+        flakes = list(self.flake_dict.values())
+
+        flake_dict = {
+            (
+                bytes(flake.test_id),
+                bytes(flake.flags_id) if flake.flags_id else None,
+            ): flake
+            for flake in flakes
+        }
+
+        for upload in uploads:
+            testruns = self.testruns_for_upload(upload.id, set(flake_dict.keys()))
+            for testrun in testruns:
+                if flake := flake_dict.get((testrun["test_id"], testrun["flags_hash"])):
+                    match testrun["outcome"]:
+                        case (
+                            ta_testrun_pb2.TestRun.Outcome.FAILED
+                            | ta_testrun_pb2.TestRun.Outcome.FLAKY_FAILED
+                        ):
+                            flake.fail_count += 1
+                            flake.count += 1
+                            flake.recent_passes_count = 0
+                        case ta_testrun_pb2.TestRun.Outcome.PASSED:
+                            flake.recent_passes_count += 1
+                            flake.count += 1
+
+                            if flake.recent_passes_count == 30:
+                                flake.end_date = datetime.now()
+                        case _:
+                            pass
+
+                    flake.save()
+                else:
+                    match testrun["outcome"]:
+                        case (
+                            ta_testrun_pb2.TestRun.Outcome.FAILED
+                            | ta_testrun_pb2.TestRun.Outcome.FLAKY_FAILED
+                        ):
+                            flake = Flake.objects.create(
+                                repoid=self.repo_id,
+                                test_id=testrun["test_id"],
+                                fail_count=1,
+                                count=1,
+                                recent_passes_count=0,
+                                start_date=datetime.fromtimestamp(
+                                    testrun["timestamp"] / 1000000
+                                ),
+                                end_date=None,
+                            )
+                            flake.save()
+
+                            flake_dict[(testrun["test_id"], testrun["flags_hash"])] = (
+                                flake
+                            )
+                        case _:
+                            pass
+
+            upload.state = "flake_processed"
+            upload.save()
+            transaction.commit()
 
     def analytics(
         self,
@@ -326,3 +519,90 @@ class BQDriver(TADriver):
             params.append(ScalarQueryParameter("branch", "STRING", branch))
 
         return self.bq_service.query(query, params)
+
+    def cache_analytics(self, buckets: list[str], branch: str | None) -> None:
+        storage_service = shared.storage.get_appropriate_storage_service(self.repo_id)
+
+        for interval_start, interval_end in [
+            # NOTE: working with calendar days and intervals,
+            # `(CURRENT_DATE - INTERVAL '1 days')` means *yesterday*,
+            # and `2..1` matches *the day before yesterday*.
+            (1, None),
+            (2, 1),
+            (7, None),
+            (14, 7),
+            (30, None),
+            (60, 30),
+        ]:
+            analytics_results = self.analytics(
+                self.repo_id,
+                interval_start=interval_start,
+                interval_end=interval_end,
+                branch=branch,
+            )
+
+            df = pl.DataFrame(
+                analytics_results,
+                [
+                    "name",
+                    "classname",
+                    "testsuite",
+                    "computed_name",
+                    ("flags", pl.List(pl.String)),
+                    "test_id",
+                    ("updated_at", pl.Datetime(time_zone=dt.UTC)),
+                    "avg_duration",
+                    "fail_count",
+                    "flaky_fail_count",
+                    "pass_count",
+                    "skip_count",
+                    "commits_where_fail",
+                    "last_duration",
+                ],
+                orient="row",
+            )
+
+            serialized_table = df.write_ipc(None)
+            serialized_table.seek(0)  # avoids Stream must be at beginning errors
+
+            storage_key = get_storage_key(
+                self.repo_id, branch, interval_start, interval_end
+            )
+            for bucket in buckets:
+                storage_service.write_file(
+                    bucket,
+                    storage_key,
+                    serialized_table,
+                )
+
+    def get_repo_flakes(
+        self, test_ids: tuple[tuple[bytes, bytes | None], ...] | None = None
+    ) -> dict[tuple[bytes, bytes | None], FlakeInfo]:
+        if test_ids:
+            return {
+                (
+                    bytes(flake.test_id),
+                    bytes(flake.flags_id) if flake.flags_id else None,
+                ): FlakeInfo(
+                    failed=flake.fail_count,
+                    count=flake.count,
+                )
+                for flake in Flake.objects.raw(
+                    "SELECT * FROM flake WHERE repoid = %s AND (test_id, flags_id) IN %s AND end_date IS NULL AND count != recent_passes_count + fail_count",
+                    [self.repo_id, test_ids],
+                ).all()
+            }
+        else:
+            return {
+                (
+                    bytes(flake.test_id),
+                    bytes(flake.flags_id) if flake.flags_id else None,
+                ): FlakeInfo(
+                    failed=flake.fail_count,
+                    count=flake.count,
+                )
+                for flake in Flake.objects.raw(
+                    "SELECT * FROM flake WHERE repoid = %s AND end_date IS NULL AND count != recent_passes_count + fail_count",
+                    [self.repo_id],
+                ).all()
+            }

--- a/ta_storage/pg.py
+++ b/ta_storage/pg.py
@@ -1,22 +1,144 @@
 from __future__ import annotations
 
+import datetime as dt
 from datetime import date, datetime
 from typing import Any, Literal, TypedDict
 
+import polars as pl
+import shared.storage
 import test_results_parser
+from django.db import connections
+from django.db import transaction as django_transaction
+from django.db.models import Q
+from shared.config import get_config
+from shared.django_apps.reports.models import (
+    CommitReport as DjangoCommitReport,
+)
+from shared.django_apps.reports.models import (
+    DailyTestRollup as DjangoDailyTestRollup,
+)
+from shared.django_apps.reports.models import (
+    Flake as DjangoFlake,
+)
+from shared.django_apps.reports.models import (
+    ReportSession as DjangoReportSession,
+)
+from shared.django_apps.reports.models import (
+    TestInstance as DjangoTestInstance,
+)
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
 from database.models import (
     DailyTestRollup,
+    Flake,
     RepositoryFlag,
     Test,
     TestFlagBridge,
     TestInstance,
-    Upload,
 )
-from services.test_results import generate_flags_hash, generate_test_id
-from ta_storage.base import TADriver
+from services.ta_utils import (
+    FlakeInfo,
+    generate_flags_hash,
+    generate_test_id,
+    get_test_summary_for_commit,
+    latest_failures_for_commit,
+)
+from ta_storage.base import (
+    PRCommentAggResult,
+    PRCommentFailResult,
+    TADriver,
+)
+
+# Reminder: `a BETWEEN x AND y` is equivalent to `a >= x AND a <= y`
+# Since we are working with calendar days, using a range of `0..0` gives us *today*,
+# and a range of `1..1` gives use *yesterday*.
+BASE_SUBQUERY = """
+SELECT *
+FROM reports_dailytestrollups
+WHERE repoid = %(repoid)s
+  AND branch = %(branch)s
+  AND date BETWEEN
+    (CURRENT_DATE - INTERVAL %(interval_start)s) AND
+    (CURRENT_DATE - INTERVAL %(interval_end)s)
+"""
+
+TEST_AGGREGATION_SUBQUERY = """
+SELECT test_id,
+       CASE
+           WHEN SUM(pass_count) + SUM(fail_count) = 0 THEN 0
+           ELSE SUM(fail_count)::float / (SUM(pass_count) + SUM(fail_count))
+       END AS failure_rate,
+       CASE
+           WHEN SUM(pass_count) + SUM(fail_count) = 0 THEN 0
+           ELSE SUM(flaky_fail_count)::float / (SUM(pass_count) + SUM(fail_count))
+       END AS flake_rate,
+       MAX(latest_run) AS updated_at,
+       AVG(avg_duration_seconds) AS avg_duration,
+       SUM(fail_count) AS total_fail_count,
+       SUM(flaky_fail_count) AS total_flaky_fail_count,
+       SUM(pass_count) AS total_pass_count,
+       SUM(skip_count) AS total_skip_count
+FROM base_cte
+GROUP BY test_id
+"""
+
+COMMITS_FAILED_SUBQUERY = """
+SELECT test_id,
+       array_length((array_agg(DISTINCT unnested_cwf)), 1) AS failed_commits_count
+FROM
+  (SELECT test_id,
+          commits_where_fail AS cwf
+   FROM base_cte
+   WHERE array_length(commits_where_fail, 1) > 0) AS tests_with_commits_that_failed,
+     unnest(cwf) AS unnested_cwf
+GROUP BY test_id
+"""
+
+LAST_DURATION_SUBQUERY = """
+SELECT base_cte.test_id,
+       last_duration_seconds
+FROM base_cte
+JOIN
+  (SELECT test_id,
+          max(created_at) AS created_at
+   FROM base_cte
+   GROUP BY test_id) AS latest_rollups ON base_cte.created_at = latest_rollups.created_at
+AND base_cte.test_id = latest_rollups.test_id
+"""
+
+TEST_FLAGS_SUBQUERY = """
+SELECT test_id,
+       array_agg(DISTINCT flag_name) AS flags
+FROM reports_test_results_flag_bridge tfb
+JOIN reports_test rt ON rt.id = tfb.test_id
+JOIN reports_repositoryflag rr ON tfb.flag_id = rr.id
+WHERE rt.repoid = %(repoid)s
+GROUP BY test_id
+"""
+
+ROLLUP_QUERY = f"""
+WITH
+  base_cte AS ({BASE_SUBQUERY}),
+  failure_rate_cte AS ({TEST_AGGREGATION_SUBQUERY}),
+  commits_where_fail_cte AS ({COMMITS_FAILED_SUBQUERY}),
+  last_duration_cte AS ({LAST_DURATION_SUBQUERY}),
+  flags_cte AS ({TEST_FLAGS_SUBQUERY})
+
+SELECT COALESCE(rt.computed_name, rt.name) AS name,
+       rt.testsuite,
+       flags_cte.flags,
+       results.*
+FROM
+  (SELECT failure_rate_cte.*,
+          coalesce(commits_where_fail_cte.failed_commits_count, 0) AS commits_where_fail,
+          last_duration_cte.last_duration_seconds AS last_duration
+   FROM failure_rate_cte
+   FULL OUTER JOIN commits_where_fail_cte USING (test_id)
+   FULL OUTER JOIN last_duration_cte USING (test_id)) AS results
+JOIN reports_test rt ON results.test_id = rt.id
+LEFT JOIN flags_cte USING (test_id)
+"""
 
 
 class DailyTotals(TypedDict):
@@ -54,7 +176,8 @@ def modify_structures(
     test_flag_bridge_data: list[dict],
     daily_totals: dict[str, DailyTotals],
     testrun: test_results_parser.Testrun,
-    upload: Upload,
+    upload_id: int,
+    flag_names: list[str],
     repoid: int,
     branch: str | None,
     commit_sha: str,
@@ -62,7 +185,7 @@ def modify_structures(
     flaky_test_set: set[str],
     framework: str | None,
 ):
-    flags_hash = generate_flags_hash(upload.flag_names)
+    flags_hash = generate_flags_hash(flag_names)
 
     test_name = f"{testrun['classname']}\x1f{testrun['name']}"
     test_id = generate_test_id(
@@ -78,7 +201,7 @@ def modify_structures(
     tests_to_write[test_id] = test
 
     test_instance = generate_test_instance_dict(
-        test_id, upload, testrun, commit_sha, branch, repoid
+        test_id, upload_id, testrun, commit_sha, branch, repoid
     )
     test_instances_to_write.append(test_instance)
 
@@ -129,7 +252,7 @@ def generate_test_dict(
 
 def generate_test_instance_dict(
     test_id: str,
-    upload: Upload,
+    upload_id: int,
     testrun: test_results_parser.Testrun,
     commit_sha: str,
     branch: str | None,
@@ -137,7 +260,7 @@ def generate_test_instance_dict(
 ) -> dict[str, Any]:
     return {
         "test_id": test_id,
-        "upload_id": upload.id,
+        "upload_id": upload_id,
         "duration_seconds": testrun["duration"],
         "outcome": testrun["outcome"],
         "failure_message": testrun["failure_message"],
@@ -282,27 +405,220 @@ def save_test_instances(db_session: Session, test_instance_data: list[dict]):
     db_session.commit()
 
 
-class PGDriver(TADriver):
-    def __init__(self, db_session: Session, flaky_test_set: set[str]):
+FLAKE_EXPIRY_COUNT = 30
+
+
+def process_flake_for_repo_commit(
+    repo_id: int,
+    commit_id: str,
+):
+    uploads = DjangoReportSession.objects.filter(
+        report__report_type=DjangoCommitReport.ReportType.TEST_RESULTS.value,
+        report__commit__repository__repoid=repo_id,
+        report__commit__commitid=commit_id,
+        state__in=["processed", "v2_finished"],
+    ).all()
+
+    process_flakes_for_uploads(repo_id, [upload for upload in uploads])
+
+    return {"successful": True}
+
+
+def process_flakes_for_uploads(repo_id: int, uploads: list[DjangoReportSession]):
+    curr_flakes = fetch_curr_flakes(repo_id)
+    new_flakes: dict[str, DjangoFlake] = dict()
+
+    rollups_to_update: list[DjangoDailyTestRollup] = []
+
+    flaky_tests = list(curr_flakes.keys())
+
+    for upload in uploads:
+        test_instances = get_test_instances(upload, flaky_tests)
+        for test_instance in test_instances:
+            if test_instance.outcome == DjangoTestInstance.Outcome.PASS.value:
+                flake = new_flakes.get(test_instance.test_id) or curr_flakes.get(
+                    test_instance.test_id
+                )
+                if flake is not None:
+                    update_flake(flake, test_instance)
+            elif test_instance.outcome in (
+                DjangoTestInstance.Outcome.FAILURE.value,
+                DjangoTestInstance.Outcome.ERROR.value,
+            ):
+                flake = new_flakes.get(test_instance.test_id) or curr_flakes.get(
+                    test_instance.test_id
+                )
+                if flake:
+                    update_flake(flake, test_instance)
+                else:
+                    flake, rollup = create_flake(test_instance, repo_id)
+
+                    new_flakes[test_instance.test_id] = flake
+
+                    if rollup:
+                        rollups_to_update.append(rollup)
+
+        if rollups_to_update:
+            DjangoDailyTestRollup.objects.bulk_update(
+                rollups_to_update,
+                ["flaky_fail_count"],
+            )
+
+        merge_flake_dict = {}
+
+        if new_flakes:
+            flakes_to_merge = DjangoFlake.objects.bulk_create(new_flakes.values())
+            merge_flake_dict: dict[str, DjangoFlake] = {
+                flake.test_id: flake for flake in flakes_to_merge
+            }
+
+        DjangoFlake.objects.bulk_update(
+            curr_flakes.values(),
+            [
+                "count",
+                "fail_count",
+                "recent_passes_count",
+                "end_date",
+            ],
+        )
+
+        curr_flakes = {**merge_flake_dict, **curr_flakes}
+
+        new_flakes.clear()
+
+        upload.state = "flake_processed"
+        upload.save()
+        django_transaction.commit()
+
+
+def get_test_instances(
+    upload: DjangoReportSession,
+    flaky_tests: list[str],
+) -> list[DjangoTestInstance]:
+    # get test instances on this upload that either:
+    # - failed
+    # - passed but belong to an already flaky test
+
+    upload_filter = Q(upload_id=upload.id)
+    test_failed_filter = Q(outcome=DjangoTestInstance.Outcome.ERROR.value) | Q(
+        outcome=DjangoTestInstance.Outcome.FAILURE.value
+    )
+    test_passed_but_flaky_filter = Q(outcome=DjangoTestInstance.Outcome.PASS.value) & Q(
+        test_id__in=flaky_tests
+    )
+    test_instances = list(
+        DjangoTestInstance.objects.filter(
+            upload_filter & (test_failed_filter | test_passed_but_flaky_filter)
+        )
+        .select_related("test")
+        .all()
+    )
+    return test_instances
+
+
+def fetch_curr_flakes(repo_id: int) -> dict[str, DjangoFlake]:
+    flakes = DjangoFlake.objects.filter(
+        repository_id=repo_id, end_date__isnull=True
+    ).all()
+    return {flake.test_id: flake for flake in flakes}
+
+
+def create_flake(
+    test_instance: DjangoTestInstance,
+    repo_id: int,
+) -> tuple[DjangoFlake, DjangoDailyTestRollup | None]:
+    # retroactively mark newly caught flake as flaky failure in its rollup
+    rollup = DjangoDailyTestRollup.objects.filter(
+        repoid=repo_id,
+        date=test_instance.created_at.date(),
+        branch=test_instance.branch,
+        test_id=test_instance.test_id,
+    ).first()
+
+    if rollup:
+        rollup.flaky_fail_count += 1
+
+    f = DjangoFlake(
+        repository_id=repo_id,
+        test=test_instance.test,
+        reduced_error=None,
+        count=1,
+        fail_count=1,
+        start_date=test_instance.created_at,
+        recent_passes_count=0,
+    )
+
+    return f, rollup
+
+
+def update_flake(
+    flake: DjangoFlake,
+    test_instance: DjangoTestInstance,
+) -> None:
+    flake.count += 1
+
+    match test_instance.outcome:
+        case DjangoTestInstance.Outcome.PASS.value:
+            flake.recent_passes_count += 1
+            if flake.recent_passes_count == FLAKE_EXPIRY_COUNT:
+                flake.end_date = test_instance.created_at
+        case (
+            DjangoTestInstance.Outcome.FAILURE.value
+            | DjangoTestInstance.Outcome.ERROR.value
+        ):
+            flake.fail_count += 1
+            flake.recent_passes_count = 0
+        case _:
+            pass
+
+
+def get_storage_key(
+    repo_id: int, branch: str | None, interval_start: int, interval_end: int | None
+) -> str:
+    interval_section = (
+        f"{interval_start}"
+        if interval_end is None
+        else f"{interval_start}_{interval_end}"
+    )
+    if branch:
+        return f"ta_rollups/{repo_id}/{branch}/{interval_section}"
+    else:
+        return f"ta_rollups/{repo_id}/{interval_section}"
+
+
+class PGDriver(TADriver[str]):
+    def __init__(
+        self,
+        repo_id: int,
+        db_session: Session | None = None,
+        flaky_test_set: set[str] | None = None,
+    ):
+        super().__init__(repo_id)
         self.db_session = db_session
         self.flaky_test_set = flaky_test_set
 
     def write_testruns(
         self,
         timestamp: int | None,
-        repo_id: int,
         commit_sha: str,
         branch_name: str,
-        upload: Upload,
+        upload_id: int,
+        flag_names: list[str],
         framework: str | None,
         testruns: list[test_results_parser.Testrun],
     ):
+        if self.db_session is None:
+            raise ValueError("DB session is required")
+
+        if self.flaky_test_set is None:
+            self.flaky_test_set = set(self.get_repo_flakes().keys())
+
         tests_to_write: dict[str, dict[str, Any]] = {}
         test_instances_to_write: list[dict[str, Any]] = []
         daily_totals: dict[str, DailyTotals] = dict()
         test_flag_bridge_data: list[dict] = []
 
-        repo_flag_ids = get_repo_flag_ids(self.db_session, repo_id, upload.flag_names)
+        repo_flag_ids = get_repo_flag_ids(self.db_session, self.repo_id, flag_names)
 
         for testrun in testruns:
             modify_structures(
@@ -311,8 +627,9 @@ class PGDriver(TADriver):
                 test_flag_bridge_data,
                 daily_totals,
                 testrun,
-                upload,
-                repo_id,
+                upload_id,
+                flag_names,
+                self.repo_id,
                 branch_name,
                 commit_sha,
                 repo_flag_ids,
@@ -331,3 +648,140 @@ class PGDriver(TADriver):
 
         if len(test_instances_to_write) > 0:
             save_test_instances(self.db_session, test_instances_to_write)
+
+    def cache_analytics(self, buckets: list[str], branch: str | None) -> None:
+        storage_service = shared.storage.get_appropriate_storage_service(self.repo_id)
+
+        if get_config("setup", "database", "read_replica_enabled", default=False):
+            connection = connections["default_read"]
+        else:
+            connection = connections["default"]
+
+        with connection.cursor() as cursor:
+            for interval_start, interval_end in [
+                # NOTE: working with calendar days and intervals,
+                # `(CURRENT_DATE - INTERVAL '1 days')` means *yesterday*,
+                # and `2..1` matches *the day before yesterday*.
+                (1, None),
+                (2, 1),
+                (7, None),
+                (14, 7),
+                (30, None),
+                (60, 30),
+            ]:
+                query_params = {
+                    "repoid": self.repo_id,
+                    "branch": branch,
+                    "interval_start": f"{interval_start} days",
+                    # SQL `BETWEEN` syntax is equivalent to `<= end`, with an inclusive end date,
+                    # thats why we do a `+1` here:
+                    "interval_end": f"{interval_end + 1 if interval_end else 0} days",
+                }
+
+                cursor.execute(ROLLUP_QUERY, query_params)
+                aggregation_of_test_results = cursor.fetchall()
+
+                df = pl.DataFrame(
+                    aggregation_of_test_results,
+                    [
+                        "name",
+                        "testsuite",
+                        ("flags", pl.List(pl.String)),
+                        "test_id",
+                        "failure_rate",
+                        "flake_rate",
+                        ("updated_at", pl.Datetime(time_zone=dt.UTC)),
+                        "avg_duration",
+                        "total_fail_count",
+                        "total_flaky_fail_count",
+                        "total_pass_count",
+                        "total_skip_count",
+                        "commits_where_fail",
+                        "last_duration",
+                    ],
+                    orient="row",
+                )
+
+                serialized_table = df.write_ipc(None)
+                serialized_table.seek(0)  # avoids Stream must be at beginning errors
+
+                storage_key = (
+                    f"test_results/rollups/{self.repo_id}/{branch}/{interval_start}"
+                    if interval_end is None
+                    else f"test_results/rollups/{self.repo_id}/{branch}/{interval_start}_{interval_end}"
+                )
+
+                for bucket in buckets:
+                    storage_service.write_file(bucket, storage_key, serialized_table)
+
+    def pr_comment_agg(self, commit_sha: str) -> PRCommentAggResult:
+        if self.db_session is None:
+            raise ValueError("DB session is required")
+
+        test_summary = get_test_summary_for_commit(
+            self.db_session, self.repo_id, commit_sha
+        )
+
+        return {
+            "commit_sha": commit_sha,
+            "passed_ct": test_summary.get("pass", 0),
+            "failed_ct": test_summary.get("failure", 0) + test_summary.get("error", 0),
+            "skipped_ct": test_summary.get("skip", 0),
+            "flaky_failed_ct": 0,
+        }
+
+    def pr_comment_fail(self, commit_sha: str) -> list[PRCommentFailResult[str]]:
+        if self.db_session is None:
+            raise ValueError("DB session is required")
+
+        test_instances = latest_failures_for_commit(
+            self.db_session, self.repo_id, commit_sha
+        )
+
+        return [
+            {
+                "computed_name": instance.test.computed_name
+                or f"{instance.test.testsuite}.{instance.test.name.replace('\x1f', '.')}",
+                "failure_message": instance.failure_message,
+                "id": instance.test.id,
+                "duration_seconds": instance.duration_seconds,
+                "upload_id": instance.upload_id,
+            }
+            for instance in test_instances
+        ]
+
+    def write_flakes(self, uploads: list[DjangoReportSession]) -> None:
+        return process_flakes_for_uploads(self.repo_id, uploads)
+
+    def get_repo_flakes(
+        self, test_ids: tuple[str, ...] | None = None
+    ) -> dict[str, FlakeInfo]:
+        if self.db_session is None:
+            raise ValueError("DB session is required")
+        if test_ids:
+            matching_flakes = list(
+                self.db_session.query(Flake)
+                .filter(
+                    Flake.repoid == self.repo_id,
+                    Flake.testid.in_(test_ids),
+                    Flake.end_date.is_(None),
+                    Flake.count != (Flake.recent_passes_count + Flake.fail_count),
+                )
+                .all()
+            )
+        else:
+            matching_flakes = list(
+                self.db_session.query(Flake)
+                .filter(
+                    Flake.repoid == self.repo_id,
+                    Flake.end_date.is_(None),
+                    Flake.count != (Flake.recent_passes_count + Flake.fail_count),
+                )
+                .all()
+            )
+
+        flaky_test_ids = {
+            flake.testid: FlakeInfo(flake.fail_count, flake.count)
+            for flake in matching_flakes
+        }
+        return flaky_test_ids

--- a/ta_storage/tests/snapshots/bq__analytics__0.txt
+++ b/ta_storage/tests/snapshots/bq__analytics__0.txt
@@ -1,0 +1,31 @@
+
+            WITH
+            
+analytics_base AS (
+    SELECT *
+    FROM `test-project.test-dataset.test-table`
+    WHERE repoid = @repoid
+        AND timestamp BETWEEN
+        (CURRENT_DATE - INTERVAL @interval_start) AND
+        (CURRENT_DATE - INTERVAL @interval_end)
+)
+
+            
+SELECT
+    name,
+    classname,
+    testsuite,
+    ANY_VALUE(computed_name) AS computed_name,
+    COUNT(DISTINCT IF(outcome = 1 OR outcome = 3, commit_sha, NULL)) AS cwf,
+    AVG(duration_seconds) AS avg_duration,
+    MAX_BY(duration_seconds, timestamp) AS last_duration,
+    SUM(IF(outcome = 0, 1, 0)) AS pass_count,
+    SUM(IF(outcome = 1, 1, 0)) AS fail_count,
+    SUM(IF(outcome = 2, 1, 0)) AS skip_count,
+    SUM(IF(outcome = 3, 1, 0)) AS flaky_fail_count,
+    MAX(timestamp) AS updated_at,
+    ARRAY_AGG(DISTINCT unnested_flags) AS flags
+FROM analytics_base, UNNEST(flags) AS unnested_flags
+GROUP BY name, classname, testsuite
+
+            

--- a/ta_storage/tests/snapshots/bq__analytics_with_branch__0.txt
+++ b/ta_storage/tests/snapshots/bq__analytics_with_branch__0.txt
@@ -1,0 +1,32 @@
+
+            WITH
+            
+analytics_base AS (
+    SELECT *
+    FROM `test-project.test-dataset.test-table`
+    WHERE repoid = @repoid
+        AND branch_name = @branch
+        AND timestamp BETWEEN
+        (CURRENT_TIMESTAMP() - INTERVAL @interval_start DAY) AND
+        (CURRENT_TIMESTAMP() - INTERVAL @interval_end DAY)
+)
+
+            
+SELECT
+    name,
+    classname,
+    testsuite,
+    ANY_VALUE(computed_name) AS computed_name,
+    COUNT(DISTINCT IF(outcome = 1 OR outcome = 3, commit_sha, NULL)) AS cwf,
+    AVG(duration_seconds) AS avg_duration,
+    MAX_BY(duration_seconds, timestamp) AS last_duration,
+    SUM(IF(outcome = 0, 1, 0)) AS pass_count,
+    SUM(IF(outcome = 1, 1, 0)) AS fail_count,
+    SUM(IF(outcome = 2, 1, 0)) AS skip_count,
+    SUM(IF(outcome = 3, 1, 0)) AS flaky_fail_count,
+    MAX(timestamp) AS updated_at,
+    ARRAY_AGG(DISTINCT unnested_flags) AS flags
+FROM analytics_base, UNNEST(flags) AS unnested_flags
+GROUP BY name, classname, testsuite
+
+            

--- a/ta_storage/tests/snapshots/bq__cache_analytics__0.json
+++ b/ta_storage/tests/snapshots/bq__cache_analytics__0.json
@@ -1,0 +1,40 @@
+{
+  "name": [
+    "test_something"
+  ],
+  "classname": [
+    "TestClass"
+  ],
+  "testsuite": [
+    "test_suite"
+  ],
+  "computed_name": [
+    "TestClass.test_something"
+  ],
+  "flags": [
+    [
+      "unit"
+    ]
+  ],
+  "avg_duration": [
+    1.5
+  ],
+  "fail_count": [
+    2
+  ],
+  "flaky_fail_count": [
+    1
+  ],
+  "pass_count": [
+    10
+  ],
+  "skip_count": [
+    1
+  ],
+  "commits_where_fail": [
+    2
+  ],
+  "last_duration": [
+    1.2
+  ]
+}

--- a/ta_storage/tests/snapshots/bq__cache_analytics__1.txt
+++ b/ta_storage/tests/snapshots/bq__cache_analytics__1.txt
@@ -1,0 +1,32 @@
+
+            WITH
+            
+analytics_base AS (
+    SELECT *
+    FROM `test-project.test-dataset.test-table`
+    WHERE repoid = @repoid
+        AND branch_name = @branch
+        AND timestamp BETWEEN
+        (CURRENT_TIMESTAMP() - INTERVAL @interval_start DAY) AND
+        (CURRENT_TIMESTAMP() - INTERVAL @interval_end DAY)
+)
+
+            
+SELECT
+    name,
+    classname,
+    testsuite,
+    ANY_VALUE(computed_name) AS computed_name,
+    COUNT(DISTINCT IF(outcome = 1 OR outcome = 3, commit_sha, NULL)) AS cwf,
+    AVG(duration_seconds) AS avg_duration,
+    MAX_BY(duration_seconds, timestamp) AS last_duration,
+    SUM(IF(outcome = 0, 1, 0)) AS pass_count,
+    SUM(IF(outcome = 1, 1, 0)) AS fail_count,
+    SUM(IF(outcome = 2, 1, 0)) AS skip_count,
+    SUM(IF(outcome = 3, 1, 0)) AS flaky_fail_count,
+    MAX(timestamp) AS updated_at,
+    ARRAY_AGG(DISTINCT unnested_flags) AS flags
+FROM analytics_base, UNNEST(flags) AS unnested_flags
+GROUP BY name, classname, testsuite
+
+            

--- a/ta_storage/tests/snapshots/bq__pr_comment_agg__0.txt
+++ b/ta_storage/tests/snapshots/bq__pr_comment_agg__0.txt
@@ -1,0 +1,51 @@
+
+        WITH 
+        
+ranked_data AS (
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                name,
+                classname,
+                testsuite,
+                flags_hash
+            ORDER BY timestamp DESC
+        ) AS row_num
+    FROM
+        `test-project.test-dataset.test-table`
+    WHERE
+        repoid = @repoid
+        AND commit_sha = @commit_sha
+)
+,
+        
+latest_instances AS (
+    SELECT
+        *
+    FROM
+        ranked_data
+    WHERE
+        row_num = 1
+)
+
+        
+SELECT
+    *
+FROM (
+    SELECT
+        commit_sha,
+        outcome
+    FROM
+        latest_instances
+) PIVOT (
+    COUNT(*) AS ct
+    FOR outcome IN (
+        0 as passed,
+        1 as failed,
+        2 as skipped,
+        3 as flaky_failed
+    )
+)
+
+        

--- a/ta_storage/tests/snapshots/bq__pr_comment_agg__1.json
+++ b/ta_storage/tests/snapshots/bq__pr_comment_agg__1.json
@@ -1,0 +1,7 @@
+{
+  "commit_sha": "abc123",
+  "passed_ct": 10,
+  "failed_ct": 2,
+  "skipped_ct": 1,
+  "flaky_failed_ct": 1
+}

--- a/ta_storage/tests/snapshots/bq__pr_comment_fail__0.txt
+++ b/ta_storage/tests/snapshots/bq__pr_comment_fail__0.txt
@@ -1,0 +1,45 @@
+
+        WITH 
+        
+ranked_data AS (
+    SELECT
+        *,
+        ROW_NUMBER() OVER (
+            PARTITION BY
+                name,
+                classname,
+                testsuite,
+                flags_hash
+            ORDER BY timestamp DESC
+        ) AS row_num
+    FROM
+        `test-project.test-dataset.test-table`
+    WHERE
+        repoid = @repoid
+        AND commit_sha = @commit_sha
+)
+,
+        
+latest_instances AS (
+    SELECT
+        *
+    FROM
+        ranked_data
+    WHERE
+        row_num = 1
+)
+
+        
+SELECT
+    computed_name,
+    failure_message,
+    test_id,
+    flags_hash,
+    duration_seconds,
+    upload_id
+FROM
+    latest_instances
+WHERE
+    outcome = 1
+
+        

--- a/ta_storage/tests/snapshots/bq__pr_comment_fail__1.json
+++ b/ta_storage/tests/snapshots/bq__pr_comment_fail__1.json
@@ -1,0 +1,12 @@
+[
+  {
+    "computed_name": "TestClass.test_something",
+    "failure_message": "assertion failed",
+    "id": [
+      "746573745f6964",
+      "666c6167735f68617368"
+    ],
+    "duration_seconds": 1.5,
+    "upload_id": 1
+  }
+]

--- a/ta_storage/tests/snapshots/bq__write_flakes__0.txt
+++ b/ta_storage/tests/snapshots/bq__write_flakes__0.txt
@@ -1,0 +1,24 @@
+
+        
+SELECT
+    timestamp,
+    test_id,
+    outcome,
+    branch_name,
+    flags_hash,
+FROM
+    `test-project.test-dataset.test-table`
+WHERE
+    upload_id = @upload_id
+    AND (
+        outcome = 1
+        OR outcome = 3
+        OR EXISTS (
+            SELECT 1
+                FROM UNNEST(@flake_ids) AS flake_id
+            WHERE flake_id.candidate_test_id = test_id
+            AND IF(flake_id.candidate_flags_hash IS NULL, flags_hash IS NULL, flake_id.candidate_flags_hash = flags_hash)
+        )
+    )
+
+        

--- a/ta_storage/tests/snapshots/bq__write_flakes__1.json
+++ b/ta_storage/tests/snapshots/bq__write_flakes__1.json
@@ -1,0 +1,12 @@
+[
+  {
+    "repoid": 1,
+    "test_id": "746573745f6964",
+    "fail_count": 1,
+    "count": 1,
+    "recent_passes_count": 0,
+    "start_date": "2025-01-01T00:00:00+00:00",
+    "end_date": null,
+    "flags_id": null
+  }
+]

--- a/ta_storage/tests/snapshots/bq__write_testruns__0.json
+++ b/ta_storage/tests/snapshots/bq__write_testruns__0.json
@@ -1,0 +1,22 @@
+[
+  {
+    "timestamp": "1735689600000000",
+    "name": "test_something",
+    "classname": "TestClass",
+    "testsuite": "test_suite",
+    "computed_name": "TestClass.test_something",
+    "outcome": "PASSED",
+    "duration_seconds": 1.5,
+    "repoid": "1",
+    "commit_sha": "abc123",
+    "branch_name": "main",
+    "flags": [
+      "unit"
+    ],
+    "filename": "test_file.py",
+    "framework": "pytest",
+    "upload_id": "1",
+    "flags_hash": "XLlcxAYPeBI=",
+    "test_id": "qbBVI/QFDPj9mlIXcoeGQA=="
+  }
+]

--- a/ta_storage/tests/snapshots/bq__write_testruns_with_flake__0.json
+++ b/ta_storage/tests/snapshots/bq__write_testruns_with_flake__0.json
@@ -1,0 +1,23 @@
+[
+  {
+    "timestamp": "1735689600000000",
+    "name": "test_something",
+    "classname": "TestClass",
+    "testsuite": "test_suite",
+    "computed_name": "TestClass.test_something",
+    "outcome": "FAILED",
+    "failure_message": "assertion failed",
+    "duration_seconds": 1.5,
+    "repoid": "1",
+    "commit_sha": "abc123",
+    "branch_name": "main",
+    "flags": [
+      "unit"
+    ],
+    "filename": "test_file.py",
+    "framework": "pytest",
+    "upload_id": "1",
+    "flags_hash": "XLlcxAYPeBI=",
+    "test_id": "qbBVI/QFDPj9mlIXcoeGQA=="
+  }
+]

--- a/ta_storage/tests/test_pg_django.py
+++ b/ta_storage/tests/test_pg_django.py
@@ -126,8 +126,6 @@ def test_pg_driver_cache_analytics(mock_storage):
         branch=upload.report.commit.branch,
     )
 
-    print(rollups)
-
     expected_intervals = [
         (1, None),  # Today
         (2, 1),  # Yesterday
@@ -148,7 +146,6 @@ def test_pg_driver_cache_analytics(mock_storage):
             table = read_table(mock_storage, bucket, storage_key)
             table_dict = table.to_dict(as_series=False)
 
-            print(table_dict)
             # Verify data based on intervals
             if (interval_start, interval_end) == (1, None):
                 # Today's data

--- a/ta_storage/tests/test_pg_django.py
+++ b/ta_storage/tests/test_pg_django.py
@@ -1,0 +1,272 @@
+from datetime import datetime, timedelta
+
+import polars as pl
+import pytest
+from shared.django_apps.reports.models import DailyTestRollup, Flake
+from shared.django_apps.reports.tests.factories import (
+    DailyTestRollupFactory,
+    TestFactory,
+    TestInstanceFactory,
+    UploadFactory,
+)
+
+from services.processing.flake_processing import FLAKE_EXPIRY_COUNT
+from ta_storage.pg import PGDriver
+
+
+def read_table(mock_storage, bucket: str, storage_path: str):
+    decompressed_table: bytes = mock_storage.read_file(bucket, storage_path)
+    return pl.read_ipc(decompressed_table)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pg_driver_cache_analytics(mock_storage):
+    # Create test data
+    upload = UploadFactory()
+    upload.save()
+
+    test = TestFactory(
+        repository=upload.report.commit.repository,
+        name="test_name",
+        testsuite="test_suite",
+        computed_name="test_computed_name",
+    )
+    test.save()
+
+    test_instance = TestInstanceFactory(
+        test=test,
+        upload=upload,
+        outcome="pass",
+        duration_seconds=1.5,
+        commitid=upload.report.commit.commitid,
+        branch=upload.report.commit.branch,
+        repoid=upload.report.commit.repository.repoid,
+    )
+    test_instance.save()
+
+    # Create daily rollup data for different intervals
+    today = datetime.now().date()
+
+    # Today's data
+    rollup_today = DailyTestRollupFactory(
+        test=test,
+        repoid=test.repository.repoid,
+        branch=upload.report.commit.branch,
+        date=today,
+        pass_count=10,
+        fail_count=2,
+        skip_count=1,
+        flaky_fail_count=1,
+        avg_duration_seconds=1.5,
+        last_duration_seconds=1.2,
+        latest_run=datetime.now(),
+        commits_where_fail=[upload.report.commit.commitid],
+    )
+    rollup_today.save()
+
+    # Yesterday's data
+    rollup_yesterday = DailyTestRollupFactory(
+        test=test,
+        repoid=test.repository.repoid,
+        branch=upload.report.commit.branch,
+        date=today - timedelta(days=1),
+        pass_count=5,
+        fail_count=3,
+        skip_count=0,
+        flaky_fail_count=2,
+        avg_duration_seconds=1.8,
+        last_duration_seconds=1.4,
+        latest_run=datetime.now() - timedelta(days=1),
+        commits_where_fail=[upload.report.commit.commitid],
+    )
+    rollup_yesterday.save()
+
+    # Data from 7 days ago
+    rollup_week = DailyTestRollupFactory(
+        test=test,
+        repoid=test.repository.repoid,
+        branch=upload.report.commit.branch,
+        date=today - timedelta(days=7),
+        pass_count=8,
+        fail_count=4,
+        skip_count=2,
+        flaky_fail_count=3,
+        avg_duration_seconds=1.6,
+        last_duration_seconds=1.3,
+        latest_run=datetime.now() - timedelta(days=7),
+        commits_where_fail=[upload.report.commit.commitid],
+    )
+    rollup_week.save()
+
+    # Data from 30 days ago
+    rollup_month = DailyTestRollupFactory(
+        test=test,
+        repoid=test.repository.repoid,
+        branch=upload.report.commit.branch,
+        date=today - timedelta(days=30),
+        pass_count=15,
+        fail_count=5,
+        skip_count=3,
+        flaky_fail_count=4,
+        avg_duration_seconds=1.7,
+        last_duration_seconds=1.5,
+        latest_run=datetime.now() - timedelta(days=30),
+        commits_where_fail=[upload.report.commit.commitid],
+    )
+    rollup_month.save()
+
+    buckets = ["bucket1", "bucket2"]
+    branch = upload.report.commit.branch
+
+    pg = PGDriver(upload.report.commit.repository.repoid)
+    pg.cache_analytics(buckets, branch)
+
+    rollups = DailyTestRollup.objects.filter(
+        repoid=test.repository.repoid,
+        branch=upload.report.commit.branch,
+    )
+
+    print(rollups)
+
+    expected_intervals = [
+        (1, None),  # Today
+        (2, 1),  # Yesterday
+        (7, None),  # Last week
+        (14, 7),  # Week before last
+        (30, None),  # Last month
+        (60, 30),  # Month before last
+    ]
+
+    # Verify data for each interval in each bucket
+    for bucket in buckets:
+        for interval_start, interval_end in expected_intervals:
+            storage_key = (
+                f"test_results/rollups/{upload.report.commit.repository.repoid}/{branch}/{interval_start}"
+                if interval_end is None
+                else f"test_results/rollups/{upload.report.commit.repository.repoid}/{branch}/{interval_start}_{interval_end}"
+            )
+            table = read_table(mock_storage, bucket, storage_key)
+            table_dict = table.to_dict(as_series=False)
+
+            print(table_dict)
+            # Verify data based on intervals
+            if (interval_start, interval_end) == (1, None):
+                # Today's data
+                assert table_dict["total_pass_count"] == [15]
+                assert table_dict["total_fail_count"] == [5]
+            elif (interval_start, interval_end) == (2, 1):
+                # Yesterday's data
+                assert table_dict["total_pass_count"] == []
+                assert table_dict["total_fail_count"] == []
+            elif (interval_start, interval_end) == (7, None):
+                # Last week's data (includes today)
+                assert table_dict["total_pass_count"] == [23]  # 10 + 5 + 8
+                assert table_dict["total_fail_count"] == [9]  # 2 + 3 + 4
+            elif (interval_start, interval_end) == (30, None):
+                # Last month's data (includes all)
+                assert table_dict["total_pass_count"] == [38]  # 10 + 5 + 8 + 15
+                assert table_dict["total_fail_count"] == [14]  # 2 + 3 + 4 + 5
+            elif (interval_start, interval_end) == (14, 7):
+                # Week before last (should be empty since we have no data in this range)
+                assert table_dict["total_pass_count"] == []
+                assert table_dict["total_fail_count"] == []
+            elif (interval_start, interval_end) == (60, 30):
+                # Month before last (should be empty)
+                assert table_dict["total_pass_count"] == []
+                assert table_dict["total_fail_count"] == []
+
+
+@pytest.mark.django_db(transaction=True)
+def test_pg_driver_write_flakes(mock_storage):
+    # Create test data
+    upload1 = UploadFactory()
+    upload1.save()
+
+    test1 = TestFactory(
+        repository=upload1.report.commit.repository,
+        name="test_name1",
+        testsuite="test_suite",
+        computed_name="test_computed_name1",
+    )
+    test1.save()
+
+    test2 = TestFactory(
+        repository=upload1.report.commit.repository,
+        name="test_name2",
+        testsuite="test_suite",
+        computed_name="test_computed_name2",
+    )
+    test2.save()
+
+    # Create a pre-existing flake for test1
+    flake1 = Flake.objects.create(
+        repository=test1.repository,
+        test=test1,
+        fail_count=1,
+        count=1,
+        recent_passes_count=0,
+        start_date=datetime.now(),
+    )
+    flake1.save()
+
+    # Create test instances that will update the existing flake
+    test_instance1 = TestInstanceFactory(
+        test=test1,
+        upload=upload1,
+        outcome="pass",  # This should increment recent_passes_count
+        duration_seconds=1.5,
+        commitid=upload1.report.commit.commitid,
+        branch=upload1.report.commit.branch,
+        repoid=upload1.report.commit.repository.repoid,
+    )
+    test_instance1.save()
+
+    # Create test instances that will create a new flake
+    test_instance2 = TestInstanceFactory(
+        test=test2,
+        upload=upload1,
+        outcome="failure",  # This should create a new flake
+        duration_seconds=1.8,
+        failure_message="Test failed",
+        commitid=upload1.report.commit.commitid,
+        branch=upload1.report.commit.branch,
+        repoid=upload1.report.commit.repository.repoid,
+    )
+    test_instance2.save()
+
+    # Create another upload with more test instances
+    upload2 = UploadFactory()
+    upload2.save()
+
+    # Create test instances that will expire the flake
+    for _ in range(FLAKE_EXPIRY_COUNT - 1):  # -1 because we already have one pass
+        test_instance = TestInstanceFactory(
+            test=test1,
+            upload=upload2,
+            outcome="pass",  # These passes should eventually expire the flake
+            duration_seconds=1.5,
+            commitid=upload2.report.commit.commitid,
+            branch=upload2.report.commit.branch,
+            repoid=upload2.report.commit.repository.repoid,
+        )
+        test_instance.save()
+
+    pg = PGDriver(upload1.report.commit.repository.repoid)
+    pg.write_flakes([upload1, upload2])
+
+    # Verify the flakes
+    flakes = Flake.objects.filter(repository=test1.repository).order_by("test")
+
+    # Verify the first flake (should be expired)
+    assert flakes[0].test == test1
+    assert flakes[0].count == FLAKE_EXPIRY_COUNT + 1  # Original + all passes
+    assert flakes[0].fail_count == 1  # Unchanged
+    assert flakes[0].recent_passes_count == FLAKE_EXPIRY_COUNT
+    assert flakes[0].end_date is not None  # Should be expired
+
+    # Verify the second flake (newly created)
+    assert flakes[1].test == test2
+    assert flakes[1].count == 1
+    assert flakes[1].fail_count == 1
+    assert flakes[1].recent_passes_count == 0
+    assert flakes[1].end_date is None  # Should not be expired

--- a/ta_storage/utils.py
+++ b/ta_storage/utils.py
@@ -1,4 +1,8 @@
+import logging
+
 import mmh3
+
+log = logging.getLogger(__name__)
 
 
 def calc_test_id(name: str, classname: str, testsuite: str) -> bytes:
@@ -13,6 +17,8 @@ def calc_test_id(name: str, classname: str, testsuite: str) -> bytes:
 
 def calc_flags_hash(flags: list[str]) -> bytes | None:
     flags_str = " ".join(sorted(flags))  # we know that flags cannot contain spaces
+    if not flags:
+        return None
 
     # returns a tuple of two int64 values
     # we only need the first one

--- a/tasks/tests/unit/snapshots/ta_processor_task__TestUploadTestProcessorTask__ta_processor_task_call__2.json
+++ b/tasks/tests/unit/snapshots/ta_processor_task__TestUploadTestProcessorTask__ta_processor_task_call__2.json
@@ -11,7 +11,6 @@
     "commit_sha": "cd76b0821854a780b60012aed85af0a8263004ad",
     "framework": "Pytest",
     "upload_id": "1",
-    "flags_hash": "AAAAAAAAAAA=",
     "test_id": "S/K2VdzrrehI4hnoZNsPVg=="
   },
   {
@@ -27,7 +26,6 @@
     "commit_sha": "cd76b0821854a780b60012aed85af0a8263004ad",
     "framework": "Pytest",
     "upload_id": "1",
-    "flags_hash": "AAAAAAAAAAA=",
     "test_id": "CVU2jNUNOkOrl6/lJdK0nw=="
   },
   {
@@ -42,7 +40,6 @@
     "commit_sha": "cd76b0821854a780b60012aed85af0a8263004ad",
     "framework": "Pytest",
     "upload_id": "1",
-    "flags_hash": "AAAAAAAAAAA=",
     "test_id": "UDBibp0NWEToP72TpCn1xg=="
   },
   {
@@ -57,7 +54,6 @@
     "commit_sha": "cd76b0821854a780b60012aed85af0a8263004ad",
     "framework": "Pytest",
     "upload_id": "1",
-    "flags_hash": "AAAAAAAAAAA=",
     "test_id": "VE2yD2IYxdSbTvGB6XCJPA=="
   }
 ]

--- a/tasks/tests/unit/test_ta_processor_task.py
+++ b/tasks/tests/unit/test_ta_processor_task.py
@@ -33,6 +33,7 @@ def mock_bigquery_service():
 class TestUploadTestProcessorTask(object):
     @pytest.mark.integration
     @travel("2025-01-01T00:00:00Z", tick=False)
+    @pytest.mark.django_db(transaction=True, databases=["test_analytics"])
     def test_ta_processor_task_call(
         self,
         mocker,
@@ -45,7 +46,15 @@ class TestUploadTestProcessorTask(object):
         snapshot,
     ):
         mock_configuration.set_params(
-            mock_configuration.params | {"services": {"bigquery": {"enabled": True}}}
+            mock_configuration.params
+            | {
+                "services": {"bigquery": {"write_enabled": True}},
+            }
+        )
+
+        mocker.patch(
+            "django_scaffold.settings.BIGQUERY_WRITE_ENABLED",
+            True,
         )
 
         tests = dbsession.query(Test).all()

--- a/worker.sh
+++ b/worker.sh
@@ -15,6 +15,10 @@ if [ "$RUN_ENV" = "ENTERPRISE" ] || [ "$RUN_ENV" = "DEV" ]; then
     python manage.py migrate --database "timeseries"
 fi
 
+if [ "$RUN_ENV" = "DEV" ]; then
+    python manage.py migrate --database "test_analytics"
+fi
+
 if [ -z "$1" ];
 then
   python main.py worker ${queues}


### PR DESCRIPTION
depends on: https://github.com/codecov/shared/pull/484

- improve the TADriver interface
- complete the BQDriver and PGDriver implementations
  - the PGDriver changes are mostly moving around existing code
- Introduce ta_utils which is going to replace services.test_results
  -  the reason it's being introduced is because I had to change the interface of TestResultsNotifier but we still want the old one around for the old test results pipeline
- add and use the test_analytics app from shared
- consume the config options in django_scaffold.settings instead of making various get_config calls