### PR TITLE
fix: Bundle Analysis - display negative number when size change goes down

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/190bbc8a911099749928e13d5fe57f6027ca1e74.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/4201051a754ec495d125a3ea83d8849ee6381e0a.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/6fcd226abe345030ae32f92ec9440c4ccd2a6614.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -377,7 +377,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.7.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/4201051a754ec495d125a3ea83d8849ee6381e0a.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/6fcd226abe345030ae32f92ec9440c4ccd2a6614.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/bundle_analysis/notify/helpers.py
+++ b/services/bundle_analysis/notify/helpers.py
@@ -1,5 +1,5 @@
 import numbers
-from typing import Literal
+from typing import Literal, Optional
 
 from shared.bundle_analysis import BundleAnalysisComparison, BundleChange
 from shared.django_apps.codecov_auth.models import Service
@@ -63,8 +63,9 @@ def get_github_app_used(torngit: TorngitBaseAdapter | None) -> int | None:
     return selected_installation_id
 
 
-def bytes_readable(bytes: int) -> str:
+def bytes_readable(bytes: int, show_negative: Optional[bool] = True) -> str:
     """Converts bytes into human-readable string (up to GB)"""
+    is_negative = bytes < 0
     value: float = abs(bytes)
     exponent_index = 0
 
@@ -74,7 +75,11 @@ def bytes_readable(bytes: int) -> str:
 
     exponent_str = [" bytes", "kB", "MB", "GB"][exponent_index]
     rounded_value = round(value, 2)
-    return f"{rounded_value}{exponent_str}"
+
+    if is_negative and show_negative:
+        return f"-{rounded_value}{exponent_str}"
+    else:
+        return f"{rounded_value}{exponent_str}"
 
 
 def to_BundleThreshold(value: int | float | BundleThreshold) -> BundleThreshold:

--- a/services/bundle_analysis/notify/messages/comment.py
+++ b/services/bundle_analysis/notify/messages/comment.py
@@ -144,7 +144,7 @@ class BundleAnalysisCommentMarkdownStrategy(MessageStrategyInterface):
                 round(context.bundle_analysis_comparison.percentage_delta, 2)
             )
             + "%",
-            total_size_readable=bytes_readable(total_size_delta),
+            total_size_readable=bytes_readable(total_size_delta, show_negative=False),
             warning_threshold_readable=warning_threshold_readable,
             individual_bundle_data=individual_bundle_data,
         )

--- a/services/bundle_analysis/notify/messages/commit_status.py
+++ b/services/bundle_analysis/notify/messages/commit_status.py
@@ -50,10 +50,7 @@ class CommitStatusMessageStrategy(MessageStrategyInterface):
         if warning_threshold.type == "absolute":
             warning_threshold_readable = bytes_readable(warning_threshold.threshold)
             absolute_change = context.bundle_analysis_comparison.total_size_delta
