### PR TITLE
Add `ProfilingUpload` to the `regular_cleanup` job

### DIFF
--- a/services/cleanup/cleanup.py
+++ b/services/cleanup/cleanup.py
@@ -1,16 +1,23 @@
+import contextlib
 import logging
 
 from django.db.models.query import QuerySet
 
 from services.cleanup.models import MANUAL_CLEANUP
 from services.cleanup.relations import build_relation_graph
-from services.cleanup.utils import CleanupResult, CleanupSummary, cleanup_context
+from services.cleanup.utils import (
+    CleanupContext,
+    CleanupResult,
+    CleanupSummary,
+    cleanup_context,
+)
 
 log = logging.getLogger(__name__)
 
 
 def run_cleanup(
     query: QuerySet,
+    context: CleanupContext | None = None,
 ) -> CleanupSummary:
     """
     Cleans up all the models and storage files reachable from the given `QuerySet`.
@@ -26,7 +33,8 @@ def run_cleanup(
     cleaned_models = 0
     cleaned_files = 0
 
-    with cleanup_context() as context:
+    cm = contextlib.nullcontext(context) if context else cleanup_context()
+    with cm as context:
         for relation in models_to_cleanup:
             model = relation.model
             result = CleanupResult(0)

--- a/services/cleanup/regular.py
+++ b/services/cleanup/regular.py
@@ -1,9 +1,11 @@
 import logging
+import random
 
+from shared.django_apps.profiling.models import ProfilingUpload
 from shared.django_apps.reports.models import ReportDetails
 
 from services.cleanup.cleanup import run_cleanup
-from services.cleanup.utils import CleanupResult, CleanupSummary
+from services.cleanup.utils import CleanupResult, CleanupSummary, cleanup_context
 
 log = logging.getLogger(__name__)
 
@@ -12,12 +14,23 @@ def run_regular_cleanup() -> CleanupSummary:
     log.info("Starting regular cleanup job")
     complete_summary = CleanupSummary(CleanupResult(0), summary={})
 
-    # Usage of this model was removed, and we should clean up all its data before dropping the table for good.
-    log.info("Cleaning up `ReportDetails`")
-    query = ReportDetails.objects.all()
-    summary = run_cleanup(query)
-    log.info("Cleaned up `ReportDetails`", extra={"summary": summary})
-    complete_summary.add(summary)
+    # Usage of these model was removed, and we should clean up all its data before dropping the table for good.
+    cleanups_to_run = [
+        ReportDetails.objects.all(),
+        ProfilingUpload.objects.all(),
+    ]
+
+    # as we expect this job to have frequent retries, and cleanup to take a long time,
+    # lets shuffle the various cleanups so that each one of those makes a little progress.
+    random.shuffle(cleanups_to_run)
+
+    with cleanup_context() as context:
+        for query in cleanups_to_run:
+            name = query.model.__name__
+            log.info(f"Cleaning up `{name}`")
+            summary = run_cleanup(query, context=context)
+            log.info(f"Cleaned up `{name}`", extra={"summary": summary})
+            complete_summary.add(summary)
 
     # TODO:
     # - cleanup old `ReportSession`s (aka `Upload`s)


### PR DESCRIPTION
Thi `regular_cleanup` cron task is a scheduled task that is used to clean up data that is not needed anymore.

In particular, it will delete all the storage associated with certain models, as opposed to just dropping the table.

As we have deprecated the "profiling"/"impact analysis" feature, and are about to drop the `ProfilingUpload` model completely, lets run it through this cleanup task to fully wipe all the uploaded data as well.