### PR TITLE
fix: change get_or_create_author() to upsert_author(). track username/name/email changes

### DIFF
--- a/services/repository.py
+++ b/services/repository.py
@@ -291,16 +291,16 @@ def upsert_author(
 
     if author:
         needs_update = False
-        if author.username != username and username != None:
+        if author.username != username and username is not None:
             author.username = username
             needs_update = True
-        if author.name != name and name != None:
+        if author.name != name and name is not None:
             author.name = name
             needs_update = True
-        if author.email != email and email != None:
+        if author.email != email and email is not None:
             author.email = email
             needs_update = True
-        
+
         if needs_update:
             db_session.commit()
     else:

--- a/services/repository.py
+++ b/services/repository.py
@@ -291,6 +291,7 @@ def upsert_author(
 
     if author:
         needs_update = False
+        db_session.begin(nested=True)
         if author.username != username and username is not None:
             author.username = username
             needs_update = True
@@ -303,6 +304,8 @@ def upsert_author(
 
         if needs_update:
             db_session.commit()
+        else:
+            db_session.rollback()
     else:
         db_session.begin(nested=True)
         try:

--- a/services/repository.py
+++ b/services/repository.py
@@ -216,7 +216,7 @@ async def update_commit_from_provider_info(
             ),
         )
     else:
-        commit_author = get_or_create_author(
+        commit_author = upsert_author(
             db_session,
             commit.repository.service,
             author_info["id"],
@@ -281,37 +281,50 @@ async def update_commit_from_provider_info(
     db_session.commit()
 
 
-def get_or_create_author(
+def upsert_author(
     db_session, service, service_id, username, email=None, name=None
 ) -> Owner:
     query = db_session.query(Owner).filter(
         Owner.service == service, Owner.service_id == str(service_id)
     )
     author = query.first()
-    if author:
-        return author
 
-    db_session.begin(nested=True)
-    try:
-        author = Owner(
-            service=service,
-            service_id=str(service_id),
-            username=username,
-            name=name,
-            email=email,
-            createstamp=datetime.now(),
-        )
-        db_session.add(author)
-        db_session.commit()
-        return author
-    except IntegrityError:
-        log.warning(
-            "IntegrityError in get_or_create_author",
-            extra=dict(service=service, service_id=service_id, username=username),
-        )
-        db_session.rollback()
-        author = query.one()
-        return author
+    if author:
+        needs_update = False
+        if author.username != username and username != None:
+            author.username = username
+            needs_update = True
+        if author.name != name and name != None:
+            author.name = name
+            needs_update = True
+        if author.email != email and email != None:
+            author.email = email
+            needs_update = True
+        
+        if needs_update:
+            db_session.commit()
+    else:
+        db_session.begin(nested=True)
+        try:
+            author = Owner(
+                service=service,
+                service_id=str(service_id),
+                username=username,
+                name=name,
+                email=email,
+                createstamp=datetime.now(),
+            )
+            db_session.add(author)
+            db_session.commit()
+        except IntegrityError:
+            log.warning(
+                "IntegrityError in upsert_author",
+                extra=dict(service=service, service_id=service_id, username=username),
+            )
+            db_session.rollback()
+            author = query.one()
+
+    return author
 
 
 WEBHOOK_EVENTS = {
@@ -541,7 +554,7 @@ async def fetch_and_update_pull_request_information(
     pull.compared_to = compared_to
 
     if pull is not None and not pull.author:
-        pr_author = get_or_create_author(
+        pr_author = upsert_author(
             db_session,
             repository_service.service,
             pull_information["author"]["id"],

--- a/services/tests/test_repository_service.py
+++ b/services/tests/test_repository_service.py
@@ -747,30 +747,30 @@ def test_upsert_author_doesnt_exist(dbsession):
 
 
 def test_upsert_author_already_exists(dbsession):
+    username = "username"
+    email = "email@email.com"
+    service = "bitbucket"
+    service_id = "975"
     owner = OwnerFactory.create(
-        service="bitbucket",
-        service_id="975",
-        email="different_email@email.com",
-        username="whoknew",
+        service=service,
+        service_id=service_id,
+        email=email,
+        username=username,
         yaml=dict(a=["12", "3"]),
     )
     dbsession.add(owner)
     dbsession.flush()
-    service = "bitbucket"
-    author_id = "975"
-    username = "username"
-    email = "email"
-    name = "name"
-    author = upsert_author(dbsession, service, author_id, username, email, name)
+
+    author = upsert_author(dbsession, service, service_id, username, None, None)
     dbsession.flush()
     assert author.ownerid == owner.ownerid
     assert author.free == 0
     assert author is not None
-    assert author.service == "bitbucket"
-    assert author.service_id == "975"
+    assert author.service == service
+    assert author.service_id == service_id
     assert author.name == owner.name
-    assert author.email == "different_email@email.com"
-    assert author.username == "whoknew"
+    assert author.email == email
+    assert author.username == username
     assert author.plan_activated_users == []
     assert author.admins == []
     assert author.permission == []

--- a/services/tests/test_repository_service.py
+++ b/services/tests/test_repository_service.py
@@ -41,10 +41,10 @@ from services.repository import (
     fetch_and_update_pull_request_information_from_commit,
     fetch_appropriate_parent_for_commit,
     fetch_commit_yaml_and_possibly_store,
-    upsert_author,
     get_repo_provider_service,
     get_repo_provider_service_by_id,
     update_commit_from_provider_info,
+    upsert_author,
 )
 from tasks.notify import get_repo_provider_service_for_specific_commit
 
@@ -798,7 +798,9 @@ def test_upsert_author_needs_update(dbsession):
     new_name = "Newt Namenheim"
     new_username = "new_username"
     new_email = "new_email@email.com"
-    author = upsert_author(dbsession, service, service_id, new_username, new_email, new_name)
+    author = upsert_author(
+        dbsession, service, service_id, new_username, new_email, new_name
+    )
     dbsession.flush()
 
     assert author is not None


### PR DESCRIPTION
fixes https://github.com/codecov/engineering-team/issues/3289

i rearranged the function a little bit but the only change is that, if the owner already exists, we will make sure `owner.username`, `owner.name`, and `owner.email` are updated and then commit if anything changed.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.