### PR TITLE
Try more kwargs when populating the `LogContext`

### DIFF
--- a/tasks/base.py
+++ b/tasks/base.py
@@ -267,9 +267,9 @@ class BaseCodecovTask(celery_app.Task):
             db_session = get_db_session()
 
             log_context = LogContext(
-                repo_id=kwargs.get("repoid"),
+                repo_id=kwargs.get("repoid") or kwargs.get("repo_id"),
                 owner_id=kwargs.get("ownerid"),
-                commit_sha=kwargs.get("commitid"),
+                commit_sha=kwargs.get("commitid") or kwargs.get("commit_id"),
             )
 
             task = get_current_task()

--- a/tasks/sync_repo_languages.py
+++ b/tasks/sync_repo_languages.py
@@ -3,7 +3,6 @@ import logging
 from asgiref.sync import async_to_sync
 from shared.celery_config import sync_repo_languages_task_name
 from shared.torngit.exceptions import TorngitError
-from sqlalchemy import String
 from sqlalchemy.orm.session import Session
 
 from app import celery_app
@@ -24,7 +23,7 @@ REPOSITORY_LANGUAGE_SYNC_THRESHOLD = 7
 
 class SyncRepoLanguagesTask(BaseCodecovTask, name=sync_repo_languages_task_name):
     def run_impl(
-        self, db_session: Session, repoid: String, manual_trigger=False, *args, **kwargs
+        self, db_session: Session, repoid: int, manual_trigger=False, *args, **kwargs
     ):
         repository = db_session.query(Repository).get(repoid)
         if repository is None:


### PR DESCRIPTION
The `ProcessFlakesTask` is using `repo_id` and `commit_id` with underscores, so lets add those to the `LogContext` resolution as well.