### PR TITLE
dev: Add error type to log for better debugging

### DIFF
--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -275,7 +275,7 @@ class BundleAnalysisReportService(BaseReportService):
 
             # save the bundle report back to storage
             bundle_loader.save(bundle_report, commit_report.external_id)
-        except FileNotInStorageError:
+        except FileNotInStorageError as e:
             BUNDLE_ANALYSIS_REPORT_PROCESSOR_COUNTER.labels(
                 result="file_not_in_storage",
                 plugin_name="n/a",

--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -312,7 +312,11 @@ class BundleAnalysisReportService(BaseReportService):
             log.error(
                 "Unable to parse upload for bundle analysis",
                 exc_info=True,
-                extra=dict(repoid=commit.repoid, commit=commit.commitid),
+                extra=dict(
+                    repoid=commit.repoid,
+                    commit=commit.commitid,
+                    error_type=type(e).__name__,
+                ),
             )
             return ProcessingResult(
                 upload=upload,

--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -305,9 +305,11 @@ class BundleAnalysisReportService(BaseReportService):
         except Exception as e:
             # Metrics to count number of parsing errors of bundle files by plugins
             plugin_name = getattr(e, "bundle_analysis_plugin_name", "unknown")
+            error_type = type(e).__name__
             BUNDLE_ANALYSIS_REPORT_PROCESSOR_COUNTER.labels(
                 result="parser_error",
                 plugin_name=plugin_name,
+                error_type=error_type,
             ).inc()
             log.error(
                 "Unable to parse upload for bundle analysis",
@@ -315,7 +317,7 @@ class BundleAnalysisReportService(BaseReportService):
                 extra=dict(
                     repoid=commit.repoid,
                     commit=commit.commitid,
-                    error_type=type(e).__name__,
+                    error_type=error_type,
                 ),
             )
             return ProcessingResult(


### PR DESCRIPTION
Starts fixing https://github.com/codecov/engineering-team/issues/3190 by first adding the error name to the logs and see what that gives back to us. From there we can start exploring the different exception types a bit easier

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.