### PR TITLE
makefile changes for monorepo prep

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,7 +218,7 @@ test_env.install_cli:
 test_env.container_prepare:
 	apt-get update
 	apt-get install -y git build-essential netcat-traditional
-	git config --global --add safe.directory /worker
+	git config --global --add safe.directory /worker || true
 
 test_env.container_check_db:
 	while ! nc -vz postgres 5432; do sleep 1; echo "waiting for postgres"; done


### PR DESCRIPTION
needed for https://github.com/codecov/umbrella/pull/4

we bindmount our local `worker` into the docker container. currently our local `worker` is the actual git repo, so the `git` invocation works. in umbrella, it's not the actual git repo, so the command fails

apparently this is all i need to change...?