### PR TITLE
create utils for accessing testrun timescale models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,4 +83,4 @@ dev-dependencies = [
 [tool.uv.sources]
 timestring = { git = "https://github.com/codecov/timestring", rev = "d37ceacc5954dff3b5bd2f887936a98a668dda42" }
 test-results-parser = { git = "https://github.com/codecov/test-results-parser", rev = "190bbc8a911099749928e13d5fe57f6027ca1e74" }
-shared = { git = "https://github.com/codecov/shared", rev = "4755e7f77efc711c6ca34c2fb284edce71836402" }
+shared = { git = "https://github.com/codecov/shared", rev = "e9567e60e40893fd873c319b7dcc7ca05b5685e3" }

--- a/services/test_analytics/ta_timeseries.py
+++ b/services/test_analytics/ta_timeseries.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import TypedDict
+
+import test_results_parser
+from django.db import connections
+from django.db.models import Q
+from shared.django_apps.test_analytics.models import Flake
+from shared.django_apps.timeseries.models import (
+    Testrun,
+    TestrunBranchSummary,
+    TestrunSummary,
+)
+
+from services.test_analytics.utils import calc_test_id
+from services.test_results import FlakeInfo
+
+LOWER_BOUND_NUM_DAYS = 60
+
+
+def get_flaky_tests_set(repo_id: int) -> set[bytes]:
+    return set(
+        Flake.objects.filter(repoid=repo_id, end_date__isnull=True)
+        .values_list("test_id", flat=True)
+        .distinct()
+    )
+
+
+def get_flaky_tests_dict(repo_id: int) -> dict[bytes, FlakeInfo]:
+    return {
+        flake.test_id: FlakeInfo(flake.fail_count, flake.count)
+        for flake in Flake.objects.filter(repoid=repo_id, end_date__isnull=True)
+    }
+
+
+def insert_testrun(
+    timestamp: datetime,
+    repo_id: int | None,
+    commit_sha: str | None,
+    branch: str | None,
+    upload_id: int | None,
+    flags: list[str] | None,
+    parsing_info: test_results_parser.ParsingInfo,
+    flaky_test_ids: set[bytes] | None = None,
+):
+    testruns_to_create = []
+    for testrun in parsing_info["testruns"]:
+        test_id = calc_test_id(
+            testrun["name"], testrun["classname"], testrun["testsuite"]
+        )
+        outcome = testrun["outcome"]
+
+        if outcome == "failure" and flaky_test_ids and test_id in flaky_test_ids:
+            outcome = "flaky_failure"
+
+        testruns_to_create.append(
+            Testrun(
+                timestamp=timestamp,
+                test_id=test_id,
+                name=testrun["name"],
+                classname=testrun["classname"],
+                testsuite=testrun["testsuite"],
+                computed_name=testrun["computed_name"],
+                outcome=outcome,
+                duration_seconds=testrun["duration"],
+                failure_message=testrun["failure_message"],
+                framework=parsing_info["framework"],
+                filename=testrun["filename"],
+                repo_id=repo_id,
+                commit_sha=commit_sha,
+                branch=branch,
+                flags=flags,
+                upload_id=upload_id,
+            )
+        )
+    Testrun.objects.bulk_create(testruns_to_create)
+
+
+class TestInstance(TypedDict):
+    test_id: bytes
+    computed_name: str
+    failure_message: str
+    upload_id: int
+    duration_seconds: float | None
+
+
+def get_pr_comment_failures(repo_id: int, commit_sha: str) -> list[TestInstance]:
+    with connections["timeseries"].cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT 
+                test_id,
+                LAST(computed_name, timestamp) as computed_name,
+                LAST(failure_message, timestamp) as failure_message,
+                LAST(upload_id, timestamp) as upload_id,
+                LAST(duration_seconds, timestamp) as duration_seconds
+            FROM timeseries_testrun
+            WHERE repo_id = %s AND commit_sha = %s AND outcome IN ('failure', 'flaky_failure')
+            GROUP BY test_id
+            """,
+            [repo_id, commit_sha],
+        )
+        return [
+            {
+                "test_id": bytes(test_id),
+                "computed_name": computed_name,
+                "failure_message": failure_message,
+                "upload_id": upload_id,
+                "duration_seconds": duration_seconds,
+            }
+            for test_id, computed_name, failure_message, upload_id, duration_seconds in cursor.fetchall()
+        ]
+
+
+def get_pr_comment_agg(repo_id: int, commit_sha: str) -> dict[str, int]:
+    with connections["timeseries"].cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT outcome, count(*) FROM (
+                SELECT 
+                    test_id,
+                    LAST(outcome, timestamp) as outcome
+                FROM timeseries_testrun
+                WHERE repo_id = %s AND commit_sha = %s
+                GROUP BY test_id
+            ) AS t
+            GROUP BY outcome
+            """,
+            [repo_id, commit_sha],
+        )
+        return {outcome: count for outcome, count in cursor.fetchall()}
+
+
+def get_testruns_for_flake_detection(
+    upload_id: int,
+    flaky_test_ids: set[bytes],
+) -> list[Testrun]:
+    return list(
+        Testrun.objects.filter(
+            Q(upload_id=upload_id)
+            & (
+                Q(outcome="failure")
+                | Q(outcome="flaky_failure")
+                | (Q(outcome="pass") & Q(test_id__in=flaky_test_ids))
+            )
+        )
+    )
+
+
+def update_testrun_to_flaky(timestamp: datetime, test_id: bytes):
+    with connections["timeseries"].cursor() as cursor:
+        cursor.execute(
+            "UPDATE timeseries_testrun SET outcome = %s WHERE timestamp = %s AND test_id = %s",
+            ["flaky_failure", timestamp, test_id],
+        )
+
+
+def timestamp_lower_bound():
+    return datetime.now() - timedelta(days=LOWER_BOUND_NUM_DAYS)
+
+
+def get_summary(repo_id: int) -> list[TestrunSummary]:
+    return list(
+        TestrunSummary.objects.filter(
+            repo_id=repo_id, timestamp_bin__gte=timestamp_lower_bound()
+        )
+    )
+
+
+def get_branch_summary(repo_id: int, branch: str) -> list[TestrunBranchSummary]:
+    return list(
+        TestrunBranchSummary.objects.filter(
+            repo_id=repo_id, branch=branch, timestamp_bin__gte=timestamp_lower_bound()
+        )
+    )
+
+
+@dataclass
+class BranchSummary:
+    testsuite: str
+    classname: str
+    name: str
+    timestamp_bin: datetime
+    computed_name: str
+    failing_commits: int
+    last_duration_seconds: float
+    avg_duration_seconds: float
+    pass_count: int
+    fail_count: int
+    skip_count: int
+    flaky_fail_count: int
+    updated_at: datetime
+    flags: list[str]
+
+
+def get_testrun_branch_summary_via_testrun(
+    repo_id: int, branch: str
+) -> list[BranchSummary]:
+    with connections["timeseries"].cursor() as cursor:
+        cursor.execute(
+            """
+            select
+                testsuite,
+                classname,
+                name,
+                time_bucket(interval '1 days', timestamp) as timestamp_bin,
+
+                min(computed_name) as computed_name,
+                COUNT(DISTINCT CASE WHEN outcome = 'failure' OR outcome = 'flaky_fail' THEN commit_sha ELSE NULL END) AS failing_commits,
+                last(duration_seconds, timestamp) as last_duration_seconds,
+                avg(duration_seconds) as avg_duration_seconds,
+                COUNT(*) FILTER (WHERE outcome = 'pass') AS pass_count,
+                COUNT(*) FILTER (WHERE outcome = 'failure') AS fail_count,
+                COUNT(*) FILTER (WHERE outcome = 'skip') AS skip_count,
+                COUNT(*) FILTER (WHERE outcome = 'flaky_fail') AS flaky_fail_count,
+                MAX(timestamp) AS updated_at,
+                array_merge_dedup_agg(flags) as flags
+            from timeseries_testrun
+            where repo_id = %s and branch = %s and timestamp > %s
+            group by
+                testsuite, classname, name, timestamp_bin;
+            """,
+            [repo_id, branch, timestamp_lower_bound()],
+        )
+
+        return [
+            BranchSummary(
+                testsuite=row[0],
+                classname=row[1],
+                name=row[2],
+                timestamp_bin=row[3],
+                computed_name=row[4],
+                failing_commits=row[5],
+                last_duration_seconds=row[6],
+                avg_duration_seconds=row[7],
+                pass_count=row[8],
+                fail_count=row[9],
+                skip_count=row[10],
+                flaky_fail_count=row[11],
+                updated_at=row[12],
+                flags=row[13] or [],
+            )
+            for row in cursor.fetchall()
+        ]

