### PR TITLE
Generate separate queries instead of `OR` filters

### DIFF
--- a/services/cleanup/tests/snapshots/relations__builds_delete_queries__owner.txt
+++ b/services/cleanup/tests/snapshots/relations__builds_delete_queries__owner.txt
@@ -1,14 +1,16 @@
 -- UserMeasurement
 DELETE
 FROM "user_measurements"
-WHERE "user_measurements"."owner_id" IN (%s)
+WHERE "user_measurements"."owner_id" IN (%s);
 
 
 -- YamlHistory
 DELETE
 FROM "yaml_history"
-WHERE ("yaml_history"."ownerid" IN (%s)
-       OR "yaml_history"."author" IN (%s))
+WHERE "yaml_history"."ownerid" IN (%s);
+DELETE
+FROM "yaml_history"
+WHERE "yaml_history"."author" IN (%s);
 
 
 -- CommitNotification
@@ -17,37 +19,37 @@ FROM "commit_notifications"
 WHERE "commit_notifications"."gh_app_id" IN
     (SELECT U0."id"
      FROM "codecov_auth_githubappinstallation" U0
-     WHERE U0."owner_id" IN (%s))
+     WHERE U0."owner_id" IN (%s));
 
 
 -- OwnerInstallationNameToUseForTask
 DELETE
 FROM "codecov_auth_ownerinstallationnametousefortask"
-WHERE "codecov_auth_ownerinstallationnametousefortask"."owner_id" IN (%s)
+WHERE "codecov_auth_ownerinstallationnametousefortask"."owner_id" IN (%s);
 
 
 -- OrganizationLevelToken
 DELETE
 FROM "codecov_auth_organizationleveltoken"
-WHERE "codecov_auth_organizationleveltoken"."ownerid" IN (%s)
+WHERE "codecov_auth_organizationleveltoken"."ownerid" IN (%s);
 
 
 -- OwnerProfile
 DELETE
 FROM "codecov_auth_ownerprofile"
-WHERE "codecov_auth_ownerprofile"."owner_id" IN (%s)
+WHERE "codecov_auth_ownerprofile"."owner_id" IN (%s);
 
 
 -- Session
 DELETE
 FROM "sessions"
-WHERE "sessions"."ownerid" IN (%s)
+WHERE "sessions"."ownerid" IN (%s);
 
 
 -- UserToken
 DELETE
 FROM "codecov_auth_usertoken"
-WHERE "codecov_auth_usertoken"."ownerid" IN (%s)
+WHERE "codecov_auth_usertoken"."ownerid" IN (%s);
 
 
 -- TestInstance
@@ -56,7 +58,7 @@ FROM "reports_testinstance"
 WHERE "reports_testinstance"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- DailyTestRollup
@@ -65,7 +67,7 @@ FROM "reports_dailytestrollups"
 WHERE "reports_dailytestrollups"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- CacheConfig
@@ -74,7 +76,7 @@ FROM "bundle_analysis_cacheconfig"
 WHERE "bundle_analysis_cacheconfig"."repo_id" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- RepositoryToken
@@ -83,7 +85,7 @@ FROM "codecov_auth_repositorytoken"
 WHERE "codecov_auth_repositorytoken"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- Branch
@@ -92,7 +94,7 @@ FROM "branches"
 WHERE "branches"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- FlagComparison
@@ -104,7 +106,7 @@ WHERE "compare_flagcomparison"."repositoryflag_id" IN
      WHERE V0."repository_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
-          WHERE U0."ownerid" IN (%s)))
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- ComponentComparison
@@ -113,20 +115,25 @@ FROM "compare_componentcomparison"
 WHERE "compare_componentcomparison"."commit_comparison_id" IN
     (SELECT W0."id"
      FROM "compare_commitcomparison" W0
-     WHERE (W0."base_commit_id" IN
-              (SELECT V0."id"
-               FROM "commits" V0
-               WHERE V0."repoid" IN
-                   (SELECT U0."repoid"
-                    FROM "repos" U0
-                    WHERE U0."ownerid" IN (%s)))
-            OR W0."compare_commit_id" IN
-              (SELECT V0."id"
-               FROM "commits" V0
-               WHERE V0."repoid" IN
-                   (SELECT U0."repoid"
-                    FROM "repos" U0
-                    WHERE U0."ownerid" IN (%s)))))
+     WHERE W0."base_commit_id" IN
+         (SELECT V0."id"
+          FROM "commits" V0
+          WHERE V0."repoid" IN
+              (SELECT U0."repoid"
+               FROM "repos" U0
+               WHERE U0."ownerid" IN (%s))));
+DELETE
+FROM "compare_componentcomparison"
+WHERE "compare_componentcomparison"."commit_comparison_id" IN
+    (SELECT W0."id"
+     FROM "compare_commitcomparison" W0
+     WHERE W0."compare_commit_id" IN
+         (SELECT V0."id"
+          FROM "commits" V0
+          WHERE V0."repoid" IN
+              (SELECT U0."repoid"
+               FROM "repos" U0
+               WHERE U0."ownerid" IN (%s))));
 
 
 -- CommitError
