### PR TITLE
fix: References to old free plan and Deprecated BillingPlan enum

### DIFF
--- a/celery_task_router.py
+++ b/celery_task_router.py
@@ -1,6 +1,6 @@
 import shared.celery_config as shared_celery_config
-from shared.billing import BillingPlan
 from shared.celery_router import route_tasks_based_on_user_plan
+from shared.plan.constants import DEFAULT_FREE_PLAN
 
 from database.engine import get_db_session
 from database.models.core import Commit, CompareCommit, Owner, Repository
@@ -13,7 +13,7 @@ def _get_user_plan_from_ownerid(db_session, ownerid, *args, **kwargs) -> str:
     result = db_session.query(Owner.plan).filter(Owner.ownerid == ownerid).first()
     if result:
         return result.plan
-    return BillingPlan.users_basic.db_name
+    return DEFAULT_FREE_PLAN
 
 
 def _get_user_plan_from_repoid(db_session, repoid, *args, **kwargs) -> str:
@@ -25,7 +25,7 @@ def _get_user_plan_from_repoid(db_session, repoid, *args, **kwargs) -> str:
     )
     if result:
         return result.plan
-    return BillingPlan.users_basic.db_name
+    return DEFAULT_FREE_PLAN
 
 
 def _get_user_plan_from_org_ownerid(dbsession, org_ownerid, *args, **kwargs) -> str:
@@ -44,7 +44,7 @@ def _get_user_plan_from_profiling_commit(
     )
     if result:
         return result.plan
-    return BillingPlan.users_basic.db_name
+    return DEFAULT_FREE_PLAN
 
 
 def _get_user_plan_from_profiling_upload(
@@ -60,7 +60,7 @@ def _get_user_plan_from_profiling_upload(
     )
     if result:
         return result.plan
-    return BillingPlan.users_basic.db_name
+    return DEFAULT_FREE_PLAN
 
 
 def _get_user_plan_from_comparison_id(dbsession, comparison_id, *args, **kwargs) -> str:
@@ -74,7 +74,7 @@ def _get_user_plan_from_comparison_id(dbsession, comparison_id, *args, **kwargs)
     )
     if result:
         return result.plan
-    return BillingPlan.users_basic.db_name
+    return DEFAULT_FREE_PLAN
 
 
 def _get_user_plan_from_label_request_id(dbsession, request_id, *args, **kwargs) -> str:
@@ -88,7 +88,7 @@ def _get_user_plan_from_label_request_id(dbsession, request_id, *args, **kwargs)
     )
     if result:
         return result.plan
-    return BillingPlan.users_basic.db_name
+    return DEFAULT_FREE_PLAN
 
 
 def _get_user_plan_from_suite_id(dbsession, suite_id, *args, **kwargs) -> str:
@@ -102,7 +102,7 @@ def _get_user_plan_from_suite_id(dbsession, suite_id, *args, **kwargs) -> str:
     )
     if result:
         return result.plan
-    return BillingPlan.users_basic.db_name
+    return DEFAULT_FREE_PLAN
 
 
 def _get_user_plan_from_task(dbsession, task_name: str, task_kwargs: dict) -> str:
@@ -139,7 +139,7 @@ def _get_user_plan_from_task(dbsession, task_name: str, task_kwargs: dict) -> st
         shared_celery_config.static_analysis_task_name: _get_user_plan_from_suite_id,
     }
     func_to_use = owner_plan_lookup_funcs.get(
-        task_name, lambda *args, **kwargs: BillingPlan.users_basic.db_name
+        task_name, lambda *args, **kwargs: DEFAULT_FREE_PLAN
     )
     return func_to_use(dbsession, **task_kwargs)
 

--- a/services/notification/notifiers/comment/__init__.py
+++ b/services/notification/notifiers/comment/__init__.py
@@ -4,8 +4,8 @@ from typing import Any, Mapping, Optional
 
 import sentry_sdk
 from asgiref.sync import async_to_sync
-from shared.billing import BillingPlan
 from shared.metrics import Counter, inc_counter
