### PR TITLE
Bundle Analysis: fix processor retry

### DIFF
--- a/tasks/tests/unit/test_bundle_analysis_processor_task.py
+++ b/tasks/tests/unit/test_bundle_analysis_processor_task.py
@@ -176,7 +176,7 @@ def test_bundle_analysis_processor_task_error(
 
     assert commit.state == "error"
     assert upload.state == "error"
-    retry.assert_called_once_with(countdown=20, max_retries=5)
+    retry.assert_called_once_with(countdown=30)
 
 
 def test_bundle_analysis_processor_task_general_error(
@@ -362,7 +362,7 @@ def test_bundle_analysis_processor_task_locked(
     assert result is None
 
     assert upload.state == "started"
-    retry.assert_called_once_with(countdown=ANY, max_retries=5)
+    retry.assert_called_once_with(countdown=ANY)
 
 
 def test_bundle_analysis_process_upload_rate_limit_error(
@@ -431,7 +431,7 @@ def test_bundle_analysis_process_upload_rate_limit_error(
 
     assert commit.state == "error"
     assert upload.state == "error"
-    retry.assert_called_once_with(countdown=20, max_retries=5)
+    retry.assert_called_once_with(countdown=30)
 
 
 def test_bundle_analysis_process_associate_no_parent_commit_id(


### PR DESCRIPTION
Fix a retry issue where it doesn't trigger more than once and change the cooldown to be exponentially increasing

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.