### PR TITLE
Capture `SoftTimeLimitExceeded` errors

### DIFF
--- a/helpers/sentry.py
+++ b/helpers/sentry.py
@@ -1,7 +1,6 @@
 import os
 
 import sentry_sdk
-from celery.exceptions import SoftTimeLimitExceeded
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.httpx import HttpxIntegration
@@ -10,14 +9,6 @@ from sentry_sdk.integrations.sqlalchemy import SqlalchemyIntegration
 from shared.config import get_config
 
 from helpers.version import get_current_version
-
-
-def before_send(event, hint):
-    if "exc_info" in hint:
-        exc_type, exc_value, tb = hint["exc_info"]
-        if isinstance(exc_value, SoftTimeLimitExceeded):
-            return None
-    return event
 
 
 def is_sentry_enabled() -> bool:
@@ -30,7 +21,6 @@ def initialize_sentry() -> None:
     sentry_dsn = get_config("services", "sentry", "server_dsn")
     sentry_sdk.init(
         sentry_dsn,
-        before_send=before_send,
         sample_rate=float(os.getenv("SENTRY_PERCENTAGE", 1.0)),
         environment=os.getenv("DD_ENV", "production"),
         traces_sample_rate=float(os.environ.get("SERVICES__SENTRY__SAMPLE_RATE", 1)),

--- a/helpers/tests/unit/test_sentry.py
+++ b/helpers/tests/unit/test_sentry.py
@@ -1,6 +1,6 @@
 import os
 
-from helpers.sentry import before_send, initialize_sentry
+from helpers.sentry import initialize_sentry
 
 
 class TestSentry(object):
@@ -16,7 +16,6 @@ class TestSentry(object):
         assert initialize_sentry() is None
         mocked_init.assert_called_with(
             "this_dsn",
-            before_send=before_send,
             release="worker-FAKE_VERSION_FOR_YOU",
             sample_rate=1.0,
             traces_sample_rate=1.0,

--- a/tasks/base.py
+++ b/tasks/base.py
@@ -363,7 +363,7 @@ class BaseCodecovTask(celery_app.Task):
 
     def on_failure(self, exc, task_id, args, kwargs, einfo):
         """
-        Includes SoftTimeoutLimitException, for example
+        Includes SoftTimeLimitExceeded, for example
         """
         res = super().on_failure(exc, task_id, args, kwargs, einfo)
         self.task_failure_counter.inc()


### PR DESCRIPTION
Previously, Sentry was configured to drop such errors and not capture those.

I believe it is still valuable to capture these, even though they might be unactionable in lots of cases.