### PR TITLE
fix: Update default plan value on owner model to DEFAULT_PLAN_VAL

### DIFF
--- a/database/models/core.py
+++ b/database/models/core.py
@@ -114,7 +114,7 @@ class Owner(CodecovBaseModel):
     trial_end_date = Column(types.DateTime, server_default=FetchedValue())
     trial_status = Column(types.Text, server_default=FetchedValue())
     trial_fired_by = Column(types.Integer, server_default=FetchedValue())
-    plan = Column(types.Text, server_default=FetchedValue())
+    plan = Column(types.Text, default=DEFAULT_FREE_PLAN)
     plan_user_count = Column(types.SmallInteger, server_default=FetchedValue())
     pretrial_users_count = Column(types.SmallInteger, server_default=FetchedValue())
     plan_auto_activate = Column(types.Boolean, server_default=FetchedValue())


### PR DESCRIPTION
@calvin-codecov found that owners were still being created with users-basic, which is a value being derived from the DB

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.