### PR TITLE
Remove Impact Analysis Deprecation Notice

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -9,10 +9,6 @@ SYNC_PULL_USE_MERGE_COMMIT_SHA = Feature("sync_pull_use_merge_commit_sha")
 
 CHECKPOINT_ENABLED_REPOSITORIES = Feature("checkpoint_enabled_repositories")
 
-SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG = Feature(
-    "show_impact_analysis_deprecation_message"
-)
-
 NEW_TA_TASKS = Feature("new_ta_tasks")
 
 PARALLEL_COMPONENT_COMPARISON = Feature("parallel_component_comparison")

--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -10,7 +10,6 @@ from shared.validation.helpers import LayoutStructure
 from database.models.core import Owner
 from helpers.environment import is_enterprise
 from helpers.metrics import metrics
-from rollouts import SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG
 from services.comparison import ComparisonProxy, FilteredComparison
 from services.notification.notifiers.mixins.message.helpers import (
     should_message_be_compact,
@@ -187,20 +186,7 @@ class MessageMixin(object):
                         section_writer,
                     )
 
-        self._possibly_write_impact_analysis_deprecation(comparison, write)
-
         return [m for m in message if m is not None]
-
-    def _possibly_write_impact_analysis_deprecation(self, comparison, write):
-        # CAN BE REMOVED AFTER January 31st 2025
-        # Will only be shown to orgs specified in the feature flag override.
-        repo: Repository = comparison.head.commit.repository
-        if SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG.check_value(
-            identifier=repo.repoid, default=False
-        ):
-            write(
-                ":warning: Impact Analysis from Codecov is deprecated and will be sunset on Jan 31 2025. [See more](https://docs.codecov.com/docs/impact-analysis)"
-            )
 
     def _possibly_write_install_app(
         self, comparison: ComparisonProxy, write: Callable

--- a/services/notification/notifiers/mixins/message/writers.py
+++ b/services/notification/notifiers/mixins/message/writers.py
@@ -7,7 +7,6 @@ from shared.reports.resources import Report
 
 from database.models import Repository
 from helpers.reports import get_totals_from_file_in_reports
-from rollouts import SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG
 from services.comparison import ComparisonProxy
 from services.notification.notifiers.mixins.message.helpers import (
     ellipsis,
@@ -149,10 +148,4 @@ class TeamPlanWriter:
         # CAN BE REMOVED AFTER January 31st 2025
         # Will only be shown to orgs specified in the feature flag override.
         repo: Repository = comparison.head.commit.repository
-        if SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG.check_value(
-            identifier=repo.repoid, default=False
-        ):
-            lines.append(
-                ":warning: Impact Analysis from Codecov is deprecated and will be sunset on Jan 31 2025. [See more](https://docs.codecov.com/docs/impact-analysis)"
-            )
         return lines

--- a/services/notification/notifiers/tests/unit/test_comment.py
+++ b/services/notification/notifiers/tests/unit/test_comment.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import List
-from unittest.mock import PropertyMock, patch
+from unittest.mock import PropertyMock
 
 import pytest
 from shared.plan.constants import DEFAULT_FREE_PLAN, PlanName
@@ -21,7 +21,6 @@ from shared.yaml import UserYaml
 from database.models.core import Commit, GithubAppInstallation, Pull, Repository
 from database.tests.factories import RepositoryFactory
 from database.tests.factories.core import CommitFactory, OwnerFactory, PullFactory
-from rollouts import SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG
 from services.comparison import ComparisonContext, ComparisonProxy
 from services.comparison.types import Comparison, FullCommit, ReportUploadedCount
 from services.decoration import Decoration
@@ -681,11 +680,6 @@ class TestCommentNotifier(object):
             == ":warning: Please install the !['codecov app svg image'](https://github.com/codecov/engineering-team/assets/152432831/e90313f4-9d3a-4b63-8b54-cfe14e7ec20d) to ensure uploads and comments are reliably processed by Codecov."
         )
 
-    @patch.object(
-        SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG,
-        "check_value",
-        return_value=True,
-    )
     @pytest.mark.django_db
     def test_build_message(
         self, dbsession, mock_configuration, mock_repo_provider, sample_comparison
@@ -756,7 +750,6 @@ class TestCommentNotifier(object):
             f"[{sample_comparison.project_coverage_base.commit.commitid[:7]}...{sample_comparison.head.commit.commitid[:7]}](test.example.br/gh/{repository.slug}/pull/{pull.pullid}?dropdown=coverage&src=pr&el=lastupdated). "
             f"Read the [comment docs](https://docs.codecov.io/docs/pull-request-comments).",
             "",
-            ":warning: Impact Analysis from Codecov is deprecated and will be sunset on Jan 31 2025. [See more](https://docs.codecov.com/docs/impact-analysis)",
         ]
         for exp, res in zip(expected_result, result):
             assert exp == res
@@ -3530,9 +3523,6 @@ class TestAnnouncementsSectionWriter(object):
 
 
 class TestNewFooterSectionWriter(object):
-    @patch.object(
-        SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG, "check_value", return_value=True
-    )
     def test_footer_section_writer_in_github(self, mocker):
         writer = NewFooterSectionWriter(
             mocker.MagicMock(),
@@ -4096,9 +4086,6 @@ class TestCommentNotifierInNewLayout(object):
         ]
         assert result == expected_result
 
-    @patch.object(
-        SHOW_IMPACT_ANALYSIS_DEPRECATION_MSG, "check_value", return_value=True
-    )
     @pytest.mark.django_db
     def test_build_message_team_plan_customer_all_lines_covered(
         self,
@@ -4138,7 +4125,6 @@ class TestCommentNotifierInNewLayout(object):
             ":white_check_mark: All tests successful. No failed tests found.",
             "",
             ":loudspeaker: Thoughts on this report? [Let us know!](https://github.com/codecov/feedback/issues/255)",
-            ":warning: Impact Analysis from Codecov is deprecated and will be sunset on Jan 31 2025. [See more](https://docs.codecov.com/docs/impact-analysis)",
         ]
         assert result == expected_result
 


### PR DESCRIPTION
This mainly removes the Impact Analysis Deprecation Notice from the code.

Also includes a change to remove a table reference from some clean up code.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.