### PR TITLE
move upload task to get_repo_provider_service wrapper

### DIFF
--- a/tasks/tests/unit/test_upload_task.py
+++ b/tasks/tests/unit/test_upload_task.py
@@ -484,7 +484,7 @@ class TestUploadTaskIntegration(object):
         }
 
         mocker.patch(
-            "tasks.upload.get_repo_provider_service",
+            "tasks.base.get_repo_provider_service",
             return_value=mock_repo_provider_service,
         )
         mocker.patch("tasks.upload.hasattr", return_value=False)
@@ -888,7 +888,7 @@ class TestUploadTaskIntegration(object):
             {"build": "part2", "url": "url2"},
         ]
         jsonified_redis_queue = [json.dumps(x) for x in redis_queue]
-        mock_get_repo_service = mocker.patch("tasks.upload.get_repo_provider_service")
+        mock_get_repo_service = mocker.patch("tasks.base.get_repo_provider_service")
         mock_get_repo_service.side_effect = RepositoryWithoutValidBotError()
         commit = CommitFactory.create(
             message="",
@@ -955,7 +955,7 @@ class TestUploadTaskIntegration(object):
             {"build": "part2", "url": "url2"},
         ]
         jsonified_redis_queue = [json.dumps(x) for x in redis_queue]
-        mock_get_repo_service = mocker.patch("tasks.upload.get_repo_provider_service")
+        mock_get_repo_service = mocker.patch("tasks.base.get_repo_provider_service")
         mock_get_repo_service.side_effect = TorngitRepoNotFoundError(
             "fake_response", "message"
         )
@@ -1198,7 +1198,8 @@ class TestUploadTaskUnit(object):
     def test_schedule_task_with_one_task(self, dbsession, mocker, mock_repo_provider):
         _start_upload_flow(mocker)
         mocker.patch(
-            "tasks.upload.get_repo_provider_service", return_value=mock_repo_provider
+            "tasks.base.get_repo_provider_service",
+            return_value=mock_repo_provider,
         )
         mocker.patch(
             "tasks.upload.UploadTask.possibly_setup_webhooks", return_value=True

--- a/tasks/tests/utils.py
+++ b/tasks/tests/utils.py
@@ -37,7 +37,7 @@ GLOBALS_USING_REPO_PROVIDER = [
     "services.report.get_repo_provider_service",
     "tasks.notify.get_repo_provider_service",
     "tasks.upload_finisher.get_repo_provider_service",
-    "tasks.upload.get_repo_provider_service",
+    "tasks.base.get_repo_provider_service",
 ]
 
 


### PR DESCRIPTION
depends on: https://github.com/codecov/worker/pull/1107
part of: https://github.com/codecov/engineering-team/issues/3389

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.