### PR TITLE
Failed check and status messaging in comment, part IV

### DIFF
--- a/services/notification/notifiers/mixins/status.py
+++ b/services/notification/notifiers/mixins/status.py
@@ -28,6 +28,7 @@ class StatusResult(TypedDict):
 CUSTOM_TARGET_TEXT_PATCH_KEY = "custom_target_helper_text_patch"
 CUSTOM_TARGET_TEXT_PROJECT_KEY = "custom_target_helper_text_project"
 CUSTOM_RCB_INDIRECT_CHANGES_KEY = "custom_rcb_indirect_changes_helper_text"
+CUSTOM_RCB_ADJUST_BASE_KEY = "custom_rcb_adjust_base_helper_text"
 CUSTOM_TARGET_TEXT_VALUE = (
     "Your {context} {notification_type} has failed because the {point_of_comparison} coverage ({coverage}%) is below the target coverage ({target}%). "
     "You can increase the {point_of_comparison} coverage or adjust the "
@@ -38,12 +39,19 @@ CUSTOM_RCB_INDIRECT_CHANGES_VALUE = (
     "Learn more about [Unexpected Coverage Changes](https://docs.codecov.com/docs/unexpected-coverage-changes) "
     "and [reasons for indirect coverage changes](https://docs.codecov.com/docs/unexpected-coverage-changes#reasons-for-indirect-changes)."
 )
+CUSTOM_RCB_TEXT_VALUE = (
+    "Your project {notification_type} has failed because the head coverage ({coverage}%) "
+    "is below the [adjusted base coverage](https://docs.codecov.com/docs/removed-code-behavior#option-3-default-adjust_base) ({adjusted_base_cov}%). "
+    "You can increase the head coverage or adjust the "
+    "[Removed Code Behavior](https://docs.codecov.com/docs/removed-code-behavior)."
+)
 
 
 HELPER_TEXT_MAP = {
     CUSTOM_TARGET_TEXT_PATCH_KEY: CUSTOM_TARGET_TEXT_VALUE,
     CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE,
     CUSTOM_RCB_INDIRECT_CHANGES_KEY: CUSTOM_RCB_INDIRECT_CHANGES_VALUE,
+    CUSTOM_RCB_ADJUST_BASE_KEY: CUSTOM_RCB_TEXT_VALUE,
 }
 
 
@@ -229,13 +237,16 @@ class StatusProjectMixin(object):
         return None
 
     def _apply_adjust_base_behavior(
-        self, comparison: ComparisonProxy | FilteredComparison
-    ) -> tuple[str, str] | None:
+        self,
+        comparison: ComparisonProxy | FilteredComparison,
+        notification_type: str,
+    ) -> tuple[tuple[str, str] | None, dict]:
         """
         Rule for passing project status on adjust_base behavior:
         We adjust the BASE of the comparison by removing from it lines that were removed in HEAD
         And then re-calculate BASE coverage and compare it to HEAD coverage.
         """
+        helper_text = {}
         log.info(
             "Applying adjust_base behavior to project status",
             extra=dict(commit=comparison.head.commit.commitid),
@@ -248,7 +259,7 @@ class StatusProjectMixin(object):
                 "Notifier settings specify target value. Skipping adjust_base.",
                 extra=dict(commit=comparison.head.commit.commitid),
             )
-            return None
+            return None, helper_text
 
         impacted_files = comparison.get_impacted_files().get("files", [])
 
@@ -278,7 +289,7 @@ class StatusProjectMixin(object):
         )
 
         if not base_adjusted_totals:
