### PR TITLE
feat: add parallel component computation to timeseries

### DIFF
--- a/services/tests/test_timeseries.py
+++ b/services/tests/test_timeseries.py
@@ -936,6 +936,9 @@ class TestTimeseriesService(object):
         self, dbsession, sample_report, repository, mocker
     ):
         mocker.patch(
+            "tasks.save_commit_measurements.is_timeseries_enabled", return_value=True
+        )
+        mocker.patch(
             "tasks.save_commit_measurements.PARALLEL_COMPONENT_COMPARISON.check_value",
             return_value=False,
         )

--- a/services/timeseries.py
+++ b/services/timeseries.py
@@ -4,7 +4,6 @@ from typing import Any, Iterable, Mapping, Optional
 
 from shared.components import Component
 from shared.reports.readonly import ReadOnlyReport
-from shared.timeseries.helpers import is_timeseries_enabled
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
@@ -12,41 +11,9 @@ from database.models import Commit, Dataset, Measurement, MeasurementName
 from database.models.core import Repository
 from database.models.reports import RepositoryFlag
 from helpers.timeseries import backfill_max_batch_size
-from services.report import ReportService
-from services.yaml import get_repo_yaml
+from services.yaml import UserYaml, get_repo_yaml
 
 log = logging.getLogger(__name__)
-
-
-def save_commit_measurements(
-    commit: Commit, dataset_names: Iterable[str] = None
-) -> None:
-    if not is_timeseries_enabled():
-        return
-
-    if dataset_names is None:
-        dataset_names = [
-            dataset.name for dataset in repository_datasets_query(commit.repository)
-        ]
-    if len(dataset_names) == 0:
-        return
-
-    current_yaml = get_repo_yaml(commit.repository)
-    report_service = ReportService(current_yaml)
-    report = report_service.get_existing_report_for_commit(
-        commit, report_class=ReadOnlyReport
-    )
-
-    if report is None:
-        return
-
-    db_session = commit.get_db_session()
-
-    maybe_upsert_coverage_measurement(commit, dataset_names, db_session, report)
-    maybe_upsert_components_measurements(
-        commit, current_yaml, dataset_names, db_session, report
-    )
-    maybe_upsert_flag_measurements(commit, dataset_names, db_session, report)
 
 
 def maybe_upsert_coverage_measurement(commit, dataset_names, db_session, report):
@@ -65,7 +32,7 @@ def maybe_upsert_coverage_measurement(commit, dataset_names, db_session, report)
 
 def maybe_upsert_flag_measurements(commit, dataset_names, db_session, report):
     if MeasurementName.flag_coverage.value in dataset_names:
-        flag_ids = repository_flag_ids(commit.repository)
+        flag_ids = repository_flag_ids(db_session, commit.repository)
         measurements = []
 
         for flag_name, flag in report.flags.items():
@@ -123,51 +90,47 @@ def find_duplicate_component_ids(components: list[Component], commit: Commit):
     return False
 
 
