### PR TITLE
Enable autocommit for cleanup tasks, and other improvements

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 https://github.com/codecov/test-results-parser/archive/190bbc8a911099749928e13d5fe57f6027ca1e74.tar.gz#egg=test-results-parser
-https://github.com/codecov/shared/archive/016a756f2ab982016bc2d46e2467be71604c0ba5.tar.gz#egg=shared
+https://github.com/codecov/shared/archive/3aea532ed80c4d941cbc50e27b11147a8f72d3cd.tar.gz#egg=shared
 https://github.com/codecov/timestring/archive/d37ceacc5954dff3b5bd2f887936a98a668dda42.tar.gz#egg=timestring
 asgiref>=3.7.2
 analytics-python==1.3.0b1

--- a/requirements.txt
+++ b/requirements.txt
@@ -379,7 +379,7 @@ sentry-sdk==2.13.0
     #   shared
 setuptools==75.7.0
     # via nodeenv
-shared @ https://github.com/codecov/shared/archive/016a756f2ab982016bc2d46e2467be71604c0ba5.tar.gz#egg=shared
+shared @ https://github.com/codecov/shared/archive/3aea532ed80c4d941cbc50e27b11147a8f72d3cd.tar.gz#egg=shared
     # via -r requirements.in
 six==1.16.0
     # via

