### PR TITLE
Failed check and status messaging in comment, part VI

### DIFF
--- a/services/notification/notifiers/checks/changes.py
+++ b/services/notification/notifiers/checks/changes.py
@@ -1,40 +1,55 @@
 from database.enums import Notification
 from services.comparison import ComparisonProxy, FilteredComparison
-from services.notification.notifiers.checks.base import ChecksNotifier
+from services.notification.notifiers.checks.base import (
+    CheckOutput,
+    CheckResult,
+    ChecksNotifier,
+)
 from services.notification.notifiers.mixins.status import StatusChangesMixin
 
 
 class ChangesChecksNotifier(StatusChangesMixin, ChecksNotifier):
     context = "changes"
+    notification_type_display_name = "check"
 
     @property
     def notification_type(self) -> Notification:
         return Notification.checks_changes
 
-    def build_payload(self, comparison: ComparisonProxy | FilteredComparison) -> dict:
+    def build_payload(
+        self, comparison: ComparisonProxy | FilteredComparison
+    ) -> CheckResult:
         if self.is_empty_upload():
             state, message = self.get_status_check_for_empty_upload()
-            return {
-                "state": state,
-                "output": {
-                    "title": "Empty Upload",
-                    "summary": message,
-                },
-            }
-        state, message = self.get_changes_status(comparison)
+            return CheckResult(
+                state=state,
+                output=CheckOutput(
+                    title="Empty Upload",
+                    summary=message,
+                    annotations=[],
+                ),
+                included_helper_text={},
+            )
+
+        status_result = self.get_changes_status(
+            comparison, notification_type=self.notification_type_display_name
+        )
         codecov_link = self.get_codecov_pr_link(comparison)
 
-        title = message
+        title = status_result["message"]
+        message = status_result["message"]
 
         should_use_upgrade = self.should_use_upgrade_decoration()
         if should_use_upgrade:
             message = self.get_upgrade_message(comparison)
             title = "Codecov Report"
 
-        return {
-            "state": state,
-            "output": {
-                "title": f"{title}",
-                "summary": "\n\n".join([codecov_link, message]),
-            },
-        }
+        return CheckResult(
+            state=status_result["state"],
+            output=CheckOutput(
+                title=title,
+                summary="\n\n".join([codecov_link, message]),
+                annotations=[],
+            ),
+            included_helper_text={},
+        )

--- a/services/notification/notifiers/status/changes.py
+++ b/services/notification/notifiers/status/changes.py
@@ -2,7 +2,10 @@ import logging
 
 from database.enums import Notification
 from services.comparison import ComparisonProxy, FilteredComparison
-from services.notification.notifiers.mixins.status import StatusChangesMixin
+from services.notification.notifiers.mixins.status import (
+    StatusChangesMixin,
+    StatusResult,
+)
 from services.notification.notifiers.status.base import StatusNotifier
 
 log = logging.getLogger(__name__)
