### PR TITLE
Fix regular cleanup job

### DIFF
--- a/celery_config.py
+++ b/celery_config.py
@@ -98,7 +98,7 @@ def _beat_schedule():
         },
         "regular_cleanup": {
             "task": regular_cleanup_cron_task_name,
-            "schedule": crontab(minute="0", hour="2"),
+            "schedule": crontab(minute="0", hour="4"),
             "kwargs": {
                 "cron_task_generation_time_iso": BeatLazyFunc(get_utc_now_as_iso_format)
             },

--- a/tasks/regular_cleanup.py
+++ b/tasks/regular_cleanup.py
@@ -15,7 +15,7 @@ class RegularCleanupTask(BaseCodecovTask, name=regular_cleanup_cron_task_name):
     acks_late = True  # retry the task when the worker dies for whatever reason
     max_retries = None  # aka, no limit on retries
 
-    def run_cron_task(self, _db_session, *args, **kwargs) -> CleanupSummary:
+    def run_impl(self, _db_session, *args, **kwargs) -> CleanupSummary:
         try:
             return run_regular_cleanup()
         except SoftTimeLimitExceeded:


### PR DESCRIPTION
The main task fn is named differently for `BaseCodecovTask` that this task is using.

Also moves the schedule to our daily traffic low.