-def maybe_upsert_components_measurements(
-    commit, current_yaml, dataset_names, db_session, report
+def upsert_components_measurements(
+    commit: Commit,
+    current_yaml: UserYaml,
+    db_session: Session,
+    report: ReadOnlyReport,
 ):
-    if MeasurementName.component_coverage.value in dataset_names:
-        components = current_yaml.get_components()
-        if components:
-            component_measurements = dict()
-            # Check for duplicate component IDs
-            find_duplicate_component_ids(components, commit)
-            for component in components:
-                if component.paths or component.flag_regexes:
-                    report_and_component_matching_flags = component.get_matching_flags(
-                        report.flags.keys()
-                    )
-                    filtered_report = report.filter(
-                        flags=report_and_component_matching_flags, paths=component.paths
-                    )
-                    if filtered_report.totals.coverage is not None:
-                        # This measurement key is being used to check for measurement existence and log the warning.
-                        # TODO: see if we can remove this warning message as it's necessary to emit this warning.
-                        # We're currently not doing anything with this information.
-                        measurement_key = create_component_measurement_key(
-                            commit, component
-                        )
+    component_measurements = dict()
+    components = current_yaml.get_components()
+    for component in components:
+        if component.paths or component.flag_regexes:
+            report_and_component_matching_flags = component.get_matching_flags(
+                list(report.flags.keys())
+            )
+            filtered_report = report.filter(
+                flags=report_and_component_matching_flags,
+                paths=component.paths,
+            )
+            if filtered_report.totals.coverage is not None:
+                # This measurement key is being used to check for measurement existence and log the warning.
+                # TODO: see if we can remove this warning message as it's necessary to emit this warning.
+                # We're currently not doing anything with this information.
+                measurement_key = create_component_measurement_key(commit, component)
 
-                        component_measurements[measurement_key] = (
-                            create_measurement_dict(
-                                MeasurementName.component_coverage.value,
-                                commit,
-                                measurable_id=f"{component.component_id}",
-                                value=float(filtered_report.totals.coverage),
-                            )
-                        )
-
-            measurements = list(component_measurements.values())
-            if len(measurements) > 0:
-                upsert_measurements(db_session, measurements)
-                log.info(
-                    "Upserted component coverage measurements",
-                    extra=dict(
-                        repoid=commit.repoid,
-                        commit_id=commit.id_,
-                        count=len(measurements),
-                    ),
+                component_measurements[measurement_key] = create_measurement_dict(
+                    MeasurementName.component_coverage.value,
+                    commit,
+                    measurable_id=f"{component.component_id}",
+                    value=float(filtered_report.totals.coverage),
                 )
+
+    measurements = list(component_measurements.values())
+    if len(measurements) > 0:
+        upsert_measurements(db_session, measurements)
+        log.info(
+            "Upserted component coverage measurements",
+            extra=dict(
+                repoid=commit.repoid,
+                commit_id=commit.id_,
+                count=len(measurements),
+            ),
+        )
 
 
 def create_measurement_dict(
@@ -251,9 +214,9 @@ def repository_datasets_query(
     return datasets
 
 
-def repository_flag_ids(repository: Repository) -> Mapping[str, int]:
-    db_session = repository.get_db_session()
-
+def repository_flag_ids(
+    db_session: Session, repository: Repository
+) -> Mapping[str, int]:
     repo_flags = (
         db_session.query(RepositoryFlag).filter_by(repository=repository).yield_per(100)
     )

--- a/services/timeseries.py
+++ b/services/timeseries.py
@@ -147,22 +147,6 @@ def maybe_upsert_components_measurements(
                         measurement_key = create_component_measurement_key(
                             commit, component
                         )
-                        if (
-                            existing_measurement := component_measurements.get(
-                                measurement_key
-                            )
-                        ) is not None:
-                            log.warning(
-                                "Duplicate measurement keys being added to measurements",
-                                extra=dict(
-                                    repoid=commit.repoid,
-                                    commit_id=commit.id_,
-                                    commitid=commit.commitid,
-                                    measurement_key=measurement_key,
-                                    existing_value=existing_measurement.get("value"),
-                                    new_value=float(filtered_report.totals.coverage),
-                                ),
-                            )
 
                         component_measurements[measurement_key] = (
                             create_measurement_dict(

--- a/services/timeseries.py
+++ b/services/timeseries.py
@@ -32,7 +32,7 @@ def maybe_upsert_coverage_measurement(commit, dataset_names, db_session, report)
 
 def maybe_upsert_flag_measurements(commit, dataset_names, db_session, report):
     if MeasurementName.flag_coverage.value in dataset_names:
-        flag_ids = repository_flag_ids(db_session, commit.repository)
+        flag_ids = repository_flag_ids(commit.repository)
         measurements = []
 
         for flag_name, flag in report.flags.items():
@@ -214,9 +214,8 @@ def repository_datasets_query(
     return datasets
 
 
-def repository_flag_ids(
-    db_session: Session, repository: Repository
-) -> Mapping[str, int]:
+def repository_flag_ids(repository: Repository) -> Mapping[str, int]:
+    db_session = repository.get_db_session()
     repo_flags = (
         db_session.query(RepositoryFlag).filter_by(repository=repository).yield_per(100)
     )

--- a/services/timeseries.py
+++ b/services/timeseries.py
@@ -72,24 +72,6 @@ def maybe_upsert_flag_measurements(commit, dataset_names, db_session, report):
             upsert_measurements(db_session, measurements)
 
 
-def find_duplicate_component_ids(components: list[Component], commit: Commit):
-    seen_component_ids = {}
-    for component in components:
-        if component.component_id in seen_component_ids:
-            log.warning(
-                "Duplicate component ID found",
-                extra=dict(
-                    repoid=commit.repoid,
-                    commit_id=commit.commitid,
-                    component_id=component.component_id,
-                    first_component_name=seen_component_ids[component.component_id],
-                    duplicate_component_name=component.name,
-                ),
-            )
-        seen_component_ids[component.component_id] = component.name
-    return False
-
-
 def upsert_components_measurements(
     commit: Commit,
     current_yaml: UserYaml,

--- a/services/yaml/__init__.py
+++ b/services/yaml/__init__.py
@@ -30,7 +30,7 @@ def get_repo_yaml(repository: Repository):
     )
 
 
-async def get_current_yaml(commit: Commit, repository_service) -> dict:
+async def get_current_yaml(commit: Commit, repository_service) -> UserYaml:
     """
         Fetches what the current yaml is supposed to be
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -65,3 +65,4 @@ from tasks.update_branches import update_branches_task_name
 from tasks.upload import upload_task
 from tasks.upload_finisher import upload_finisher_task
 from tasks.upload_processor import upload_processor_task
+from tasks.upsert_component import upsert_component_task

--- a/tasks/save_commit_measurements.py
+++ b/tasks/save_commit_measurements.py
@@ -49,9 +49,7 @@ def save_commit_measurements(commit: Commit, dataset_names: Sequence[str]) -> No
     if MeasurementName.component_coverage.value in dataset_names:
         components = current_yaml.get_components()
         if components:
-            if PARALLEL_COMPONENT_COMPARISON.check_value(
-                commit.repository.repoid, True
-            ):
+            if PARALLEL_COMPONENT_COMPARISON.check_value(commit.repository.repoid):
                 task_signatures = []
                 components = current_yaml.get_components()
                 for component in components:

--- a/tasks/tests/integration/test_timeseries_backfill.py
+++ b/tasks/tests/integration/test_timeseries_backfill.py
@@ -10,7 +10,9 @@ from tasks.timeseries_backfill import TimeseriesBackfillCommitsTask
 
 @pytest.mark.integration
 def test_backfill_dataset_run_impl(dbsession, mocker, mock_storage):
-    mocker.patch("services.timeseries.is_timeseries_enabled", return_value=True)
+    mocker.patch(
+        "tasks.save_commit_measurements.is_timeseries_enabled", return_value=True
+    )
     mocker.patch("tasks.timeseries_backfill.is_timeseries_enabled", return_value=True)
     mocked_app = mocker.patch.object(
         TimeseriesBackfillCommitsTask,

--- a/tasks/tests/integration/test_timeseries_backfill.py
+++ b/tasks/tests/integration/test_timeseries_backfill.py
@@ -10,9 +10,6 @@ from tasks.timeseries_backfill import TimeseriesBackfillCommitsTask
 
 @pytest.mark.integration
 def test_backfill_dataset_run_impl(dbsession, mocker, mock_storage):
-    mocker.patch(
-        "tasks.save_commit_measurements.is_timeseries_enabled", return_value=True
-    )
     mocker.patch("tasks.timeseries_backfill.is_timeseries_enabled", return_value=True)
     mocked_app = mocker.patch.object(
         TimeseriesBackfillCommitsTask,

--- a/tasks/tests/unit/test_save_commit_measurements.py
+++ b/tasks/tests/unit/test_save_commit_measurements.py
@@ -1,4 +1,5 @@
 from database.tests.factories.core import CommitFactory, OwnerFactory, RepositoryFactory
+from services.timeseries import MeasurementName
 from tasks.save_commit_measurements import SaveCommitMeasurementsTask
 
 
@@ -21,10 +22,20 @@ class TestSaveCommitMeasurements(object):
 
         task = SaveCommitMeasurementsTask()
         assert task.run_impl(
-            dbsession, commitid=commit.commitid, repoid=commit.repoid
+            dbsession,
+            commitid=commit.commitid,
+            repoid=commit.repoid,
+            dataset_names=[
+                MeasurementName.coverage.value,
+                MeasurementName.flag_coverage.value,
+            ],
         ) == {"successful": True}
         save_commit_measurements_mock.assert_called_with(
-            commit=commit, dataset_names=None
+            commit=commit,
+            dataset_names=[
+                MeasurementName.coverage.value,
+                MeasurementName.flag_coverage.value,
+            ],
         )
 
     def test_save_commit_measurements_no_commit(self, dbsession):
@@ -59,7 +70,13 @@ class TestSaveCommitMeasurements(object):
 
         task = SaveCommitMeasurementsTask()
         assert task.run_impl(
-            dbsession, commitid=commit.commitid, repoid=commit.repoid
+            dbsession,
+            commitid=commit.commitid,
+            repoid=commit.repoid,
+            dataset_names=[
+                MeasurementName.coverage.value,
+                MeasurementName.flag_coverage.value,
+            ],
         ) == {
             "successful": False,
             "error": "exception",

--- a/tasks/upsert_component.py
+++ b/tasks/upsert_component.py
@@ -1,0 +1,138 @@
+import logging
+from datetime import datetime
+from typing import TypedDict
+
+from asgiref.sync import async_to_sync
+from shared.reports.readonly import ReadOnlyReport
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import Session
+
+from app import celery_app
+from database.models import Commit, Measurement, MeasurementName
+from helpers.github_installation import get_installation_name_for_owner_for_task
+from services.report import ReportService
+from services.repository import get_repo_provider_service
+from services.yaml import UserYaml, get_current_yaml
+from tasks.base import BaseCodecovTask
+
+log = logging.getLogger(__name__)
+
+
+class MeasurementDict(TypedDict):
+    name: str
+    owner_id: int
+    repo_id: int
+    measurable_id: str
+    branch: str
+    commit_sha: str
+    timestamp: datetime
+    value: float
+
+
+def create_measurement_dict(
+    name: str, commit: Commit, measurable_id: str, value: float
+) -> MeasurementDict:
+    return {
+        "name": name,
+        "owner_id": commit.repository.ownerid,
+        "repo_id": commit.repoid,
+        "measurable_id": measurable_id,
+        "branch": commit.branch,
+        "commit_sha": commit.commitid,
+        "timestamp": commit.timestamp,
+        "value": value,
+    }
+
+
+def upsert_measurements(
+    db_session: Session, measurements: list[MeasurementDict]
+) -> None:
+    command = insert(Measurement.__table__).values(measurements)
+    command = command.on_conflict_do_update(
+        index_elements=[
+            Measurement.name,
+            Measurement.owner_id,
+            Measurement.repo_id,
+            Measurement.measurable_id,
+            Measurement.commit_sha,
+            Measurement.timestamp,
+        ],
+        set_=dict(
+            branch=command.excluded.branch,
+            value=command.excluded.value,
+        ),
+    )
+    db_session.execute(command)
+    db_session.flush()
+
+
+class UpsertComponentTask(BaseCodecovTask):
+    def run_impl(
+        self,
+        db_session: Session,
+        commitid: str,
+        repoid: int,
+        component_id: str,
+        *args,
+        **kwargs,
+    ):
+        log.info("Upserting component", extra=dict(commitid=commitid, repoid=repoid))
+
+        commit = (
+            db_session.query(Commit)
+            .filter(Commit.repoid == repoid, Commit.commitid == commitid)
+            .first()
+        )
+
+        installation_name_to_use = get_installation_name_for_owner_for_task(
+            self.name, commit.repository.owner
+        )
+
+        repository_service = get_repo_provider_service(
+            commit.repository, installation_name_to_use=installation_name_to_use
+        )
+
+        yaml: UserYaml = async_to_sync(get_current_yaml)(commit, repository_service)
+
+        components = yaml.get_components()
+
+        report_service = ReportService(yaml)
+        report = report_service.get_existing_report_for_commit(
+            commit, report_class=ReadOnlyReport
+        )
+
+        if report is None:
+            log.warning(
+                "Upsert Component: No report found for commit",
+                extra=dict(
+                    component_id=component_id,
+                    commitid=commitid,
+                    repoid=repoid,
+                ),
+            )
+            return
+
+        component_dict = {component.component_id: component for component in components}
+
+        component = component_dict[component_id]
+
+        if component.paths or component.flag_regexes:
+            report_and_component_matching_flags = component.get_matching_flags(
+                list(report.flags.keys())
+            )
+            filtered_report = report.filter(
+                flags=report_and_component_matching_flags, paths=component.paths
+            )
+            if filtered_report.totals.coverage is not None:
+                measurement = create_measurement_dict(
+                    MeasurementName.component_coverage.value,
+                    commit,
+                    measurable_id=f"{component.component_id}",
+                    value=float(filtered_report.totals.coverage),
+                )
+
+                upsert_measurements(db_session, [measurement])
+
+
+registered_task = celery_app.register_task(UpsertComponentTask())
+upsert_component_task = celery_app.tasks[registered_task.name]


### PR DESCRIPTION
similar to what i just did with the compute component task
when it comes time to upserting measurements in the save_commit_measurements
task, i added a feature flag and behind that feature flag i altered the
behaviour so that instead of upserting the measurements for each component
sequentially it will queue up a task for each component so that they can upsert
in parallel

I had to reorganize the code to avoid some circular imports hence save_commit_measurements
the function, being moved to tasks/save_commit_measurements.py