### PR TITLE
layout should not be required

### DIFF
--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -274,7 +274,7 @@ class MessageMixin(object):
 
     def get_middle_layout_section_names(self, settings):
         sections = map(
-            lambda layout: layout.strip(), (settings["layout"] or "").split(",")
+            lambda layout: layout.strip(), settings.get("layout", "").split(",")
         )
         return [
             section
@@ -293,7 +293,7 @@ class MessageMixin(object):
 
     def get_upper_section_names(self, settings):
         sections = list(
-            map(lambda layout: layout.strip(), (settings["layout"] or "").split(","))
+            map(lambda layout: layout.strip(), settings.get("layout", "").split(","))
         )
         headers = ["newheader", "header", "condensed_header"]
         if all(x not in sections for x in headers):
@@ -316,8 +316,7 @@ class MessageMixin(object):
         ]
 
     def get_lower_section_name(self, settings):
-        if (
-            "newfooter" in settings["layout"]
-            or "condensed_footer" in settings["layout"]
-        ):
+        if "newfooter" in settings.get(
+            "layout", ""
+        ) or "condensed_footer" in settings.get("layout", ""):
             return "newfooter"

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -2104,6 +2104,37 @@ class TestCommentNotifier(object):
             assert exp == res
         assert result == expected_result
 
+    def test_build_message_default_layout(
+        self,
+        dbsession,
+        mock_configuration,
+        mock_repo_provider,
+        sample_report_without_flags,
+        sample_comparison,
+    ):
+        mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
+        comparison = sample_comparison
+        pull = comparison.pull
+        notifier = CommentNotifier(
+            repository=sample_comparison.head.commit.repository,
+            title="title",
+            notifier_yaml_settings={},
+            notifier_site_settings=True,
+            current_yaml={"codecov": {"ui": {"hide_complexity": True}}},
+            repository_service=mock_repo_provider,
+        )
+        repository = sample_comparison.head.commit.repository
+        result = notifier.build_message(comparison)
+        expected_result = [
+            f"## [Codecov](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?dropdown=coverage&src=pr&el=h1) Report",
+            "Attention: Patch coverage is `66.66667%` with `1 line` in your changes missing coverage. Please review.",
+            f"> Project coverage is 60.00%. Comparing base [(`{sample_comparison.project_coverage_base.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{sample_comparison.project_coverage_base.commit.commitid}?dropdown=coverage&el=desc) to head [(`{sample_comparison.head.commit.commitid[:7]}`)](test.example.br/gh/{repository.slug}/commit/{sample_comparison.head.commit.commitid}?dropdown=coverage&el=desc).",
+            "",
+        ]
+        for exp, res in zip(expected_result, result):
+            assert exp == res
+        assert result == expected_result
+
     def test_send_actual_notification_spammy(
         self, dbsession, mock_configuration, mock_repo_provider, sample_comparison
     ):


### PR DESCRIPTION
<!-- Describe your PR here. -->
`layout` should be optional - docs [here](https://docs.codecov.com/docs/pull-request-comments#layout)

it's not optional in code and popped up [in sentry](https://codecov.sentry.io/issues/6254154285/events/8c287528c07f464c83068f7fa24a41ef/)

Added a test to show what the comment looks like with no `layout`, using the defaults we have set in code.

