### PR TITLE
fix: process flakes task redis lock and key

### DIFF
--- a/tasks/ta_finisher.py
+++ b/tasks/ta_finisher.py
@@ -45,7 +45,10 @@ from services.test_results import (
 from tasks.base import BaseCodecovTask
 from tasks.cache_test_rollups import cache_test_rollups_task
 from tasks.notify import notify_task
-from tasks.process_flakes import process_flakes_task
+from tasks.process_flakes import (
+    NEW_KEY,
+    process_flakes_task,
+)
 
 log = logging.getLogger(__name__)
 
@@ -89,7 +92,7 @@ def queue_optional_tasks(
 
     if should_do_flaky_detection(repo, commit_yaml):
         if commit.merged is True or branch == repo.branch:
-            redis_client.set(f"flake_uploads:{repo.repoid}", 0)
+            redis_client.rpush(NEW_KEY.format(repo.repoid), commit.commitid)
             process_flakes_task_sig = process_flakes_task.s(
                 repo_id=repo.repoid,
                 commit_id=commit.commitid,


### PR DESCRIPTION
Previously, I made the decision to use a redis lock to exclude multiple process_flakes tasks from running for the same repo at the same time, so that we would minimize database concurrency issues. 

The idea was that I would set this redis key that represents "more flakes need to be processed for this repo" and that tasks that failed to acquire the lock could rely on the currently running task to handle their work so they wouldn't have to block. I never actually implemented the part where the currently running task takes the work of tasks that ceded their work to it.

This commit implements that by replacing the value of the current redis key with a list of commits that need to be processed, this way the currently running task actually has access to the commits that need to be processed.