### PR TITLE
Correct the types needed to `delete_multiple_sessions`

### DIFF
--- a/services/processing/merging.py
+++ b/services/processing/merging.py
@@ -24,7 +24,7 @@ log = logging.getLogger(__name__)
 @sentry_sdk.trace
 def merge_reports(
     commit_yaml: UserYaml,
-    master_report: Report,
+    master_report: EditableReport,
     intermediate_reports: list[IntermediateReport],
 ) -> tuple[Report, MergeResult]:
     session_mapping: dict[int, int] = dict()

--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -15,7 +15,7 @@ from shared.celery_config import (
     timeseries_save_commit_measurements_task_name,
     upload_finisher_task_name,
 )
-from shared.reports.resources import Report
+from shared.reports.editable import EditableReport
 from shared.timeseries.helpers import is_timeseries_enabled
 from shared.torngit.exceptions import TorngitError
 from shared.yaml import UserYaml
@@ -388,10 +388,14 @@ def perform_report_merging(
     commit_yaml: UserYaml,
     commit: Commit,
     processing_results: list[ProcessingResult],
-) -> Report:
-    master_report = report_service.get_existing_report_for_commit(commit)
+) -> EditableReport:
+    master_report: EditableReport | None
+    # its unclear how to express the generic `report_class`
+    master_report = report_service.get_existing_report_for_commit(
+        commit, report_class=EditableReport
+    )  # type: ignore
     if master_report is None:
-        master_report = Report()
+        master_report = EditableReport()
 
     upload_ids = [
         upload["upload_id"] for upload in processing_results if upload["successful"]


### PR DESCRIPTION
The `delete(_multiple)_sessions` function only exists on the `EditableReport`, so make sure to enforce that type, as well as optimizing the code so that it uses the batch-delete function.