### PR TITLE
refactor: improve test results finisher notify logic

### DIFF
--- a/services/test_results.py
+++ b/services/test_results.py
@@ -21,7 +21,7 @@ from database.models import (
     Upload,
     UploadError,
 )
-from helpers.notifier import BaseNotifier
+from helpers.notifier import BaseNotifier, NotifierResult
 from rollouts import FLAKY_TEST_DETECTION
 from services.license import requires_license
 from services.processing.types import UploadArguments
@@ -400,6 +400,18 @@ class TestResultsNotifier(BaseNotifier):
             return (False, "torngit_error")
 
         return (True, "comment_posted")
+
+    def notify(self):
+        assert self._pull
+        pull = self._pull
+
+        message = self.build_message()
+
+        sent_to_provider = self.send_to_provider(pull, message)
+        if sent_to_provider == False:
+            return NotifierResult.TORNGIT_ERROR
+
+        return NotifierResult.COMMENT_POSTED
 
 
 def latest_failures_for_commit(

--- a/services/tests/test_test_results.py
+++ b/services/tests/test_test_results.py
@@ -209,7 +209,7 @@ def test_notify(mocker):
         "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
         return_value=mock.Mock(),
     )
-    tn = TestResultsNotifier(CommitFactory(), None)
+    tn = TestResultsNotifier(CommitFactory(), None, _pull=mock.Mock())
     tn.build_message = mock.Mock()
     tn.send_to_provider = mock.Mock()
 
@@ -226,29 +226,13 @@ def test_notify_fail_torngit_error(
         "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
         return_value=mock.Mock(),
     )
-    tn = TestResultsNotifier(CommitFactory(), None)
+    tn = TestResultsNotifier(CommitFactory(), None, _pull=mock.Mock())
     tn.build_message = mock.Mock()
     tn.send_to_provider = mock.Mock(return_value=False)
 
     notification_result = tn.notify()
 
     assert notification_result == NotifierResult.TORNGIT_ERROR
-
-
-def test_notify_fail_no_pull(
-    mocker,
-):
-    mocker.patch("helpers.notifier.get_repo_provider_service", return_value=mock.Mock())
-    mocker.patch(
-        "helpers.notifier.fetch_and_update_pull_request_information_from_commit",
-        return_value=None,
-    )
-    tn = TestResultsNotifier(CommitFactory(), None)
-    tn.build_message = mock.Mock()
-    tn.send_to_provider = mock.Mock(return_value=False)
-
-    notification_result = tn.notify()
-    assert notification_result == NotifierResult.NO_PULL
 
 
 @pytest.mark.django_db

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -284,49 +284,58 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
                     "queue_notify": False,
                 }
 
-        flaky_tests = dict()
-        if should_do_flaky_detection(repo, commit_yaml):
-            flaky_tests = self.get_flaky_tests(db_session, repoid, failures)
+            flaky_tests = dict()
+            if should_do_flaky_detection(repo, commit_yaml):
+                flaky_tests = self.get_flaky_tests(db_session, repoid, failures)
 
-        failures = sorted(failures, key=lambda x: x.duration_seconds)[:3]
-        info = TACommentInDepthInfo(failures, flaky_tests)
-        payload = TestResultsNotificationPayload(
-            failed_tests, passed_tests, skipped_tests, info
-        )
-        notifier = TestResultsNotifier(
-            commit, commit_yaml, payload=payload, _pull=pull, _repo_service=repo_service
-        )
-
-        if pull is not None and repo.private == False:
-            log.info(
-                "making TA comment",
-                extra=dict(
-                    pullid=pull.database_pull.pullid,
-                    service=repo.service,
-                    slug=f"{repo.owner.username}/{repo.name}",
-                ),
+            failures = sorted(failures, key=lambda x: x.duration_seconds)[:3]
+            info = TACommentInDepthInfo(failures, flaky_tests)
+            payload = TestResultsNotificationPayload(
+                failed_tests, passed_tests, skipped_tests, info
+            )
+            notifier = TestResultsNotifier(
+                commit,
+                commit_yaml,
+                payload=payload,
+                _pull=pull,
+                _repo_service=repo_service,
             )
 
-        notifier_result = notifier.notify()
-        success = True if notifier_result is NotifierResult.COMMENT_POSTED else False
-        TestResultsFlow.log(TestResultsFlow.TEST_RESULTS_NOTIFY)
-
-        if len(flaky_tests):
-            log.info(
-                "Detected failure on test that has been identified as flaky",
-                extra=dict(
-                    success=success,
-                    notifier_result=notifier_result.value,
-                    test_ids=list(flaky_tests.keys()),
-                ),
+            if repo.private == False:
+                log.info(
+                    "making TA comment",
+                    extra=dict(
+                        pullid=pull.database_pull.pullid,
+                        service=repo.service,
+                        slug=f"{repo.owner.username}/{repo.name}",
+                    ),
+                )
+            notifier_result = notifier.notify()
+            success = (
+                True if notifier_result is NotifierResult.COMMENT_POSTED else False
             )
+            TestResultsFlow.log(TestResultsFlow.TEST_RESULTS_NOTIFY)
+            if len(flaky_tests):
+                log.info(
+                    "Detected failure on test that has been identified as flaky",
+                    extra=dict(
+                        success=success,
+                        notifier_result=notifier_result.value,
+                        test_ids=list(flaky_tests.keys()),
+                    ),
+                )
+            attempted = True
+        else:
+            success = False
+            attempted = False
+            notifier_result = NotifierResult.NO_PULL
 
         self.extra_dict["success"] = success
         self.extra_dict["notifier_result"] = notifier_result.value
         log.info("Finished test results notify", extra=self.extra_dict)
 
         return {
-            "notify_attempted": True,
+            "notify_attempted": attempted,
             "notify_succeeded": success,
             "queue_notify": False,
         }


### PR DESCRIPTION
we don't want to even try to notify if the pull is none, so i'm pushing that check out of the Notifier.notify() and overriding the base notify in the TestResultsNotifier, to expect a Pull