@@ -138,7 +145,7 @@ WHERE "core_commiterror"."commit_id" IN
      WHERE V0."repoid" IN
          (SELECT U0."repoid"
           FROM "repos" U0
-          WHERE U0."ownerid" IN (%s)))
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- LabelAnalysisProcessingError
@@ -147,20 +154,25 @@ FROM "labelanalysis_labelanalysisprocessingerror"
 WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" IN
     (SELECT W0."id"
      FROM "labelanalysis_labelanalysisrequest" W0
-     WHERE (W0."base_commit_id" IN
-              (SELECT V0."id"
-               FROM "commits" V0
-               WHERE V0."repoid" IN
-                   (SELECT U0."repoid"
-                    FROM "repos" U0
-                    WHERE U0."ownerid" IN (%s)))
-            OR W0."head_commit_id" IN
-              (SELECT V0."id"
-               FROM "commits" V0
-               WHERE V0."repoid" IN
-                   (SELECT U0."repoid"
-                    FROM "repos" U0
-                    WHERE U0."ownerid" IN (%s)))))
+     WHERE W0."base_commit_id" IN
+         (SELECT V0."id"
+          FROM "commits" V0
+          WHERE V0."repoid" IN
+              (SELECT U0."repoid"
+               FROM "repos" U0
+               WHERE U0."ownerid" IN (%s))));
+DELETE
+FROM "labelanalysis_labelanalysisprocessingerror"
+WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" IN
+    (SELECT W0."id"
+     FROM "labelanalysis_labelanalysisrequest" W0
+     WHERE W0."head_commit_id" IN
+         (SELECT V0."id"
+          FROM "commits" V0
+          WHERE V0."repoid" IN
+              (SELECT U0."repoid"
+               FROM "repos" U0
+               WHERE U0."ownerid" IN (%s))));
 
 
 -- ReportResults
@@ -175,7 +187,7 @@ WHERE "reports_reportresults"."report_id" IN
           WHERE V0."repoid" IN
               (SELECT U0."repoid"
                FROM "repos" U0
-               WHERE U0."ownerid" IN (%s))))
+               WHERE U0."ownerid" IN (%s))));
 
 
 -- ReportDetails
@@ -190,7 +202,7 @@ WHERE "reports_reportdetails"."report_id" IN
           WHERE V0."repoid" IN
               (SELECT U0."repoid"
                FROM "repos" U0
-               WHERE U0."ownerid" IN (%s))))
+               WHERE U0."ownerid" IN (%s))));
 
 
 -- ReportLevelTotals
@@ -205,7 +217,7 @@ WHERE "reports_reportleveltotals"."report_id" IN
           WHERE V0."repoid" IN
               (SELECT U0."repoid"
                FROM "repos" U0
-               WHERE U0."ownerid" IN (%s))))
+               WHERE U0."ownerid" IN (%s))));
 
 
 -- UploadError
@@ -223,7 +235,7 @@ WHERE "reports_uploaderror"."upload_id" IN
                WHERE V0."repoid" IN
                    (SELECT U0."repoid"
                     FROM "repos" U0
-                    WHERE U0."ownerid" IN (%s)))))
+                    WHERE U0."ownerid" IN (%s)))));
 
 
 -- UploadFlagMembership
@@ -235,7 +247,7 @@ WHERE "reports_uploadflagmembership"."flag_id" IN
      WHERE V0."repository_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