--- a/services/test_analytics/tests/test_ta_timeseries.py
+++ b/services/test_analytics/tests/test_ta_timeseries.py
@@ -1,0 +1,514 @@
+import time
+from datetime import datetime
+
+import pytest
+from django.db import connections
+from shared.django_apps.timeseries.models import Testrun
+from time_machine import travel
+
+from services.test_analytics.ta_timeseries import (
+    calc_test_id,
+    get_pr_comment_agg,
+    get_pr_comment_failures,
+    get_summary,
+    get_testrun_branch_summary_via_testrun,
+    get_testruns_for_flake_detection,
+    insert_testrun,
+    update_testrun_to_flaky,
+)
+
+
+@pytest.mark.django_db(databases=["timeseries"])
+def test_insert_testrun():
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha",
+        branch="branch",
+        upload_id=1,
+        flags=["flag1", "flag2"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "pass",
+                    "testsuite": "test_suite",
+                    "failure_message": None,
+                    "filename": "test_filename",
+                    "build_url": None,
+                }
+            ],
+        },
+    )
+
+    t = Testrun.objects.get(
+        name="test_name",
+        classname="test_classname",
+        testsuite="test_suite",
+        failure_message=None,
+        filename="test_filename",
+    )
+    assert t.outcome == "pass"
+
+
+@pytest.mark.django_db(databases=["timeseries"])
+def test_pr_comment_agg():
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha",
+        branch="branch",
+        upload_id=1,
+        flags=["flag1", "flag2"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "pass",
+                    "testsuite": "test_suite",
+                    "failure_message": None,
+                    "filename": "test_filename",
+                    "build_url": None,
+                }
+            ],
+        },
+    )
+
+    agg = get_pr_comment_agg(1, "commit_sha")
+    assert agg == {
+        "pass": 1,
+    }
+
+
+@pytest.mark.django_db(databases=["timeseries"])
+def test_pr_comment_failures():
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha",
+        branch="branch",
+        upload_id=1,
+        flags=["flag1", "flag2"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "failure",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                }
+            ],
+        },
+    )
+
+    failures = get_pr_comment_failures(1, "commit_sha")
+    assert len(failures) == 1
+    failure = failures[0]
+    assert failure["test_id"] == calc_test_id(
+        "test_name", "test_classname", "test_suite"
+    )
+    assert failure["computed_name"] == "computed_name"
+    assert failure["failure_message"] == "failure_message"
+    assert failure["duration_seconds"] == 1.0
+    assert failure["upload_id"] == 1
+
+
+@pytest.mark.django_db(databases=["timeseries"])
+def test_get_testruns_for_flake_detection(db):
+    test_ids = {calc_test_id("flaky_test_name", "test_classname", "test_suite")}
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha",
+        branch="branch",
+        upload_id=1,
+        flags=["flag1", "flag2"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "failure",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+                {
+                    "name": "flaky_test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "failure",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+                {
+                    "name": "flaky_test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "pass",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "pass",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+            ],
+        },
+        flaky_test_ids=test_ids,
+    )
+
+    testruns = get_testruns_for_flake_detection(1, test_ids)
+    assert len(testruns) == 3
+    assert testruns[0].outcome == "failure"
+    assert testruns[0].failure_message == "failure_message"
+    assert testruns[0].name == "test_name"
+    assert testruns[1].outcome == "flaky_failure"
+    assert testruns[1].failure_message == "failure_message"
+    assert testruns[1].name == "flaky_test_name"
+    assert testruns[2].outcome == "pass"
+    assert testruns[2].failure_message == "failure_message"
+    assert testruns[2].name == "flaky_test_name"
+
+
+@pytest.mark.django_db(databases=["timeseries"])
+@travel(datetime(2025, 1, 1), tick=False)
+def test_update_testrun_to_flaky():
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha",
+        branch="branch",
+        upload_id=1,
+        flags=["flag1", "flag2"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "failure",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+            ],
+        },
+    )
+    update_testrun_to_flaky(
+        datetime.now(),
+        calc_test_id("test_name", "test_classname", "test_suite"),
+    )
+    testrun = Testrun.objects.get(
+        name="test_name",
+        classname="test_classname",
+        testsuite="test_suite",
+    )
+    assert testrun.outcome == "flaky_failure"
+
+
+@pytest.mark.integration
+@pytest.mark.django_db(databases=["timeseries"], transaction=True)
+def test_get_testrun_summary():
+    connection = connections["timeseries"]
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            TRUNCATE TABLE timeseries_testrun;
+            TRUNCATE TABLE timeseries_testrun_summary_1day;
+            """
+        )
+        cursor.execute(
+            """
+            SELECT remove_continuous_aggregate_policy('timeseries_testrun_summary_1day');
+            select add_continuous_aggregate_policy(
+                'timeseries_testrun_summary_1day',
+                start_offset => '7 days',
+                end_offset => NULL,
+                schedule_interval => INTERVAL '1 milliseconds'
+            );
+            """
+        )
+
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha",
+        branch="branch",
+        upload_id=1,
+        flags=["flag1"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "pass",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+            ],
+        },
+    )
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha",
+        branch="branch",
+        upload_id=1,
+        flags=["flag1", "flag2"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name2",
+                    "classname": "test_classname2",
+                    "computed_name": "computed_name2",
+                    "duration": 1.0,
+                    "outcome": "pass",
+                    "testsuite": "test_suite2",
+                    "failure_message": "failure_message2",
+                    "filename": "test_filename2",
+                    "build_url": None,
+                },
+            ],
+        },
+    )
+
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha",
+        branch="branch",
+        upload_id=1,
+        flags=["flag2"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 3.0,
+                    "outcome": "failure",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+            ],
+        },
+    )
+
+    time.sleep(5)
+
+    summaries = get_summary(1)
+    assert len(summaries) == 2
+    assert summaries[0].testsuite == "test_suite"
+    assert summaries[0].classname == "test_classname"
+    assert summaries[0].name == "test_name"
+    assert summaries[0].avg_duration_seconds == 2.0
+    assert summaries[0].last_duration_seconds == 3.0
+    assert summaries[0].pass_count == 1
+    assert summaries[0].fail_count == 1
+    assert summaries[0].flaky_fail_count == 0
+    assert summaries[0].skip_count == 0
+    assert summaries[0].flags == ["flag1", "flag2"]
+
+    assert summaries[1].testsuite == "test_suite2"
+    assert summaries[1].classname == "test_classname2"
+    assert summaries[1].name == "test_name2"
+    assert summaries[1].avg_duration_seconds == 1.0
+    assert summaries[1].last_duration_seconds == 1.0
+    assert summaries[1].pass_count == 1
+    assert summaries[1].fail_count == 0
+    assert summaries[1].flaky_fail_count == 0
+    assert summaries[1].skip_count == 0
+    assert summaries[1].flags == ["flag1", "flag2"]
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT remove_continuous_aggregate_policy('timeseries_testrun_summary_1day');
+            select add_continuous_aggregate_policy(
+                'timeseries_testrun_summary_1day',
+                start_offset => '7 days',
+                end_offset => '1 days',
+                schedule_interval => INTERVAL '1 days'
+            );
+            """
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.django_db(databases=["timeseries"], transaction=True)
+def test_get_testrun_branch_summary_via_testrun():
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha1",
+        branch="feature-branch",
+        upload_id=1,
+        flags=["flag1"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 1.0,
+                    "outcome": "pass",
+                    "testsuite": "test_suite",
+                    "failure_message": None,
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+            ],
+        },
+    )
+
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha2",
+        branch="feature-branch",
+        upload_id=2,
+        flags=["flag1", "flag2"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 3.0,
+                    "outcome": "failure",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+            ],
+        },
+    )
+
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha2",
+        branch="feature-branch",
+        upload_id=2,
+        flags=["flag2"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name2",
+                    "classname": "test_classname2",
+                    "computed_name": "computed_name2",
+                    "duration": 2.0,
+                    "outcome": "pass",
+                    "testsuite": "test_suite2",
+                    "failure_message": None,
+                    "filename": "test_filename2",
+                    "build_url": None,
+                },
+            ],
+        },
+    )
+
+    # Add a test on a different branch that should not be included
+    insert_testrun(
+        timestamp=datetime.now(),
+        repo_id=1,
+        commit_sha="commit_sha3",
+        branch="other-branch",
+        upload_id=3,
+        flags=["flag1"],
+        parsing_info={
+            "framework": "Pytest",
+            "testruns": [
+                {
+                    "name": "test_name",
+                    "classname": "test_classname",
+                    "computed_name": "computed_name",
+                    "duration": 5.0,
+                    "outcome": "failure",
+                    "testsuite": "test_suite",
+                    "failure_message": "failure_message",
+                    "filename": "test_filename",
+                    "build_url": None,
+                },
+            ],
+        },
+    )
+
+    summaries = get_testrun_branch_summary_via_testrun(1, "feature-branch")
+    assert len(summaries) == 2
+
+    # Check first test summary
+    first_test = next(s for s in summaries if s.name == "test_name")
+    assert first_test.testsuite == "test_suite"
+    assert first_test.classname == "test_classname"
+    assert first_test.computed_name == "computed_name"
+    assert first_test.failing_commits == 1  # One commit had a failure
+    assert first_test.last_duration_seconds == 3.0  # Last run was 3.0
+    assert first_test.avg_duration_seconds == 2.0  # Average of 1.0 and 3.0
+    assert first_test.pass_count == 1
+    assert first_test.fail_count == 1
+    assert first_test.skip_count == 0
+    assert first_test.flaky_fail_count == 0
+    assert sorted(first_test.flags) == ["flag1", "flag2"]
+
+    # Check second test summary
+    second_test = next(s for s in summaries if s.name == "test_name2")
+    assert second_test.testsuite == "test_suite2"
+    assert second_test.classname == "test_classname2"
+    assert second_test.computed_name == "computed_name2"
+    assert second_test.failing_commits == 0  # No failures
+    assert second_test.last_duration_seconds == 2.0
+    assert second_test.avg_duration_seconds == 2.0
+    assert second_test.pass_count == 1
+    assert second_test.fail_count == 0
+    assert second_test.skip_count == 0
+    assert second_test.flaky_fail_count == 0
+    assert second_test.flags == ["flag2"]