+from shared.plan.constants import PlanName
 from shared.torngit.exceptions import (
     TorngitClientError,
     TorngitObjectNotFoundError,
@@ -356,8 +356,8 @@ class CommentNotifier(MessageMixin, AbstractBaseNotifier):
 
         if (
             not (
-                self.repository.owner.plan == BillingPlan.team_monthly.value
-                or self.repository.owner.plan == BillingPlan.team_yearly.value
+                self.repository.owner.plan == PlanName.TEAM_MONTHLY.value
+                or self.repository.owner.plan == PlanName.TEAM_YEARLY.value
             )
             and self.repository.owner.createstamp
             and self.repository.owner.createstamp > introduction_date

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -4,7 +4,7 @@ from typing import List
 from unittest.mock import PropertyMock, patch
 
 import pytest
-from shared.billing import BillingPlan
+from shared.plan.constants import DEFAULT_FREE_PLAN, PlanName
 from shared.reports.readonly import ReadOnlyReport
 from shared.reports.resources import Report, ReportFile
 from shared.reports.types import Change, LineSession, ReportLine, ReportTotals
@@ -5460,9 +5460,7 @@ class TestCommentNotifierWelcome:
             after_introduction_date
         )
 
-        sample_comparison.head.commit.repository.owner.plan = (
-            BillingPlan.team_yearly.value
-        )
+        sample_comparison.head.commit.repository.owner.plan = PlanName.TEAM_YEARLY.value
 
         dbsession.add_all(
             [
@@ -5483,9 +5481,7 @@ class TestCommentNotifierWelcome:
         result = notifier.build_message(sample_comparison)
         assert PROJECT_COVERAGE_CTA not in result
 
-        sample_comparison.head.commit.repository.owner.plan = (
-            BillingPlan.users_free.value
-        )
+        sample_comparison.head.commit.repository.owner.plan = DEFAULT_FREE_PLAN
 
         dbsession.add(sample_comparison.head.commit.repository.owner)
         dbsession.flush()

--- a/services/tests/test_seats.py
+++ b/services/tests/test_seats.py
@@ -1,5 +1,5 @@
 import pytest
-from shared.billing import BillingPlan
+from shared.plan.constants import PlanName
 
 from database.tests.factories import OwnerFactory, PullFactory
 from services.repository import EnrichedPull
@@ -51,7 +51,7 @@ def test_seat_billing_plan(dbsession):
     dbsession.flush()
 
     pull.repository.private = True
-    pull.repository.owner.plan = BillingPlan.users_monthly.value
+    pull.repository.owner.plan = PlanName.CODECOV_PRO_MONTHLY.value
     dbsession.flush()
 
     enriched_pull = EnrichedPull(
@@ -72,7 +72,7 @@ def test_seat_no_author(dbsession):
     dbsession.flush()
 
     pull.repository.private = True
-    pull.repository.owner.plan = BillingPlan.pr_monthly.value
+    pull.repository.owner.plan = PlanName.CODECOV_PRO_MONTHLY.value
     dbsession.flush()
 
     enriched_pull = EnrichedPull(
@@ -93,7 +93,7 @@ def test_seat_author_in_org(dbsession):
     dbsession.flush()
 
     pull.repository.private = True
-    pull.repository.owner.plan = BillingPlan.pr_monthly.value
+    pull.repository.owner.plan = PlanName.CODECOV_PRO_MONTHLY.value
     pull.repository.owner.service = "github"
     dbsession.flush()
 
@@ -122,7 +122,7 @@ def test_seat_author_not_in_org(dbsession):
     dbsession.flush()
 
     pull.repository.private = True
-    pull.repository.owner.plan = BillingPlan.pr_monthly.value
+    pull.repository.owner.plan = PlanName.CODECOV_PRO_MONTHLY.value
     pull.repository.owner.service = "github"
     dbsession.flush()
 
@@ -148,7 +148,7 @@ def test_seat_author_auto_activate(dbsession):
     dbsession.flush()
 
     pull.repository.private = True
-    pull.repository.owner.plan = BillingPlan.pr_monthly.value
+    pull.repository.owner.plan = PlanName.CODECOV_PRO_MONTHLY.value
     pull.repository.owner.plan_auto_activate = True
     pull.repository.owner.service = "github"
     dbsession.flush()

--- a/tasks/github_marketplace.py
+++ b/tasks/github_marketplace.py
@@ -2,8 +2,8 @@ import logging
 from datetime import datetime
 
 import requests
-from shared.billing import BillingPlan
 from shared.celery_config import ghm_sync_plans_task_name
+from shared.plan.constants import DEFAULT_FREE_PLAN
 
 from app import celery_app
 from database.models import Owner, Repository
@@ -243,7 +243,7 @@ class SyncPlansTask(BaseCodecovTask, name=ghm_sync_plans_task_name):
 
         if owner:
             # deactivate repos and remove all activated users for this owner
-            owner.plan = BillingPlan.users_basic.value
+            owner.plan = DEFAULT_FREE_PLAN
             owner.plan_user_count = 1
             owner.plan_activated_users = None
 

--- a/tasks/plan_manager_task.py
+++ b/tasks/plan_manager_task.py
@@ -1,6 +1,6 @@
 import logging
 
-from shared.billing import BillingPlan
+from shared.plan.constants import PlanName
 from sqlalchemy.orm import Session
 
 from app import celery_app
@@ -15,8 +15,8 @@ log = logging.getLogger(__name__)
 # TODO: Move to shared (celery_config)
 class DailyPlanManagerTask(CodecovCronTask, name=daily_plan_manager_task_name):
     PLANS_THAT_CAN_HAVE_ORG_LEVEL_TOKENS = [
-        BillingPlan.enterprise_cloud_monthly.value,
-        BillingPlan.enterprise_cloud_yearly.value,
+        PlanName.ENTERPRISE_CLOUD_MONTHLY.value,
+        PlanName.ENTERPRISE_CLOUD_YEARLY.value,
     ]
 
     @classmethod

--- a/tasks/tests/integration/test_ghm_sync_plans.py
+++ b/tasks/tests/integration/test_ghm_sync_plans.py
@@ -1,5 +1,5 @@
 import pytest
-from shared.billing import BillingPlan
+from shared.plan.constants import DEFAULT_FREE_PLAN
 
 from database.models import Owner, Repository
 from database.tests.factories import OwnerFactory, RepositoryFactory
@@ -141,7 +141,7 @@ class TestGHMarketplaceSyncPlansTask(object):
         assert owner is not None
         assert owner.username == "some-org"
         assert owner.plan_provider == "github"
-        assert owner.plan == BillingPlan.users_basic.value
+        assert owner.plan == DEFAULT_FREE_PLAN
         assert owner.plan_user_count == 1
         assert owner.plan_activated_users is None
 

--- a/tasks/tests/unit/test_base.py
+++ b/tasks/tests/unit/test_base.py
@@ -9,8 +9,8 @@ from celery.contrib.testing.mocks import TaskMessage
 from celery.exceptions import Retry, SoftTimeLimitExceeded
 from mock import ANY, call
 from prometheus_client import REGISTRY
-from shared.billing import BillingPlan
 from shared.celery_config import sync_repos_task_name, upload_task_name
+from shared.plan.constants import PlanName
 from shared.utils.test_utils import mock_config_helper
 from sqlalchemy.exc import (
     DBAPIError,
@@ -454,9 +454,9 @@ class TestBaseCodecovRequest(object):
 class TestBaseCodecovTaskApplyAsyncOverride(object):
     @pytest.fixture
     def fake_owners(self, dbsession):
-        owner = OwnerFactory.create(plan=BillingPlan.pr_monthly.db_name)
+        owner = OwnerFactory.create(plan=PlanName.CODECOV_PRO_MONTHLY.value)
         owner_enterprise_cloud = OwnerFactory.create(
-            plan=BillingPlan.enterprise_cloud_yearly.db_name
+            plan=PlanName.ENTERPRISE_CLOUD_YEARLY.value
         )
         dbsession.add(owner)
         dbsession.add(owner_enterprise_cloud)

--- a/tasks/tests/unit/test_ghm_sync_plans.py
+++ b/tasks/tests/unit/test_ghm_sync_plans.py
@@ -1,5 +1,5 @@
 from freezegun import freeze_time
-from shared.billing import BillingPlan
+from shared.plan.constants import DEFAULT_FREE_PLAN
 
 from database.models import Owner, Repository
 from database.tests.factories import OwnerFactory, RepositoryFactory
@@ -27,7 +27,7 @@ class TestGHMarketplaceSyncPlansTaskUnit(object):
         )
 
         assert not ghm_service.get_user.called
-        assert owner.plan == BillingPlan.users_basic.value
+        assert owner.plan == DEFAULT_FREE_PLAN
         assert owner.plan_user_count == 1
         assert owner.plan_activated_users is None
 

--- a/tasks/tests/unit/test_planmanager_task.py
+++ b/tasks/tests/unit/test_planmanager_task.py
@@ -1,4 +1,4 @@
-from shared.billing import BillingPlan
+from shared.plan.constants import DEFAULT_FREE_PLAN, PlanName
 
 from database.models.core import OrganizationLevelToken
 from database.tests.factories.core import OrgLevelTokenFactory, OwnerFactory
@@ -10,10 +10,10 @@ class TestDailyPlanManagerTask(object):
         task = DailyPlanManagerTask()
         # Populate DB
         owner_in_enterprise_plan = OwnerFactory.create(
-            service="github", plan=BillingPlan.enterprise_cloud_monthly.value
+            service="github", plan=PlanName.ENTERPRISE_CLOUD_MONTHLY.value
         )
         owner_not_in_enterprise_plan = OwnerFactory.create(
-            service="github", plan=BillingPlan.users_free.value
+            service="github", plan=DEFAULT_FREE_PLAN
         )
 
         valid_token = OrgLevelTokenFactory.create(owner=owner_in_enterprise_plan)

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 from mock import AsyncMock
-from shared.billing import BillingPlan
+from shared.plan.constants import PlanName
 from shared.torngit.exceptions import TorngitClientError
 
 from database.enums import ReportType
@@ -645,7 +645,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
 
         repo = dbsession.query(Repository).filter(Repository.repoid == repoid).first()
         repo.owner.plan_activated_users = []
-        repo.owner.plan = BillingPlan.pr_monthly.value
+        repo.owner.plan = PlanName.CODECOV_PRO_MONTHLY.value
         repo.private = True
         dbsession.flush()
 

--- a/tasks/tests/unit/test_trial_expiration.py
+++ b/tasks/tests/unit/test_trial_expiration.py
@@ -1,4 +1,4 @@
-from shared.billing import BillingPlan
+from shared.plan.constants import DEFAULT_FREE_PLAN
 
 from database.enums import TrialStatus
 from database.tests.factories.core import OwnerFactory
@@ -14,7 +14,7 @@ class TestTrialExpiration(object):
         task = TrialExpirationTask()
         assert task.run_impl(dbsession, owner.ownerid) == {"successful": True}
 
-        assert owner.plan == BillingPlan.users_basic.value
+        assert owner.plan == DEFAULT_FREE_PLAN
         assert owner.plan_activated_users is None
         assert owner.plan_user_count == 5
         assert owner.stripe_subscription_id is None
@@ -30,7 +30,7 @@ class TestTrialExpiration(object):
         task = TrialExpirationTask()
         assert task.run_impl(dbsession, owner.ownerid) == {"successful": True}
 
-        assert owner.plan == BillingPlan.users_basic.value
+        assert owner.plan == DEFAULT_FREE_PLAN
         assert owner.plan_activated_users is None
         assert owner.plan_user_count == 1
         assert owner.stripe_subscription_id is None
@@ -44,7 +44,7 @@ class TestTrialExpiration(object):
         task = TrialExpirationTask()
         assert task.run_impl(dbsession, owner.ownerid) == {"successful": True}
 
-        assert owner.plan == BillingPlan.users_basic.value
+        assert owner.plan == DEFAULT_FREE_PLAN
         assert owner.plan_activated_users == [9]
         assert owner.stripe_subscription_id is None
         assert owner.trial_status == TrialStatus.EXPIRED.value

--- a/tasks/tests/unit/test_trial_expiration_cron.py
+++ b/tasks/tests/unit/test_trial_expiration_cron.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 from unittest.mock import patch
 
-from shared.billing import BillingPlan
+from shared.plan.constants import DEFAULT_FREE_PLAN, PlanName
 
 from celery_config import trial_expiration_task_name
 from database.enums import TrialStatus
@@ -24,40 +24,40 @@ class TestTrialExpirationCheck(object):
             username="one",
             trial_status=TrialStatus.ONGOING.value,
             trial_end_date=yesterday,
-            plan=BillingPlan.users_trial.value,
+            plan=PlanName.TRIAL.value,
         )
         second_ongoing_owner_that_should_expire = OwnerFactory.create(
             username="two",
             trial_status=TrialStatus.ONGOING.value,
             trial_end_date=yesterday,
-            plan=BillingPlan.users_trial.value,
+            plan=PlanName.TRIAL.value,
         )
         # These are to represent other types of owners we could face that we should not see
         ongoing_owner_that_should_not_expire = OwnerFactory.create(
             username="three",
             trial_status=TrialStatus.ONGOING.value,
             trial_end_date=tomorrow,
-            plan=BillingPlan.users_trial.value,
+            plan=PlanName.TRIAL.value,
         )
         expired_basic_owner = OwnerFactory.create(
             trial_status=TrialStatus.EXPIRED.value,
             trial_end_date=yesterday,
-            plan=BillingPlan.users_basic.value,
+            plan=DEFAULT_FREE_PLAN,
         )
         expired_paid_owner = OwnerFactory.create(
             trial_status=TrialStatus.EXPIRED.value,
             trial_end_date=yesterday,
-            plan=BillingPlan.pr_monthly.value,
+            plan=PlanName.CODECOV_PRO_MONTHLY.value,
         )
         cannot_trial_paid_owner = OwnerFactory.create(
             trial_status=TrialStatus.CANNOT_TRIAL.value,
             trial_end_date=yesterday,
-            plan=BillingPlan.pr_monthly.value,
+            plan=PlanName.CODECOV_PRO_MONTHLY.value,
         )
         not_started_basic_owner = OwnerFactory.create(
             trial_status=TrialStatus.NOT_STARTED.value,
             trial_end_date=None,
-            plan=BillingPlan.users_basic.value,
+            plan=DEFAULT_FREE_PLAN,
         )
         dbsession.add(ongoing_owner_that_should_expire)
         dbsession.add(second_ongoing_owner_that_should_expire)

--- a/tasks/trial_expiration.py
+++ b/tasks/trial_expiration.py
@@ -1,6 +1,6 @@
 import logging
 
-from shared.billing import BillingPlan
+from shared.plan.constants import DEFAULT_FREE_PLAN
 
 from app import celery_app
 from celery_config import trial_expiration_task_name
@@ -21,7 +21,7 @@ class TrialExpirationTask(BaseCodecovTask, name=trial_expiration_task_name):
         log.info(
             "Expiring owner's trial and setting back to basic plan", extra=log_extra
         )
-        owner.plan = BillingPlan.users_basic.value
+        owner.plan = DEFAULT_FREE_PLAN
         owner.plan_activated_users = (
             [owner.trial_fired_by] if owner.trial_fired_by else None
         )

--- a/tasks/trial_expiration_cron.py
+++ b/tasks/trial_expiration_cron.py
@@ -1,6 +1,6 @@
 import logging
 
-from shared.billing import BillingPlan
+from shared.plan.constants import PlanName
 
 from app import celery_app
 from celery_config import trial_expiration_cron_task_name, trial_expiration_task_name
@@ -26,7 +26,7 @@ class TrialExpirationCronTask(CodecovCronTask, name=trial_expiration_cron_task_n
         ongoing_trial_owners_that_should_be_expired = (
             db_session.query(Owner.ownerid)
             .filter(
-                Owner.plan == BillingPlan.users_trial.value,
+                Owner.plan == PlanName.TRIAL.value,
                 Owner.trial_status == TrialStatus.ONGOING.value,
                 Owner.trial_end_date <= now,
             )

--- a/tests/unit/test_task_router.py
+++ b/tests/unit/test_task_router.py
@@ -1,6 +1,6 @@
 import pytest
 import shared.celery_config as shared_celery_config
-from shared.billing import BillingPlan
+from shared.plan.constants import DEFAULT_FREE_PLAN, PlanName
 
 from celery_task_router import (
     _get_user_plan_from_comparison_id,
@@ -30,9 +30,9 @@ from database.tests.factories.staticanalysis import StaticAnalysisSuiteFactory
 
 @pytest.fixture
 def fake_owners(dbsession):
-    owner = OwnerFactory.create(plan=BillingPlan.pr_monthly.db_name)
+    owner = OwnerFactory.create(plan=PlanName.CODECOV_PRO_MONTHLY.value)
     owner_enterprise_cloud = OwnerFactory.create(
-        plan=BillingPlan.enterprise_cloud_yearly.db_name
+        plan=PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
     dbsession.add(owner)
     dbsession.add(owner_enterprise_cloud)
@@ -137,27 +137,24 @@ def test_get_owner_plan_from_id(dbsession, fake_owners):
     (owner, owner_enterprise_cloud) = fake_owners
     assert (
         _get_user_plan_from_ownerid(dbsession, owner.ownerid)
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
     assert (
         _get_user_plan_from_ownerid(dbsession, owner_enterprise_cloud.ownerid)
-        == BillingPlan.enterprise_cloud_yearly.db_name
+        == PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
-    assert (
-        _get_user_plan_from_ownerid(dbsession, 10000000)
-        == BillingPlan.users_basic.db_name
-    )
+    assert _get_user_plan_from_ownerid(dbsession, 10000000) == DEFAULT_FREE_PLAN
 
 
 def test_get_user_plan_from_org_ownerid(dbsession, fake_owners):
     (owner, owner_enterprise_cloud) = fake_owners
     assert (
         _get_user_plan_from_org_ownerid(dbsession, owner.ownerid)
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
     assert (
         _get_user_plan_from_org_ownerid(dbsession, owner_enterprise_cloud.ownerid)
-        == BillingPlan.enterprise_cloud_yearly.db_name
+        == PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
 
 
@@ -165,31 +162,27 @@ def test_get_owner_plan_from_repoid(dbsession, fake_repos):
     (repo, repo_enterprise_cloud) = fake_repos
     assert (
         _get_user_plan_from_repoid(dbsession, repo.repoid)
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
     assert (
         _get_user_plan_from_repoid(dbsession, repo_enterprise_cloud.repoid)
-        == BillingPlan.enterprise_cloud_yearly.db_name
+        == PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
-    assert (
-        _get_user_plan_from_repoid(dbsession, 10000000)
-        == BillingPlan.users_basic.db_name
-    )
+    assert _get_user_plan_from_repoid(dbsession, 10000000) == DEFAULT_FREE_PLAN
 
 
 def test_get_user_plan_from_profiling_commit(dbsession, fake_profiling_commit):
     (profiling_commit, profiling_commit_enterprise) = fake_profiling_commit
     assert (
         _get_user_plan_from_profiling_commit(dbsession, profiling_commit.id)
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
     assert (
         _get_user_plan_from_profiling_commit(dbsession, profiling_commit_enterprise.id)
-        == BillingPlan.enterprise_cloud_yearly.db_name
+        == PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
     assert (
-        _get_user_plan_from_profiling_commit(dbsession, 10000000)
-        == BillingPlan.users_basic.db_name
+        _get_user_plan_from_profiling_commit(dbsession, 10000000) == DEFAULT_FREE_PLAN
     )
 
 
@@ -197,15 +190,14 @@ def test_get_user_plan_from_profiling_upload(dbsession, fake_profiling_commit_up
     (profiling_upload, profiling_upload_enterprise) = fake_profiling_commit_upload
     assert (
         _get_user_plan_from_profiling_upload(dbsession, profiling_upload.id)
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
     assert (
         _get_user_plan_from_profiling_upload(dbsession, profiling_upload_enterprise.id)
-        == BillingPlan.enterprise_cloud_yearly.db_name
+        == PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
     assert (
-        _get_user_plan_from_profiling_upload(dbsession, 10000000)
-        == BillingPlan.users_basic.db_name
+        _get_user_plan_from_profiling_upload(dbsession, 10000000) == DEFAULT_FREE_PLAN
     )
 
 
@@ -213,18 +205,15 @@ def test_get_user_plan_from_comparison_id(dbsession, fake_comparison_commit):
     (compare_commit, compare_commit_enterprise) = fake_comparison_commit
     assert (
         _get_user_plan_from_comparison_id(dbsession, comparison_id=compare_commit.id)
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
     assert (
         _get_user_plan_from_comparison_id(
             dbsession, comparison_id=compare_commit_enterprise.id
         )
-        == BillingPlan.enterprise_cloud_yearly.db_name
+        == PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
-    assert (
-        _get_user_plan_from_comparison_id(dbsession, 10000000)
-        == BillingPlan.users_basic.db_name
-    )
+    assert _get_user_plan_from_comparison_id(dbsession, 10000000) == DEFAULT_FREE_PLAN
 
 
 def test_get_user_plan_from_label_request_id(dbsession, fake_label_analysis_request):
@@ -236,17 +225,16 @@ def test_get_user_plan_from_label_request_id(dbsession, fake_label_analysis_requ
         _get_user_plan_from_label_request_id(
             dbsession, request_id=label_analysis_request.id
         )
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
     assert (
         _get_user_plan_from_label_request_id(
             dbsession, request_id=label_analysis_request_enterprise.id
         )
-        == BillingPlan.enterprise_cloud_yearly.db_name
+        == PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
     assert (
-        _get_user_plan_from_label_request_id(dbsession, 10000000)
-        == BillingPlan.users_basic.db_name
+        _get_user_plan_from_label_request_id(dbsession, 10000000) == DEFAULT_FREE_PLAN
     )
 
 
@@ -259,18 +247,15 @@ def test_get_user_plan_from_static_analysis_suite(
     ) = fake_static_analysis_suite
     assert (
         _get_user_plan_from_suite_id(dbsession, suite_id=static_analysis_suite.id)
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
     assert (
         _get_user_plan_from_suite_id(
             dbsession, suite_id=static_analysis_suite_enterprise.id
         )
-        == BillingPlan.enterprise_cloud_yearly.db_name
+        == PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
-    assert (
-        _get_user_plan_from_suite_id(dbsession, 10000000)
-        == BillingPlan.users_basic.db_name
-    )
+    assert _get_user_plan_from_suite_id(dbsession, 10000000) == DEFAULT_FREE_PLAN
 
 
 def test_get_user_plan_from_task(
@@ -289,7 +274,7 @@ def test_get_user_plan_from_task(
         _get_user_plan_from_task(
             dbsession, shared_celery_config.upload_task_name, task_kwargs
         )
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
 
     task_kwargs = dict(
@@ -299,7 +284,7 @@ def test_get_user_plan_from_task(
         _get_user_plan_from_task(
             dbsession, shared_celery_config.upload_task_name, task_kwargs
         )
-        == BillingPlan.enterprise_cloud_yearly.db_name
+        == PlanName.ENTERPRISE_CLOUD_YEARLY.value
     )
 
     task_kwargs = dict(ownerid=repo.ownerid)
@@ -307,7 +292,7 @@ def test_get_user_plan_from_task(
         _get_user_plan_from_task(
             dbsession, shared_celery_config.delete_owner_task_name, task_kwargs
         )
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
 
     task_kwargs = dict(org_ownerid=repo.ownerid, user_ownerid=20)
@@ -315,7 +300,7 @@ def test_get_user_plan_from_task(
         _get_user_plan_from_task(
             dbsession, shared_celery_config.new_user_activated_task_name, task_kwargs
         )
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
 
     task_kwargs = dict(profiling_id=profiling_commit.id)
@@ -323,7 +308,7 @@ def test_get_user_plan_from_task(
         _get_user_plan_from_task(
             dbsession, shared_celery_config.profiling_collection_task_name, task_kwargs
         )
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
 
     task_kwargs = dict(profiling_upload_id=profiling_upload.id)
@@ -333,7 +318,7 @@ def test_get_user_plan_from_task(
             shared_celery_config.profiling_normalization_task_name,
             task_kwargs,
         )
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
 
     task_kwargs = dict(comparison_id=compare_commit.id)
@@ -341,7 +326,7 @@ def test_get_user_plan_from_task(
         _get_user_plan_from_task(
             dbsession, shared_celery_config.compute_comparison_task_name, task_kwargs
         )
-        == BillingPlan.pr_monthly.db_name
+        == PlanName.CODECOV_PRO_MONTHLY.value
     )
 
     task_kwargs = dict(
@@ -349,7 +334,7 @@ def test_get_user_plan_from_task(
     )
     assert (
         _get_user_plan_from_task(dbsession, "unknown task", task_kwargs)
-        == BillingPlan.users_basic.db_name
+        == DEFAULT_FREE_PLAN
     )
 
 
@@ -366,5 +351,5 @@ def test_route_task(mocker, dbsession, fake_repos):
     assert response == {"queue": "correct queue"}
     mock_get_db_session.assert_called()
     mock_route_tasks_shared.assert_called_with(
-        shared_celery_config.upload_task_name, BillingPlan.pr_monthly.db_name
+        shared_celery_config.upload_task_name, PlanName.CODECOV_PRO_MONTHLY.value
     )


### PR DESCRIPTION
This PR updates a couple references of "users-basic" to use the new "DEFAULT_FREE_PLAN" variable, which will also help us if we update that free plan later on so we don't miss these references in the future.

Additionally, I removed all instances of the "billingPlan" enum in favor of the PlanName enum since that one's deprecated

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.