-          WHERE U0."ownerid" IN (%s)))
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- UploadLevelTotals
@@ -253,7 +265,7 @@ WHERE "reports_uploadleveltotals"."upload_id" IN
                WHERE V0."repoid" IN
                    (SELECT U0."repoid"
                     FROM "repos" U0
-                    WHERE U0."ownerid" IN (%s)))))
+                    WHERE U0."ownerid" IN (%s)))));
 
 
 -- TestResultReportTotals
@@ -268,7 +280,7 @@ WHERE "reports_testresultreporttotals"."report_id" IN
           WHERE V0."repoid" IN
               (SELECT U0."repoid"
                FROM "repos" U0
-               WHERE U0."ownerid" IN (%s))))
+               WHERE U0."ownerid" IN (%s))));
 
 
 -- StaticAnalysisSuiteFilepath
@@ -280,7 +292,7 @@ WHERE "staticanalysis_staticanalysissuitefilepath"."file_snapshot_id" IN
      WHERE V0."repository_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
-          WHERE U0."ownerid" IN (%s)))
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- Pull
@@ -289,7 +301,7 @@ FROM "pulls"
 WHERE "pulls"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- ProfilingUpload
@@ -301,7 +313,7 @@ WHERE "profiling_profilingupload"."profiling_commit_id" IN
      WHERE V0."repoid" IN
          (SELECT U0."repoid"
           FROM "repos" U0
-          WHERE U0."ownerid" IN (%s)))
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- TestFlagBridge
@@ -313,7 +325,7 @@ WHERE "reports_test_results_flag_bridge"."test_id" IN
      WHERE V0."repoid" IN
          (SELECT U0."repoid"
           FROM "repos" U0
-          WHERE U0."ownerid" IN (%s)))
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- Flake
@@ -322,7 +334,7 @@ FROM "reports_flake"
 WHERE "reports_flake"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- LastCacheRollupDate
@@ -331,51 +343,55 @@ FROM "reports_lastrollupdate"
 WHERE "reports_lastrollupdate"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- GithubAppInstallation
 DELETE
 FROM "codecov_auth_githubappinstallation"
-WHERE "codecov_auth_githubappinstallation"."owner_id" IN (%s)
+WHERE "codecov_auth_githubappinstallation"."owner_id" IN (%s);
 
 
 -- CommitComparison
 DELETE
 FROM "compare_commitcomparison"
-WHERE ("compare_commitcomparison"."base_commit_id" IN
-         (SELECT V0."id"
-          FROM "commits" V0
-          WHERE V0."repoid" IN
-              (SELECT U0."repoid"
-               FROM "repos" U0
-               WHERE U0."ownerid" IN (%s)))
-       OR "compare_commitcomparison"."compare_commit_id" IN
-         (SELECT V0."id"
-          FROM "commits" V0
-          WHERE V0."repoid" IN
-              (SELECT U0."repoid"
-               FROM "repos" U0
-               WHERE U0."ownerid" IN (%s))))
+WHERE "compare_commitcomparison"."base_commit_id" IN
+    (SELECT V0."id"
+     FROM "commits" V0
+     WHERE V0."repoid" IN
+         (SELECT U0."repoid"
+          FROM "repos" U0
+          WHERE U0."ownerid" IN (%s)));
+DELETE
+FROM "compare_commitcomparison"
+WHERE "compare_commitcomparison"."compare_commit_id" IN
+    (SELECT V0."id"
+     FROM "commits" V0
+     WHERE V0."repoid" IN
+         (SELECT U0."repoid"
+          FROM "repos" U0
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- LabelAnalysisRequest
 DELETE
 FROM "labelanalysis_labelanalysisrequest"
-WHERE ("labelanalysis_labelanalysisrequest"."base_commit_id" IN
-         (SELECT V0."id"
-          FROM "commits" V0
-          WHERE V0."repoid" IN
-              (SELECT U0."repoid"
-               FROM "repos" U0
-               WHERE U0."ownerid" IN (%s)))
-       OR "labelanalysis_labelanalysisrequest"."head_commit_id" IN
-         (SELECT V0."id"
-          FROM "commits" V0
-          WHERE V0."repoid" IN
-              (SELECT U0."repoid"
-               FROM "repos" U0
-               WHERE U0."ownerid" IN (%s))))
+WHERE "labelanalysis_labelanalysisrequest"."base_commit_id" IN
+    (SELECT V0."id"
+     FROM "commits" V0
+     WHERE V0."repoid" IN
+         (SELECT U0."repoid"
+          FROM "repos" U0
+          WHERE U0."ownerid" IN (%s)));
+DELETE
+FROM "labelanalysis_labelanalysisrequest"
+WHERE "labelanalysis_labelanalysisrequest"."head_commit_id" IN
+    (SELECT V0."id"
+     FROM "commits" V0
+     WHERE V0."repoid" IN
+         (SELECT U0."repoid"
+          FROM "repos" U0
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- ReportSession
@@ -390,7 +406,7 @@ WHERE "reports_upload"."report_id" IN
           WHERE V0."repoid" IN
               (SELECT U0."repoid"
                FROM "repos" U0
-               WHERE U0."ownerid" IN (%s))))
+               WHERE U0."ownerid" IN (%s))));
 
 
 -- StaticAnalysisSuite