--- a/services/cleanup/owner.py
+++ b/services/cleanup/owner.py
@@ -30,8 +30,6 @@ def clear_owner_references(owner_id: int):
     This clears the `ownerid` from various DB arrays where it is being referenced.
     """
 
-    # TODO: Some of these UPDATEs are horribly slow because of missing indices.
-    # In particular, filtering by `Commit.author` takes an incredibly long time.
     OwnerProfile.objects.filter(default_org=owner_id).update(default_org=None)
     Owner.objects.filter(bot=owner_id).update(bot=None)
     Repository.objects.filter(bot=owner_id).update(bot=None)

--- a/services/cleanup/repository.py
+++ b/services/cleanup/repository.py
@@ -99,8 +99,4 @@ def start_repo_cleanup(repo_id: int) -> tuple[bool, int]:
             image_token=new_token,
         )
 
-    # The equivalent of `SET NULL`:
-    # TODO: maybe turn this into a `MANUAL_CLEANUP`?
-    Repository.objects.filter(fork=repo_id).update(fork=None)
-
     return (True, shadow_owner.ownerid)

--- a/services/cleanup/tests/test_utils.py
+++ b/services/cleanup/tests/test_utils.py
@@ -1,0 +1,55 @@
+import pytest
+from django.db import transaction
+from shared.django_apps.core.models import Commit
+from shared.django_apps.core.tests.factories import (
+    CommitFactory,
+    OwnerFactory,
+    RepositoryFactory,
+)
+
+from services.cleanup.cleanup import run_cleanup
+from services.cleanup.utils import CleanupResult, CleanupSummary, with_autocommit
+
+
+@pytest.mark.django_db(transaction=True)
+def test_with_autommit(mock_archive_storage):
+    mock_archive_storage.write_file("archive", "some_random_path", b"some random data")
+
+    owner = OwnerFactory()
+    repo = RepositoryFactory(author=owner)
+    CommitFactory(author=owner, repository=repo)
+    CommitFactory(
+        author=owner, repository=repo, _report_storage_path="some_random_path"
+    )
+    transaction.commit()
+
+    assert Commit.objects.all().count() == 2
+
+    transaction.set_autocommit(False)
+    query = Commit.objects.all()
+    summary = run_cleanup(query)
+    transaction.rollback()
+
+    # Oops, the transaction was rolled back, but the cleanup job still reports stuff being cleaned up.
+    # Not only that, but the files actually *were* deleted, leading to inconsistency
+    assert summary == CleanupSummary(
+        CleanupResult(2, 1),
+        {
+            Commit: CleanupResult(2, 1),
+        },
+    )
+    assert Commit.objects.all().count() == 2
+    assert len(mock_archive_storage.storage["archive"]) == 0
+
+    with with_autocommit():
+        query = Commit.objects.all()
+        summary = run_cleanup(query)
+        transaction.rollback()  # <- this `rollback` here has no effect, as the cleanup was auto-committed
+
+    assert summary == CleanupSummary(
+        CleanupResult(2, 0),
+        {
+            Commit: CleanupResult(2, 0),
+        },
+    )
+    assert Commit.objects.all().count() == 0

--- a/services/cleanup/utils.py
+++ b/services/cleanup/utils.py
@@ -3,6 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 
 import shared.storage
+from django.db import transaction
 from django.db.models import Model
 from shared.api_archive.storage import StorageService
 from shared.config import get_config
@@ -32,6 +33,25 @@ def cleanup_context():
         yield context
     finally:
         context.threadpool.shutdown()
+
+
+@contextmanager
+def with_autocommit():
+    conn = transaction.get_connection()
+    # if we are in an `atomic` block, we cannot mess with the autocommit flag
+    if conn.in_atomic_block:
+        yield
+        return
+
+    try:
+        autocommit = conn.get_autocommit()
+        if autocommit != True:
+            # we first have to commit an implicitly running transaction
+            conn.commit()
+            conn.set_autocommit(True)
+        yield
+    finally:
+        conn.set_autocommit(autocommit)
 
 
 @dataclasses.dataclass

--- a/tasks/delete_owner.py
+++ b/tasks/delete_owner.py
@@ -5,7 +5,7 @@ from shared.celery_config import delete_owner_task_name
 
 from app import celery_app
 from services.cleanup.owner import cleanup_owner
-from services.cleanup.utils import CleanupSummary
+from services.cleanup.utils import CleanupSummary, with_autocommit
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
@@ -17,7 +17,8 @@ class DeleteOwnerTask(BaseCodecovTask, name=delete_owner_task_name):
 
     def run_impl(self, _db_session, ownerid: int) -> CleanupSummary:
         try:
-            return cleanup_owner(ownerid)
+            with with_autocommit():
+                return cleanup_owner(ownerid)
         except SoftTimeLimitExceeded:
             raise self.retry()
 

--- a/tasks/flush_repo.py
+++ b/tasks/flush_repo.py
@@ -4,7 +4,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 
 from app import celery_app
 from services.cleanup.repository import cleanup_repo
-from services.cleanup.utils import CleanupSummary
+from services.cleanup.utils import CleanupSummary, with_autocommit
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
@@ -16,7 +16,8 @@ class FlushRepoTask(BaseCodecovTask, name="app.tasks.flush_repo.FlushRepo"):
 
     def run_impl(self, _db_session, repoid: int) -> CleanupSummary:
         try:
-            return cleanup_repo(repoid)
+            with with_autocommit():
+                return cleanup_repo(repoid)
         except SoftTimeLimitExceeded:
             raise self.retry()
 

--- a/tasks/regular_cleanup.py
+++ b/tasks/regular_cleanup.py
@@ -5,7 +5,7 @@ from celery.exceptions import SoftTimeLimitExceeded
 from app import celery_app
 from celery_config import regular_cleanup_cron_task_name
 from services.cleanup.regular import run_regular_cleanup
-from services.cleanup.utils import CleanupSummary
+from services.cleanup.utils import CleanupSummary, with_autocommit
 from tasks.base import BaseCodecovTask
 
 log = logging.getLogger(__name__)
@@ -17,7 +17,8 @@ class RegularCleanupTask(BaseCodecovTask, name=regular_cleanup_cron_task_name):
 
     def run_impl(self, _db_session, *args, **kwargs) -> CleanupSummary:
         try:
-            return run_regular_cleanup()
+            with with_autocommit():
+                return run_regular_cleanup()
         except SoftTimeLimitExceeded:
             raise self.retry()
 


### PR DESCRIPTION
This has various improvements to the cleanup tasks:

- First, it adds a `with_autocommit` contextmanager, which enables django autocommit for the various cleanup tasks. As the tasks are designed to be retried on timeouts, we still want to commit deletion progress as we go.
- It adds the `timeseries` cleanup to the `Repository` as well. Previously, when deleting all `Repository`s related to a parent `Owner`, this would have been skipped.
- Captures and ignores all the storage-related errors, and reduces the chunksize a bit. In particular the `regular_cleanup` is currently failing consistently because of some random storage-related errors. This shoul not stop progress on the deletion job.