### PR TITLE
Further simplify Component Measurements

### DIFF
--- a/services/tests/test_timeseries.py
+++ b/services/tests/test_timeseries.py
@@ -726,7 +726,9 @@ class TestTimeseriesService(object):
         assert measurement.branch == "foo"
         assert measurement.value == 50.0
 
-    def test_commit_measurement_no_datasets(self, dbsession, dataset_names, mocker):
+    def test_commit_measurement_no_datasets(
+        self, mock_storage, dbsession, dataset_names, mocker
+    ):
         mocker.patch(
             "tasks.save_commit_measurements.PARALLEL_COMPONENT_COMPARISON.check_value",
             return_value=False,

--- a/services/timeseries.py
+++ b/services/timeseries.py
@@ -86,14 +86,14 @@ def get_relevant_components(
     if not components:
         return []
 
-    components_for_measurement = []
+    components_for_measurement = {}
     for component in components:
         if component.paths or component.flag_regexes:
             flags = component.get_matching_flags(report_flags)
-            components_for_measurement.append(
+            components_for_measurement[component.component_id] = (
                 ComponentForMeasurement(component.component_id, flags, component.paths)
             )
-    return components_for_measurement
+    return list(components_for_measurement.values())
 
 
 def upsert_components_measurements(

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -12,6 +12,7 @@ from shared.celery_config import (
     compute_comparison_task_name,
     notify_task_name,
     pulls_task_name,
+    timeseries_save_commit_measurements_task_name,
     upload_finisher_task_name,
 )
 from shared.reports.resources import Report
@@ -43,7 +44,6 @@ from services.repository import get_repo_provider_service
 from services.timeseries import repository_datasets_query
 from services.yaml import read_yaml_field
 from tasks.base import BaseCodecovTask
-from tasks.save_commit_measurements import save_commit_measurements_task
 from tasks.upload_processor import MAX_RETRIES, UPLOAD_PROCESSING_LOCK_NAME
 
 log = logging.getLogger(__name__)
@@ -160,12 +160,15 @@ class UploadFinisherTask(BaseCodecovTask, name=upload_finisher_task_name):
                         for dataset in repository_datasets_query(repository)
                     ]
                     if dataset_names:
-                        task = save_commit_measurements_task.s(
-                            commitid=commitid,
-                            repoid=repoid,
-                            dataset_names=dataset_names,
+                        self.app.tasks[
+                            timeseries_save_commit_measurements_task_name
+                        ].apply_async(
+                            kwargs=dict(
+                                commitid=commitid,
+                                repoid=repoid,
+                                dataset_names=dataset_names,
+                            )
                         )
-                        task.apply_async()
 
                 # Mark the repository as updated so it will appear earlier in the list
                 # of recently-active repositories


### PR DESCRIPTION
This primarily moves the component filtering to a separate function, and removes a bunch of unnecessary code.

It now asserts preconditions instead of logging warnings, and removes the component deduplication code which I believe to not be relevant.