@@ -402,7 +418,7 @@ WHERE "staticanalysis_staticanalysissuite"."commit_id" IN
      WHERE V0."repoid" IN
          (SELECT U0."repoid"
           FROM "repos" U0
-          WHERE U0."ownerid" IN (%s)))
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- StaticAnalysisSingleFileSnapshot
@@ -411,7 +427,7 @@ FROM "staticanalysis_staticanalysissinglefilesnapshot"
 WHERE "staticanalysis_staticanalysissinglefilesnapshot"."repository_id" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- ProfilingCommit
@@ -420,7 +436,7 @@ FROM "profiling_profilingcommit"
 WHERE "profiling_profilingcommit"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- RepositoryFlag
@@ -429,7 +445,7 @@ FROM "reports_repositoryflag"
 WHERE "reports_repositoryflag"."repository_id" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- Test
@@ -438,7 +454,7 @@ FROM "reports_test"
 WHERE "reports_test"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- ReducedError
@@ -447,7 +463,7 @@ FROM "reports_reducederror"
 WHERE "reports_reducederror"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- CommitReport
@@ -459,7 +475,7 @@ WHERE "reports_commitreport"."commit_id" IN
      WHERE V0."repoid" IN
          (SELECT U0."repoid"
           FROM "repos" U0
-          WHERE U0."ownerid" IN (%s)))
+          WHERE U0."ownerid" IN (%s)));
 
 
 -- Commit
@@ -468,16 +484,16 @@ FROM "commits"
 WHERE "commits"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
-     WHERE U0."ownerid" IN (%s))
+     WHERE U0."ownerid" IN (%s));
 
 
 -- Repository
 DELETE
 FROM "repos"
-WHERE "repos"."ownerid" IN (%s)
+WHERE "repos"."ownerid" IN (%s);
 
 
 -- Owner
 DELETE
 FROM "owners"
-WHERE "owners"."ownerid" = %s
+WHERE "owners"."ownerid" = %s;

--- a/services/cleanup/tests/snapshots/relations__builds_delete_queries__repository.txt
+++ b/services/cleanup/tests/snapshots/relations__builds_delete_queries__repository.txt
@@ -1,37 +1,37 @@
 -- TestInstance
 DELETE
 FROM "reports_testinstance"
-WHERE "reports_testinstance"."repoid" IN (%s)
+WHERE "reports_testinstance"."repoid" IN (%s);
 
 
 -- DailyTestRollup
 DELETE
 FROM "reports_dailytestrollups"
-WHERE "reports_dailytestrollups"."repoid" IN (%s)
+WHERE "reports_dailytestrollups"."repoid" IN (%s);
 
 
 -- UserMeasurement
 DELETE
 FROM "user_measurements"
-WHERE "user_measurements"."repo_id" IN (%s)
+WHERE "user_measurements"."repo_id" IN (%s);
 
 
 -- CacheConfig
 DELETE
 FROM "bundle_analysis_cacheconfig"
-WHERE "bundle_analysis_cacheconfig"."repo_id" IN (%s)
+WHERE "bundle_analysis_cacheconfig"."repo_id" IN (%s);
 
 
 -- RepositoryToken
 DELETE
 FROM "codecov_auth_repositorytoken"
-WHERE "codecov_auth_repositorytoken"."repoid" IN (%s)
+WHERE "codecov_auth_repositorytoken"."repoid" IN (%s);
 
 
 -- Branch
 DELETE
 FROM "branches"
-WHERE "branches"."repoid" IN (%s)
+WHERE "branches"."repoid" IN (%s);
 
 
 -- FlagComparison