@@ -22,17 +25,22 @@ class ChangesStatusNotifier(StatusChangesMixin, StatusNotifier):
     """
 
     context = "changes"
+    notification_type_display_name = "status"
 
     @property
     def notification_type(self) -> Notification:
         return Notification.status_changes
 
-    def build_payload(self, comparison: ComparisonProxy | FilteredComparison) -> dict:
+    def build_payload(
+        self, comparison: ComparisonProxy | FilteredComparison
+    ) -> StatusResult:
         if self.is_empty_upload():
             state, message = self.get_status_check_for_empty_upload()
-            return {"state": state, "message": message}
-        state, message = self.get_changes_status(comparison)
+            return StatusResult(state=state, message=message, included_helper_text={})
+        result = self.get_changes_status(
+            comparison, notification_type=self.notification_type_display_name
+        )
         if self.should_use_upgrade_decoration():
-            message = self.get_upgrade_message()
+            result["message"] = self.get_upgrade_message()
 
-        return {"state": state, "message": message}
+        return result

--- a/services/notification/notifiers/tests/unit/test_checks.py
+++ b/services/notification/notifiers/tests/unit/test_checks.py
@@ -1345,7 +1345,9 @@ class TestChangesChecksNotifier(object):
             "output": {
                 "title": "No indirect coverage changes found",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nNo indirect coverage changes found",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -1372,7 +1374,9 @@ class TestChangesChecksNotifier(object):
             "output": {
                 "title": "Codecov Report",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_upgrade_payload/{sample_comparison.head.commit.repository.name}/pull/{sample_comparison.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nThe author of this PR, codecov-test-user, is not an activated member of this organization on Codecov.\nPlease [activate this user on Codecov](test.example.br/members/gh/test_build_upgrade_payload) to display a detailed status check.\nCoverage data is still being uploaded to Codecov.io for purposes of overall coverage calculations.\nPlease don't hesitate to email us at support@codecov.io with any questions.",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -1401,7 +1405,9 @@ class TestChangesChecksNotifier(object):
             "output": {
                 "title": "3 files have indirect coverage changes not visible in diff",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_with_multiple_changes/{comparison_with_multiple_changes.head.commit.repository.name}/pull/{comparison_with_multiple_changes.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\n3 files have indirect coverage changes not visible in diff",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison_with_multiple_changes)
         assert expected_result == result
@@ -1427,7 +1433,9 @@ class TestChangesChecksNotifier(object):
             "output": {
                 "title": "Unable to determine changes, no report found at pull request base",
                 "summary": f"[View this Pull Request on Codecov](test.example.br/gh/test_build_payload_without_base_report/{sample_comparison_without_base_report.head.commit.repository.name}/pull/{sample_comparison_without_base_report.pull.pullid}?dropdown=coverage&src=pr&el=h1)\n\nUnable to determine changes, no report found at pull request base",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison)
         assert expected_result == result
@@ -1453,7 +1461,9 @@ class TestChangesChecksNotifier(object):
             "output": {
                 "title": "Empty Upload",
                 "summary": "Testable files changed",
+                "annotations": [],
             },
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result

--- a/services/notification/notifiers/tests/unit/test_status.py
+++ b/services/notification/notifiers/tests/unit/test_status.py
@@ -2658,6 +2658,7 @@ class TestChangesStatusNotifier(object):
         expected_result = {
             "message": "No indirect coverage changes found",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2678,6 +2679,7 @@ class TestChangesStatusNotifier(object):
         expected_result = {
             "message": "Please activate this user to display a detailed status check",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result
@@ -2704,6 +2706,13 @@ class TestChangesStatusNotifier(object):
         expected_result = {
             "message": "3 files have indirect coverage changes not visible in diff",
             "state": "failure",
+            "included_helper_text": {
+                "indirect_changes_helper_text": (
+                    "Your changes status has failed because you have indirect coverage changes. "
+                    "Learn more about [Unexpected Coverage Changes](https://docs.codecov.com/docs/unexpected-coverage-changes) "
+                    "and [reasons for indirect coverage changes](https://docs.codecov.com/docs/unexpected-coverage-changes#reasons-for-indirect-changes)."
+                )
+            },
         }
         result = notifier.build_payload(comparison_with_multiple_changes)
         assert expected_result == result
@@ -2727,6 +2736,7 @@ class TestChangesStatusNotifier(object):
         expected_result = {
             "message": "Unable to determine changes, no report found at pull request base",
             "state": "success",
+            "included_helper_text": {},
         }
         result = notifier.build_payload(comparison)
         assert expected_result == result
@@ -2750,6 +2760,7 @@ class TestChangesStatusNotifier(object):
             "message": "No indirect coverage changes found",
             "state": "success",
             "url": f"test.example.br/gh/{sample_comparison.head.commit.repository.slug}/pull/{sample_comparison.pull.pullid}",
+            "included_helper_text": {},
         }
         result = notifier.notify(sample_comparison)
         assert result == mocked_send_notification.return_value
@@ -2768,6 +2779,10 @@ class TestChangesStatusNotifier(object):
             repository_service=mock_repo_provider,
             decoration_type=Decoration.passing_empty_upload,
         )
-        expected_result = {"state": "success", "message": "Non-testable files changed."}
+        expected_result = {
+            "state": "success",
+            "message": "Non-testable files changed.",
+            "included_helper_text": {},
+        }
         result = notifier.build_payload(sample_comparison)
         assert expected_result == result

--- a/tasks/tests/integration/test_notify_task.py
+++ b/tasks/tests/integration/test_notify_task.py
@@ -474,6 +474,9 @@ class TestNotifyTask(object):
                             "title": "codecov/changes",
                             "state": "failure",
                             "message": "1 file has indirect coverage changes not visible in diff",
+                            "included_helper_text": {
+                                "indirect_changes_helper_text": "Your changes status has failed because you have indirect coverage changes. Learn more about [Unexpected Coverage Changes](https://docs.codecov.com/docs/unexpected-coverage-changes) and [reasons for indirect coverage changes](https://docs.codecov.com/docs/unexpected-coverage-changes#reasons-for-indirect-changes)."
+                            },
                         },
                         data_received={"id": 9333281703},
                     ),


### PR DESCRIPTION
when user has:
changes checks notifier OR changes status notifier
AND
comment notifier
AND
the change check/status fails
AND
there are unexpected/indirect changes
THEN
add some helper text to the comment notifier to point out that the check/status failed, with links to docs

https://github.com/codecov/engineering-team/issues/1627