### PR TITLE
Add private + owner to sync conditions for Shelter

### DIFF
--- a/database/events.py
+++ b/database/events.py
@@ -71,7 +71,7 @@ def after_update_repo(mapper, connection, target: Repository):
     state = inspect(target)
 
     for attr in state.attrs:
-        if attr.key in ["name", "upload_token"]:
+        if attr.key in ["name", "upload_token", "ownerid", "private"]:
             history = attr.history
             # Detects if there are changes and if said changes are different.
             # has_changes() is True when you update the an entry with the same value,


### PR DESCRIPTION
We want to add these two fields to Shelter sync conditions

Ticket:
https://github.com/codecov/engineering-team/issues/3341

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.