@@ -40,7 +40,7 @@ FROM "compare_flagcomparison"
 WHERE "compare_flagcomparison"."repositoryflag_id" IN
     (SELECT U0."id"
      FROM "reports_repositoryflag" U0
-     WHERE U0."repository_id" IN (%s))
+     WHERE U0."repository_id" IN (%s));
 
 
 -- ComponentComparison
@@ -49,14 +49,19 @@ FROM "compare_componentcomparison"
 WHERE "compare_componentcomparison"."commit_comparison_id" IN
     (SELECT V0."id"
      FROM "compare_commitcomparison" V0
-     WHERE (V0."base_commit_id" IN
-              (SELECT U0."id"
-               FROM "commits" U0
-               WHERE U0."repoid" IN (%s))
-            OR V0."compare_commit_id" IN
-              (SELECT U0."id"
-               FROM "commits" U0
-               WHERE U0."repoid" IN (%s))))
+     WHERE V0."base_commit_id" IN
+         (SELECT U0."id"
+          FROM "commits" U0
+          WHERE U0."repoid" IN (%s)));
+DELETE
+FROM "compare_componentcomparison"
+WHERE "compare_componentcomparison"."commit_comparison_id" IN
+    (SELECT V0."id"
+     FROM "compare_commitcomparison" V0
+     WHERE V0."compare_commit_id" IN
+         (SELECT U0."id"
+          FROM "commits" U0
+          WHERE U0."repoid" IN (%s)));
 
 
 -- CommitNotification
@@ -65,7 +70,7 @@ FROM "commit_notifications"
 WHERE "commit_notifications"."commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
-     WHERE U0."repoid" IN (%s))
+     WHERE U0."repoid" IN (%s));
 
 
 -- CommitError
@@ -74,7 +79,7 @@ FROM "core_commiterror"
 WHERE "core_commiterror"."commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
-     WHERE U0."repoid" IN (%s))
+     WHERE U0."repoid" IN (%s));
 
 
 -- LabelAnalysisProcessingError
@@ -83,14 +88,19 @@ FROM "labelanalysis_labelanalysisprocessingerror"
 WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" IN
     (SELECT V0."id"
      FROM "labelanalysis_labelanalysisrequest" V0
-     WHERE (V0."base_commit_id" IN
-              (SELECT U0."id"
-               FROM "commits" U0
-               WHERE U0."repoid" IN (%s))
-            OR V0."head_commit_id" IN
-              (SELECT U0."id"
-               FROM "commits" U0
-               WHERE U0."repoid" IN (%s))))
+     WHERE V0."base_commit_id" IN
+         (SELECT U0."id"
+          FROM "commits" U0
+          WHERE U0."repoid" IN (%s)));
+DELETE
+FROM "labelanalysis_labelanalysisprocessingerror"
+WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" IN
+    (SELECT V0."id"
+     FROM "labelanalysis_labelanalysisrequest" V0
+     WHERE V0."head_commit_id" IN
+         (SELECT U0."id"
+          FROM "commits" U0
+          WHERE U0."repoid" IN (%s)));
 
 
 -- ReportResults
@@ -102,7 +112,7 @@ WHERE "reports_reportresults"."report_id" IN
      WHERE V0."commit_id" IN
          (SELECT U0."id"
           FROM "commits" U0
-          WHERE U0."repoid" IN (%s)))
+          WHERE U0."repoid" IN (%s)));
 
 
 -- ReportDetails
@@ -114,7 +124,7 @@ WHERE "reports_reportdetails"."report_id" IN
      WHERE V0."commit_id" IN
          (SELECT U0."id"
           FROM "commits" U0
-          WHERE U0."repoid" IN (%s)))
+          WHERE U0."repoid" IN (%s)));
 
 
 -- ReportLevelTotals
@@ -126,7 +136,7 @@ WHERE "reports_reportleveltotals"."report_id" IN
      WHERE V0."commit_id" IN
          (SELECT U0."id"
           FROM "commits" U0
-          WHERE U0."repoid" IN (%s)))
+          WHERE U0."repoid" IN (%s)));
 
 
 -- UploadError
@@ -141,7 +151,7 @@ WHERE "reports_uploaderror"."upload_id" IN
           WHERE V0."commit_id" IN
               (SELECT U0."id"
                FROM "commits" U0
-               WHERE U0."repoid" IN (%s))))
+               WHERE U0."repoid" IN (%s))));
 
 
 -- UploadFlagMembership