--- a/services/test_analytics/utils.py
+++ b/services/test_analytics/utils.py
@@ -1,0 +1,22 @@
+import mmh3
+from shared.config import get_config
+
+
+def should_use_timeseries(repoid: int) -> bool:
+    timeseries_enabled = get_config("setup", "timeseries", "enabled", default=False)
+    test_analytics_database_enabled = get_config(
+        "setup", "test_analytics_database", "enabled", default=False
+    )
+    if timeseries_enabled and test_analytics_database_enabled:
+        return True
+    return False
+
+
+def calc_test_id(name: str, classname: str, testsuite: str) -> bytes:
+    h = mmh3.mmh3_x64_128()  # assumes we're running on x64 machines
+    h.update(testsuite.encode("utf-8"))
+    h.update(classname.encode("utf-8"))
+    h.update(name.encode("utf-8"))
+    test_id_hash = h.digest()
+
+    return test_id_hash

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = "==3.13.*"
 resolution-markers = [
     "platform_python_implementation != 'PyPy'",
@@ -1308,6 +1307,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/39/1b/d0b013bf7d1af7cf0a6a4fce13f5fe5813ab225313755367b36e714a63f8/pycryptodome-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:18caa8cfbc676eaaf28613637a89980ad2fd96e00c564135bf90bc3f0b34dd93", size = 2254397 },
     { url = "https://files.pythonhosted.org/packages/14/71/4cbd3870d3e926c34706f705d6793159ac49d9a213e3ababcdade5864663/pycryptodome-3.21.0-cp36-abi3-win32.whl", hash = "sha256:280b67d20e33bb63171d55b1067f61fbd932e0b1ad976b3a184303a3dad22764", size = 1775641 },
     { url = "https://files.pythonhosted.org/packages/43/1d/81d59d228381576b92ecede5cd7239762c14001a828bdba30d64896e9778/pycryptodome-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b7aa25fc0baa5b1d95b7633af4f5f1838467f1815442b22487426f94e0d66c53", size = 1812863 },
+    { url = "https://files.pythonhosted.org/packages/25/b3/09ff7072e6d96c9939c24cf51d3c389d7c345bf675420355c22402f71b68/pycryptodome-3.21.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:2cb635b67011bc147c257e61ce864879ffe6d03342dc74b6045059dfbdedafca", size = 1691593 },
+    { url = "https://files.pythonhosted.org/packages/a8/91/38e43628148f68ba9b68dedbc323cf409e537fd11264031961fd7c744034/pycryptodome-3.21.0-pp27-pypy_73-win32.whl", hash = "sha256:4c26a2f0dc15f81ea3afa3b0c87b87e501f235d332b7f27e2225ecb80c0b1cdd", size = 1765997 },
 ]
 
 [[package]]