-            is_negative = absolute_change < 0
-            change_readable = ("-" if is_negative else "") + bytes_readable(
-                absolute_change
-            )
+            change_readable = bytes_readable(absolute_change)
         else:
             warning_threshold_readable = str(warning_threshold.threshold) + "%"
             change_readable = (

--- a/services/bundle_analysis/notify/messages/tests/test_comment.py
+++ b/services/bundle_analysis/notify/messages/tests/test_comment.py
@@ -62,10 +62,10 @@ class TestCommentMesage:
                 | Bundle name | Size | Change |
                 | ----------- | ---- | ------ |
                 | @codecov/sveltekit-plugin-esm | 1.1kB | 188 bytes (20.68%) :arrow_up: |
-                | @codecov/rollup-plugin-esm | 1.32kB | 1.01kB (-43.37%) :arrow_down: |
-                | @codecov/bundler-plugin-core-esm | 8.2kB | 30.02kB (-78.55%) :arrow_down: |
+                | @codecov/rollup-plugin-esm | 1.32kB | -1.01kB (-43.37%) :arrow_down: |
+                | @codecov/bundler-plugin-core-esm | 8.2kB | -30.02kB (-78.55%) :arrow_down: |
                 | @codecov/bundler-plugin-core-cjs | 43.32kB | 611 bytes (1.43%) :arrow_up: |
-                | @codecov/example-next-app-server-cjs | (removed) | 342.32kB (-100.0%) :arrow_down: |
+                | @codecov/example-next-app-server-cjs | (removed) | -342.32kB (-100.0%) :arrow_down: |
 
                 </details>
                 """).format(

--- a/services/bundle_analysis/tests/test_bundle_analysis.py
+++ b/services/bundle_analysis/tests/test_bundle_analysis.py
@@ -493,7 +493,7 @@ async def test_bundle_analysis_save_measurements_error(dbsession, mocker, mock_s
             | ----------- | ---- | ------ |
             | added-bundle | 123.46kB | 12.35kB (5.56%) :arrow_up::warning: |
             | changed-bundle | 123.46kB | 3.46kB (0.35%) :arrow_up: |
-            | removed-bundle | (removed) | 1.23kB (-1.23%) :arrow_down: |
+            | removed-bundle | (removed) | -1.23kB (-1.23%) :arrow_down: |
             """),
             id="comment_increase_size_warning",
         ),
@@ -535,7 +535,7 @@ async def test_bundle_analysis_save_measurements_error(dbsession, mocker, mock_s
             | ----------- | ---- | ------ |
             | added-bundle | 123.46kB | 12.35kB (5.56%) :arrow_up::x: |
             | changed-bundle | 123.46kB | 3.46kB (2.56%) :arrow_up: |
-            | removed-bundle | (removed) | 1.23kB (-100.0%) :arrow_down: |
+            | removed-bundle | (removed) | -1.23kB (-100.0%) :arrow_down: |
             """),
             id="comment_increase_size_error",
         ),
@@ -579,7 +579,7 @@ async def test_bundle_analysis_save_measurements_error(dbsession, mocker, mock_s
             | ----------- | ---- | ------ |
             | added-bundle | 123.46kB | 12.35kB (2.56%) :arrow_up: |
             | cached-bundle* | 123.46kB | 3.46kB (2.56%) :arrow_up: |
-            | removed-bundle | (removed) | 1.23kB (2.56%) :arrow_down: |
+            | removed-bundle | (removed) | -1.23kB (2.56%) :arrow_down: |
 
             </details>
 
@@ -614,7 +614,7 @@ async def test_bundle_analysis_save_measurements_error(dbsession, mocker, mock_s
 
             | Bundle name | Size | Change |
             | ----------- | ---- | ------ |
-            | test-bundle | 123.46kB | 3.46kB (-2.56%) :arrow_down: |
+            | test-bundle | 123.46kB | -3.46kB (-2.56%) :arrow_down: |
 
             </details>
             """),