@@ -150,7 +160,7 @@ FROM "reports_uploadflagmembership"
 WHERE "reports_uploadflagmembership"."flag_id" IN
     (SELECT U0."id"
      FROM "reports_repositoryflag" U0
-     WHERE U0."repository_id" IN (%s))
+     WHERE U0."repository_id" IN (%s));
 
 
 -- UploadLevelTotals
@@ -165,7 +175,7 @@ WHERE "reports_uploadleveltotals"."upload_id" IN
           WHERE V0."commit_id" IN
               (SELECT U0."id"
                FROM "commits" U0
-               WHERE U0."repoid" IN (%s))))
+               WHERE U0."repoid" IN (%s))));
 
 
 -- TestResultReportTotals
@@ -177,7 +187,7 @@ WHERE "reports_testresultreporttotals"."report_id" IN
      WHERE V0."commit_id" IN
          (SELECT U0."id"
           FROM "commits" U0
-          WHERE U0."repoid" IN (%s)))
+          WHERE U0."repoid" IN (%s)));
 
 
 -- StaticAnalysisSuiteFilepath
@@ -186,13 +196,13 @@ FROM "staticanalysis_staticanalysissuitefilepath"
 WHERE "staticanalysis_staticanalysissuitefilepath"."file_snapshot_id" IN
     (SELECT U0."id"
      FROM "staticanalysis_staticanalysissinglefilesnapshot" U0
-     WHERE U0."repository_id" IN (%s))
+     WHERE U0."repository_id" IN (%s));
 
 
 -- Pull
 DELETE
 FROM "pulls"
-WHERE "pulls"."repoid" IN (%s)
+WHERE "pulls"."repoid" IN (%s);
 
 
 -- ProfilingUpload
@@ -201,7 +211,7 @@ FROM "profiling_profilingupload"
 WHERE "profiling_profilingupload"."profiling_commit_id" IN
     (SELECT U0."id"
      FROM "profiling_profilingcommit" U0
-     WHERE U0."repoid" IN (%s))
+     WHERE U0."repoid" IN (%s));
 
 
 -- TestFlagBridge
@@ -210,45 +220,49 @@ FROM "reports_test_results_flag_bridge"
 WHERE "reports_test_results_flag_bridge"."test_id" IN
     (SELECT U0."id"
      FROM "reports_test" U0
-     WHERE U0."repoid" IN (%s))
+     WHERE U0."repoid" IN (%s));
 
 
 -- Flake
 DELETE
 FROM "reports_flake"
-WHERE "reports_flake"."repoid" IN (%s)
+WHERE "reports_flake"."repoid" IN (%s);
 
 
 -- LastCacheRollupDate
 DELETE
 FROM "reports_lastrollupdate"
-WHERE "reports_lastrollupdate"."repoid" IN (%s)
+WHERE "reports_lastrollupdate"."repoid" IN (%s);
 
 
 -- CommitComparison
 DELETE
 FROM "compare_commitcomparison"
-WHERE ("compare_commitcomparison"."base_commit_id" IN
-         (SELECT U0."id"
-          FROM "commits" U0
-          WHERE U0."repoid" IN (%s))
-       OR "compare_commitcomparison"."compare_commit_id" IN
-         (SELECT U0."id"
-          FROM "commits" U0
-          WHERE U0."repoid" IN (%s)))
+WHERE "compare_commitcomparison"."base_commit_id" IN
+    (SELECT U0."id"
+     FROM "commits" U0
+     WHERE U0."repoid" IN (%s));
+DELETE
+FROM "compare_commitcomparison"
+WHERE "compare_commitcomparison"."compare_commit_id" IN
+    (SELECT U0."id"
+     FROM "commits" U0
+     WHERE U0."repoid" IN (%s));
 
 
 -- LabelAnalysisRequest
 DELETE
 FROM "labelanalysis_labelanalysisrequest"
-WHERE ("labelanalysis_labelanalysisrequest"."base_commit_id" IN
-         (SELECT U0."id"
-          FROM "commits" U0
-          WHERE U0."repoid" IN (%s))
-       OR "labelanalysis_labelanalysisrequest"."head_commit_id" IN
-         (SELECT U0."id"
-          FROM "commits" U0
-          WHERE U0."repoid" IN (%s)))
+WHERE "labelanalysis_labelanalysisrequest"."base_commit_id" IN
+    (SELECT U0."id"
+     FROM "commits" U0
+     WHERE U0."repoid" IN (%s));
+DELETE
+FROM "labelanalysis_labelanalysisrequest"
+WHERE "labelanalysis_labelanalysisrequest"."head_commit_id" IN
+    (SELECT U0."id"
+     FROM "commits" U0
+     WHERE U0."repoid" IN (%s));
 
 
 -- ReportSession