-            return None
+            return None, helper_text
 
         # The coverage info is in percentage, so multiply by 100
         base_adjusted_coverage = (
@@ -303,19 +314,34 @@ class StatusProjectMixin(object):
         quantized_base_adjusted_coverage = base_adjusted_coverage.quantize(
             Decimal("0.00000")
         )
+        rounded_base_adjusted_coverage = round_number(
+            self.current_yaml, base_adjusted_coverage
+        )
+
         if quantized_base_adjusted_coverage - head_coverage < Decimal("0.005"):
             rounded_difference = max(
                 0,
                 round_number(self.current_yaml, head_coverage - base_adjusted_coverage),
             )
-            rounded_base_adjusted_coverage = round_number(
-                self.current_yaml, base_adjusted_coverage
-            )
             return (
-                StatusState.success.value,
-                f", passed because coverage increased by {rounded_difference}% when compared to adjusted base ({rounded_base_adjusted_coverage}%)",
+                (
+                    StatusState.success.value,
+                    f", passed because coverage increased by {rounded_difference}% when compared to adjusted base ({rounded_base_adjusted_coverage}%)",
+                ),
+                helper_text,
             )
-        return None
+        # use rounded numbers for messages
+        coverage_rounded = round_number(self.current_yaml, head_coverage)
+
+        # their comparison failed despite the adjusted base, give them helper text about it
+        helper_text[CUSTOM_RCB_ADJUST_BASE_KEY] = HELPER_TEXT_MAP[
+            CUSTOM_RCB_ADJUST_BASE_KEY
+        ].format(
+            notification_type=notification_type,
+            coverage=coverage_rounded,
+            adjusted_base_cov=rounded_base_adjusted_coverage,
+        )
+        return None, helper_text
 
     def _apply_fully_covered_patch_behavior(
         self,
@@ -387,15 +413,26 @@ class StatusProjectMixin(object):
         # The removed code behavior can change the `state` from `failure` to `success` and add to the `message`.
         # We need both reports to be able to get the diff and apply the removed_code behavior
         if comparison.project_coverage_base.report and comparison.head.report:
+            is_custom_rcb = True
             removed_code_behavior = self.notifier_yaml_settings.get(
-                "removed_code_behavior", self.DEFAULT_REMOVED_CODE_BEHAVIOR
+                "removed_code_behavior", None
             )
+            if removed_code_behavior is None:
+                is_custom_rcb = False
+                removed_code_behavior = self.DEFAULT_REMOVED_CODE_BEHAVIOR
+
             # Apply removed_code_behavior
             removed_code_result = None
             if removed_code_behavior == "removals_only":
                 removed_code_result = self._apply_removals_only_behavior(comparison)
             elif removed_code_behavior == "adjust_base":
-                removed_code_result = self._apply_adjust_base_behavior(comparison)
+                removed_code_result, helper_text = self._apply_adjust_base_behavior(
+                    comparison,
+                    notification_type=notification_type,
+                )
+                if is_custom_rcb:
+                    # if user set this in their yaml, give them helper text related to it
+                    result["included_helper_text"].update(helper_text)
             elif removed_code_behavior == "fully_covered_patch":
                 removed_code_result, helper_text = (
                     self._apply_fully_covered_patch_behavior(

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -21,8 +21,8 @@ from services.notification.notifiers.checks.checks_with_fallback import (
     ChecksWithFallback,
 )
 from services.notification.notifiers.mixins.status import (
-    CUSTOM_TARGET_TEXT_PATCH_KEY,
-    CUSTOM_TARGET_TEXT_VALUE,
+    HelperTextKey,
+    HelperTextTemplate,
 )
 from services.notification.notifiers.status import PatchStatusNotifier
 from tests.helpers import mock_all_plans_and_tiers
@@ -798,7 +798,7 @@ class TestPatchChecksNotifier(object):
                 "annotations": [],
             },
             "included_helper_text": {
-                CUSTOM_TARGET_TEXT_PATCH_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                HelperTextKey.CUSTOM_TARGET_PATCH: HelperTextTemplate.CUSTOM_TARGET.format(
                     context="patch",
                     notification_type="check",
                     point_of_comparison="patch",

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -21,12 +21,9 @@ from services.comparison.types import FullCommit
 from services.decoration import Decoration
 from services.notification.notifiers.base import NotificationResult
 from services.notification.notifiers.mixins.status import (
-    CUSTOM_RCB_INDIRECT_CHANGES_KEY,
-    CUSTOM_RCB_ADJUST_BASE_KEY,
-    CUSTOM_TARGET_TEXT_PATCH_KEY,
-    CUSTOM_TARGET_TEXT_PROJECT_KEY,
-    CUSTOM_TARGET_TEXT_VALUE,
     HELPER_TEXT_MAP,
+    HelperTextKey,
+    HelperTextTemplate,
 )
 from services.notification.notifiers.status import (
     ChangesStatusNotifier,
@@ -1611,9 +1608,9 @@ class TestProjectStatusNotifier(object):
                 (
                     None,
                     {
-                        CUSTOM_RCB_ADJUST_BASE_KEY: HELPER_TEXT_MAP[
-                            CUSTOM_RCB_ADJUST_BASE_KEY
-                        ].format(
+                        HelperTextKey.RCB_ADJUST_BASE.value: HELPER_TEXT_MAP[
+                            HelperTextKey.RCB_ADJUST_BASE
+                        ].value.format(
                             notification_type="status",
                             coverage=94.27,
                             adjusted_base_cov=94.28,
@@ -1744,7 +1741,7 @@ class TestProjectStatusNotifier(object):
             "message": "60.00% (target 80.00%)",
             "state": "failure",
             "included_helper_text": {
-                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                HelperTextKey.CUSTOM_TARGET_PROJECT: HelperTextTemplate.CUSTOM_TARGET.format(
                     context="project",
                     notification_type="status",
                     point_of_comparison="head",
@@ -1798,9 +1795,9 @@ class TestProjectStatusNotifier(object):
             "message": f"50.00% (-10.00%) compared to {sample_comparison.project_coverage_base.commit.commitid[:7]}",
             "state": "failure",
             "included_helper_text": {
-                CUSTOM_RCB_ADJUST_BASE_KEY: HELPER_TEXT_MAP[
-                    CUSTOM_RCB_ADJUST_BASE_KEY
-                ].format(
+                HelperTextKey.RCB_ADJUST_BASE.value: HELPER_TEXT_MAP[
+                    HelperTextKey.RCB_ADJUST_BASE
+                ].value.format(
                     notification_type="status",
                     coverage="50.00",
                     adjusted_base_cov=71.43,
@@ -1880,7 +1877,7 @@ class TestProjectStatusNotifier(object):
             "message": "50.00% (target 80.00%)",
             "state": "failure",
             "included_helper_text": {
-                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                HelperTextKey.CUSTOM_TARGET_PROJECT: HelperTextTemplate.CUSTOM_TARGET.format(
                     context="project",
                     notification_type="status",
                     point_of_comparison="head",
@@ -1912,7 +1909,7 @@ class TestProjectStatusNotifier(object):
             "message": "60.00% (target 80.00%)",
             "state": "failure",
             "included_helper_text": {
-                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                HelperTextKey.CUSTOM_TARGET_PROJECT: HelperTextTemplate.CUSTOM_TARGET.format(
                     context="project",
                     notification_type="status",
                     point_of_comparison="head",
@@ -1973,7 +1970,7 @@ class TestProjectStatusNotifier(object):
             "message": "50.00% (target 70.00%)",
             "state": "failure",
             "included_helper_text": {
-                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                HelperTextKey.CUSTOM_TARGET_PROJECT: HelperTextTemplate.CUSTOM_TARGET.format(
                     context="project",
                     notification_type="status",
                     point_of_comparison="head",
@@ -2035,16 +2032,16 @@ class TestProjectStatusNotifier(object):
             "message": "50.00% (target 70.00%)",
             "state": "failure",
             "included_helper_text": {
-                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                HelperTextKey.CUSTOM_TARGET_PROJECT.value: HelperTextTemplate.CUSTOM_TARGET.value.format(
                     context="project",
                     notification_type="status",
                     point_of_comparison="head",
                     coverage="50.00",
                     target="70.00",
                 ),
-                CUSTOM_RCB_INDIRECT_CHANGES_KEY: HELPER_TEXT_MAP[
-                    CUSTOM_RCB_INDIRECT_CHANGES_KEY
-                ].format(
+                HelperTextKey.RCB_INDIRECT_CHANGES.value: HELPER_TEXT_MAP[
+                    HelperTextKey.RCB_INDIRECT_CHANGES
+                ].value.format(
                     context="project",
                     notification_type="status",
                 ),
@@ -2329,7 +2326,7 @@ class TestPatchStatusNotifier(object):
             "message": "66.67% of diff hit (target 70.00%)",
             "state": "failure",
             "included_helper_text": {
-                CUSTOM_TARGET_TEXT_PATCH_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                HelperTextKey.CUSTOM_TARGET_PATCH: HelperTextTemplate.CUSTOM_TARGET.format(
                     context="patch",
                     notification_type="status",
                     point_of_comparison="patch",

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -22,6 +22,7 @@ from services.decoration import Decoration
 from services.notification.notifiers.base import NotificationResult
 from services.notification.notifiers.mixins.status import (
     CUSTOM_RCB_INDIRECT_CHANGES_KEY,
+    CUSTOM_RCB_ADJUST_BASE_KEY,
     CUSTOM_TARGET_TEXT_PATCH_KEY,
     CUSTOM_TARGET_TEXT_PROJECT_KEY,
     CUSTOM_TARGET_TEXT_VALUE,
@@ -1553,8 +1554,11 @@ class TestProjectStatusNotifier(object):
                     }
                 ],
                 (
-                    "success",
-                    ", passed because coverage increased by 0.02% when compared to adjusted base (94.24%)",
+                    (
+                        "success",
+                        ", passed because coverage increased by 0.02% when compared to adjusted base (94.24%)",
+                    ),
+                    {},
                 ),
                 id="many_removed_hits_makes_head_more_covered_than_base",
             ),
@@ -1579,8 +1583,11 @@ class TestProjectStatusNotifier(object):
                     }
                 ],
                 (
-                    "success",
-                    ", passed because coverage increased by 0% when compared to adjusted base (94.27%)",
+                    (
+                        "success",
+                        ", passed because coverage increased by 0% when compared to adjusted base (94.27%)",
+                    ),
+                    {},
                 ),
                 id="many_removed_hits_makes_head_same_as_base",
             ),
@@ -1601,14 +1608,25 @@ class TestProjectStatusNotifier(object):
                         ]
                     }
                 ],
-                None,
+                (
+                    None,
+                    {
+                        CUSTOM_RCB_ADJUST_BASE_KEY: HELPER_TEXT_MAP[
+                            CUSTOM_RCB_ADJUST_BASE_KEY
+                        ].format(
+                            notification_type="status",
+                            coverage=94.27,
+                            adjusted_base_cov=94.28,
+                        ),
+                    },
+                ),
                 id="not_enough_hits_removed_for_status_to_pass",
             ),
             pytest.param(
                 ReportTotals(hits=0, misses=0, partials=0),
                 ReportTotals(hits=0, misses=0, partials=0, coverage="100"),
                 [],
-                None,
+                (None, {}),
                 id="zero_coverage",
             ),
         ],
@@ -1633,7 +1651,9 @@ class TestProjectStatusNotifier(object):
             current_yaml=settings,
             repository_service={},
         )
-        result = status_mixin._apply_adjust_base_behavior(comparison)
+        result = status_mixin._apply_adjust_base_behavior(
+            comparison, notification_type="status"
+        )
         assert result == expected
 
     def test_notify_pass_adjust_base_behavior(
@@ -1773,6 +1793,61 @@ class TestProjectStatusNotifier(object):
             current_yaml=UserYaml({}),
             repository_service={},
         )
+        # included helper text for this user because they have adjust_base in their yaml
+        expected_result = {
+            "message": f"50.00% (-10.00%) compared to {sample_comparison.project_coverage_base.commit.commitid[:7]}",
+            "state": "failure",
+            "included_helper_text": {
+                CUSTOM_RCB_ADJUST_BASE_KEY: HELPER_TEXT_MAP[
+                    CUSTOM_RCB_ADJUST_BASE_KEY
+                ].format(
+                    notification_type="status",
+                    coverage="50.00",
+                    adjusted_base_cov=71.43,
+                )
+            },
+        }
+        result = notifier.build_payload(sample_comparison)
+        assert result == expected_result
+        mock_get_impacted_files.assert_called()
+
+    def test_notify_rcb_default(
+        self, mock_configuration, sample_comparison_negative_change, mocker
+    ):
+        sample_comparison = sample_comparison_negative_change
+        mock_get_impacted_files = mocker.patch.object(
+            ComparisonProxy,
+            "get_impacted_files",
+            return_value={
+                "files": [
+                    {
+                        "base_name": "tests/file1.py",
+                        "head_name": "tests/file1.py",
+                        # Not complete, but we only care about these fields
+                        "removed_diff_coverage": [[1, "h"], [3, "m"], [4, "m"]],
+                        "added_diff_coverage": [],
+                        "unexpected_line_changes": [],
+                    },
+                    {
+                        "base_name": "tests/file2.go",
+                        "head_name": "tests/file2.go",
+                        "removed_diff_coverage": [],
+                        "added_diff_coverage": [],
+                        "unexpected_line_changes": [],
+                    },
+                ],
+            },
+        )
+        mock_configuration.params["setup"]["codecov_dashboard_url"] = "test.example.br"
+        notifier = ProjectStatusNotifier(
+            repository=sample_comparison.head.commit.repository,
+            title="title",
+            notifier_yaml_settings={},
+            notifier_site_settings=True,
+            current_yaml=UserYaml({}),
+            repository_service={},
+        )
+        # NO helper text for this user because they have NOT specified adjust_base in their yaml
         expected_result = {
             "message": f"50.00% (-10.00%) compared to {sample_comparison.project_coverage_base.commit.commitid[:7]}",
             "state": "failure",

--- a/services/notification/tests/unit/test_notification_service.py
+++ b/services/notification/tests/unit/test_notification_service.py
@@ -31,9 +31,8 @@ from services.notification.notifiers.checks.checks_with_fallback import (
     ChecksWithFallback,
 )
 from services.notification.notifiers.mixins.status import (
-    CUSTOM_TARGET_TEXT_PATCH_KEY,
-    CUSTOM_TARGET_TEXT_PROJECT_KEY,
-    CUSTOM_TARGET_TEXT_VALUE,
+    HelperTextKey,
+    HelperTextTemplate,
 )
 from tests.helpers import mock_all_plans_and_tiers
 
@@ -774,7 +773,7 @@ class TestNotificationService(object):
                 "annotations": [],
             },
             "included_helper_text": {
-                CUSTOM_TARGET_TEXT_PATCH_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                HelperTextKey.CUSTOM_TARGET_PATCH: HelperTextTemplate.CUSTOM_TARGET.format(
                     context="patch",
                     notification_type="check",
                     point_of_comparison="patch",
@@ -797,7 +796,7 @@ class TestNotificationService(object):
                 "annotations": [],
             },
             "included_helper_text": {
-                CUSTOM_TARGET_TEXT_PROJECT_KEY: CUSTOM_TARGET_TEXT_VALUE.format(
+                HelperTextKey.CUSTOM_TARGET_PROJECT: HelperTextTemplate.CUSTOM_TARGET.format(
                     context="project",
                     notification_type="check",
                     point_of_comparison="head",
@@ -866,11 +865,11 @@ class TestNotificationService(object):
                 assert (
                     ":x: "
                     + checks_patch_result["included_helper_text"][
-                        CUSTOM_TARGET_TEXT_PATCH_KEY
+                        HelperTextKey.CUSTOM_TARGET_PATCH
                     ]
                     and ":x: "
                     + checks_proj_result["included_helper_text"][
-                        CUSTOM_TARGET_TEXT_PROJECT_KEY
+                        HelperTextKey.CUSTOM_TARGET_PROJECT
                     ]
                     in r["result"].data_sent["message"]
                 )


### PR DESCRIPTION
<!-- Describe your PR here. -->
when user has:
project checks notifier OR project status notifier
AND
comment notifier
AND
has defined `removed_code_behavior` as `adjust_base` in their codecov.yml
AND
the project check/status fails
AND
the `adjusted_base` coverage does NOT allow the check/status to pass
THEN
add some helper text to the comment notifier to point out that the check/status failed, with links to `rcb` and `adjust_base` docs, and tell them the coverage on the head vs the adjusted base.


https://github.com/codecov/engineering-team/issues/1607