### PR TITLE
fix: N+1 query for plans / tiers

### DIFF
--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Callable, List, Mapping, Optional
 
 from shared.django_apps.core.models import Repository
-from shared.plan.constants import PlanName
+from shared.plan.constants import TierName
 from shared.plan.service import PlanService
 from shared.reports.resources import ReportTotals
 from shared.validation.helpers import LayoutStructure
@@ -91,10 +91,7 @@ class MessageMixin(object):
 
         # Separate PR comment based on plan that can't/won't be tweaked by codecov.yml settings
         owner_plan = PlanService(owner)
-        if owner_plan.plan_name in {
-            PlanName.TEAM_MONTHLY.value,
-            PlanName.TEAM_YEARLY.value,
-        }:
+        if owner_plan.tier_name == TierName.TEAM.value:
             return self._team_plan_notification(
                 comparison=comparison,
                 message=message,


### PR DESCRIPTION
This PR aims to fix an N+1 query that was introduced when swapping to the plan model as the source of truth from the consts in shared for the same.

Previously we were calling the plan query n number of times depending on how many values get returned in line 179 here:

https://github.com/codecov/worker/blob/2508bbccd03eee0eca3624b6ea73fba1b8aa049c/services/notification/__init__.py#L179-L185

This cascaded down to https://github.com/codecov/worker/blob/2508bbccd03eee0eca3624b6ea73fba1b8aa049c/services/notification/__init__.py#L93-L94 and 
https://github.com/codecov/worker/blob/2508bbccd03eee0eca3624b6ea73fba1b8aa049c/services/notification/__init__.py#L73-L74 where since plan wasn't persisted on the NotificationService we were calling the query every single time.

My fix is to persist the plan on the NotificationService object so if it exists we skip calling the query and just use that reference instead. I tested this against some of the existing UTs with prints to confirm the plan was persisted as I expected.


Closes https://github.com/codecov/internal-issues/issues/1195

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.