@@ -1701,7 +1702,7 @@ wheels = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = { git = "https://github.com/codecov/shared?rev=4755e7f77efc711c6ca34c2fb284edce71836402#4755e7f77efc711c6ca34c2fb284edce71836402" }
+source = { git = "https://github.com/codecov/shared?rev=e9567e60e40893fd873c319b7dcc7ca05b5685e3#e9567e60e40893fd873c319b7dcc7ca05b5685e3" }
 dependencies = [
     { name = "amplitude-analytics" },
     { name = "boto3" },
@@ -2040,7 +2041,7 @@ requires-dist = [
     { name = "regex", specifier = ">=2023.12.25" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "sentry-sdk", specifier = ">=2.13.0" },
-    { name = "shared", git = "https://github.com/codecov/shared?rev=4755e7f77efc711c6ca34c2fb284edce71836402" },
+    { name = "shared", git = "https://github.com/codecov/shared?rev=e9567e60e40893fd873c319b7dcc7ca05b5685e3" },
     { name = "sqlalchemy", specifier = "==1.3.*" },
     { name = "sqlparse", specifier = "==0.5.0" },
     { name = "statsd", specifier = ">=3.3.0" },


### PR DESCRIPTION
this PR creates some utility functions for inserting and aggregating testrun data in timescale

`transaction=True` is required for the test_get_testrun_summary for the continuous aggregates to populate the data that is expected to be in the summary for the test to pass

depends on: https://github.com/codecov/shared/pull/508