@@ -684,7 +684,7 @@ async def test_bundle_analysis_save_measurements_error(dbsession, mocker, mock_s
             | ----------- | ---- | ------ |
             | added-bundle | 123.46kB | 12.35kB (5.56%) :arrow_up::warning: |
             | changed-bundle | 123.46kB | 3.46kB (0.35%) :arrow_up: |
-            | removed-bundle | (removed) | 1.23kB (-1.23%) :arrow_down: |
+            | removed-bundle | (removed) | -1.23kB (-1.23%) :arrow_down: |
             """),
             id="comparison_by_file_path",
         ),
@@ -964,7 +964,7 @@ class MockAssetComparison:
             | ---------- | ----------- | ---------- | ---------- |
             | ```this-is-a-warning``` | 200 bytes | 1.2kB | 20.0% :warning: |
             | **```this-is-added```** _(New)_ | 10.0kB | 10.0kB | 100.0% :rocket: |
-            | ~~**```this-is-removed```**~~ _(Deleted)_ | 20.0kB | 0 bytes | -100.0% :wastebasket: |
+            | ~~**```this-is-removed```**~~ _(Deleted)_ | -20.0kB | 0 bytes | -100.0% :wastebasket: |
             | ```this-is-a-small-change``` | 1.0kB | 101.0kB | 1.0%  |
 
 
@@ -1088,7 +1088,7 @@ class MockAssetComparison:
             | ---------- | ----------- | ---------- | ---------- |
             | ```this-is-a-warning``` | 200 bytes | 1.2kB | 20.0% :warning: |
             | **```this-is-added```** _(New)_ | 10.0kB | 10.0kB | 100.0% :rocket: |
-            | ~~**```this-is-removed```**~~ _(Deleted)_ | 20.0kB | 0 bytes | -100.0% :wastebasket: |
+            | ~~**```this-is-removed```**~~ _(Deleted)_ | -20.0kB | 0 bytes | -100.0% :wastebasket: |
             | ```this-is-a-small-change``` | 1.0kB | 101.0kB | 1.0%  |
 
 
@@ -1262,7 +1262,7 @@ class MockAssetComparison:
             | ---------- | ----------- | ---------- | ---------- |
             | ```this-is-a-warning``` | 200 bytes | 1.2kB | 20.0% :warning: |
             | **```this-is-added```** _(New)_ | 10.0kB | 10.0kB | 100.0% :rocket: |
-            | ~~**```this-is-removed```**~~ _(Deleted)_ | 20.0kB | 0 bytes | -100.0% :wastebasket: |
+            | ~~**```this-is-removed```**~~ _(Deleted)_ | -20.0kB | 0 bytes | -100.0% :wastebasket: |
             | ```this-is-a-small-change``` | 1.0kB | 101.0kB | 1.0%  |
 
 
@@ -1280,7 +1280,7 @@ class MockAssetComparison:
             | App Route | Size Change | Total Size | Change (%) |
             | --------- | ----------- | ---------- | ---------- |
             | **/users** _(New)_ | 1.0kB | 1.0kB | 100% :rocket: |
-            | ~~**/faq**~~ _(Deleted)_ | 5.0kB | 0 bytes | -100.0% :wastebasket: |
+            | ~~**/faq**~~ _(Deleted)_ | -5.0kB | 0 bytes | -100.0% :wastebasket: |
             | /big-change | 10.0kB | 30.0kB | 50.0% :warning: |
             | /small-change | 1.0kB | 101.0kB | 1.0%  |
 
@@ -1436,7 +1436,7 @@ class MockAssetComparison:
             | ---------- | ----------- | ---------- | ---------- |
             | ```this-is-a-warning``` | 200 bytes | 1.2kB | 20.0% :warning: |
             | **```this-is-added```** _(New)_ | 10.0kB | 10.0kB | 100.0% :rocket: |
-            | ~~**```this-is-removed```**~~ _(Deleted)_ | 20.0kB | 0 bytes | -100.0% :wastebasket: |
+            | ~~**```this-is-removed```**~~ _(Deleted)_ | -20.0kB | 0 bytes | -100.0% :wastebasket: |
             | ```this-is-a-small-change``` | 1.0kB | 101.0kB | 1.0%  |
 
 
@@ -1472,7 +1472,7 @@ class MockAssetComparison:
             | App Route | Size Change | Total Size | Change (%) |
             | --------- | ----------- | ---------- | ---------- |
             | **/users** _(New)_ | 1.0kB | 1.0kB | 100% :rocket: |
-            | ~~**/faq**~~ _(Deleted)_ | 5.0kB | 0 bytes | -100.0% :wastebasket: |
+            | ~~**/faq**~~ _(Deleted)_ | -5.0kB | 0 bytes | -100.0% :wastebasket: |
             | /big-change | 10.0kB | 30.0kB | 50.0% :warning: |
             | /small-change | 1.0kB | 101.0kB | 1.0%  |
 


### PR DESCRIPTION

<img width="721" alt="Screenshot 2025-01-28 at 3 51 34 PM" src="https://github.com/user-attachments/assets/f818e8c8-b500-4a4e-9910-bc1a5c587754" />

should show negative numbers here as the size went down

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.