@@ -260,7 +274,7 @@ WHERE "reports_upload"."report_id" IN
      WHERE V0."commit_id" IN
          (SELECT U0."id"
           FROM "commits" U0
-          WHERE U0."repoid" IN (%s)))
+          WHERE U0."repoid" IN (%s)));
 
 
 -- StaticAnalysisSuite
@@ -269,37 +283,37 @@ FROM "staticanalysis_staticanalysissuite"
 WHERE "staticanalysis_staticanalysissuite"."commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
-     WHERE U0."repoid" IN (%s))
+     WHERE U0."repoid" IN (%s));
 
 
 -- StaticAnalysisSingleFileSnapshot
 DELETE
 FROM "staticanalysis_staticanalysissinglefilesnapshot"
-WHERE "staticanalysis_staticanalysissinglefilesnapshot"."repository_id" IN (%s)
+WHERE "staticanalysis_staticanalysissinglefilesnapshot"."repository_id" IN (%s);
 
 
 -- ProfilingCommit
 DELETE
 FROM "profiling_profilingcommit"
-WHERE "profiling_profilingcommit"."repoid" IN (%s)
+WHERE "profiling_profilingcommit"."repoid" IN (%s);
 
 
 -- RepositoryFlag
 DELETE
 FROM "reports_repositoryflag"
-WHERE "reports_repositoryflag"."repository_id" IN (%s)
+WHERE "reports_repositoryflag"."repository_id" IN (%s);
 
 
 -- Test
 DELETE
 FROM "reports_test"
-WHERE "reports_test"."repoid" IN (%s)
+WHERE "reports_test"."repoid" IN (%s);
 
 
 -- ReducedError
 DELETE
 FROM "reports_reducederror"
-WHERE "reports_reducederror"."repoid" IN (%s)
+WHERE "reports_reducederror"."repoid" IN (%s);
 
 
 -- CommitReport
@@ -308,16 +322,16 @@ FROM "reports_commitreport"
 WHERE "reports_commitreport"."commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
-     WHERE U0."repoid" IN (%s))
+     WHERE U0."repoid" IN (%s));
 
 
 -- Commit
 DELETE
 FROM "commits"
-WHERE "commits"."repoid" IN (%s)
+WHERE "commits"."repoid" IN (%s);
 
 
 -- Repository
 DELETE
 FROM "repos"
-WHERE "repos"."repoid" = %s
+WHERE "repos"."repoid" = %s;

--- a/services/cleanup/tests/test_relations.py
+++ b/services/cleanup/tests/test_relations.py
@@ -12,14 +12,16 @@ def dump_delete_queries(queryset: QuerySet) -> str:
     relations = build_relation_graph(queryset)
 
     queries = ""
-    for model, query in relations:
-        compiler = query.query.chain(DeleteQuery).get_compiler(query.db)
-        sql, _params = compiler.as_sql()
-        sql = sqlparse.format(sql, reindent=True, keyword_case="upper")
-
+    for relation in relations:
         if queries:
             queries += "\n\n"
-        queries += f"-- {model.__name__}\n{sql}\n"
+        queries += f"-- {relation.model.__name__}\n"
+
+        for query in relation.querysets:
+            compiler = query.query.chain(DeleteQuery).get_compiler(query.db)
+            sql, _params = compiler.as_sql()
+            sql = sqlparse.format(sql, reindent=True, keyword_case="upper")
+            queries += sql + ";\n"
 
     return queries
 


### PR DESCRIPTION
In todays episode of "the DB is slow for unexplainable reasons", we found out that querying `compare_commitcomparison` by **both** `base_commit_id` **OR** `compare_commit_id` is horribly slow. It is using a `Seq Scan` in that case for reasons unknown.

Splitting that `OR` filter up into two separate queries makes the DB use the appropriate indices, and the queries become instant. We can do this as the `OR` filter pretty much takes the union of both queries, which is equivalent of running both queries separately.

God only knows why, but here we are.