### PR TITLE
dev: Add default plan name var

### DIFF
--- a/django_scaffold/settings.py
+++ b/django_scaffold/settings.py
@@ -47,6 +47,8 @@ TELEMETRY_TIMESCALE_DB = "timeseries"
 
 SKIP_RISKY_MIGRATION_STEPS = get_config("migrations", "skip_risky_steps", default=False)
 
+DEFAULT_PLAN_NAME = get_config("setup", "default_plan_name", default="users-developer")
+
 MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",


### PR DESCRIPTION
Add default plan name var to worker so it doesn't break when we merge https://github.com/codecov/shared/pull/495


<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.