### PR TITLE
move sync_repos_languages task to get_repo_provider_service wrapper

### DIFF
--- a/tasks/tests/unit/test_sync_repo_languages.py
+++ b/tasks/tests/unit/test_sync_repo_languages.py
@@ -25,7 +25,7 @@ def setup_with_languages(mocker, mock_repo_provider):
 
     mock_repo_provider.get_repo_languages.return_value = LIST_WITH_INTERSECTION
     mocker.patch(
-        f"tasks.{TaskConfigGroup.sync_repo_languages.value}.get_repo_provider_service",
+        "tasks.base.get_repo_provider_service",
         return_value=mock_repo_provider,
     )
 
@@ -36,7 +36,7 @@ def setup_with_null_languages(mocker, mock_repo_provider):
 
     mock_repo_provider.get_repo_languages.return_value = None
     mocker.patch(
-        f"tasks.{TaskConfigGroup.sync_repo_languages.value}.get_repo_provider_service",
+        "tasks.base.get_repo_provider_service",
         return_value=mock_repo_provider,
     )
 
@@ -47,7 +47,7 @@ def setup_with_languages_bitbucket(mocker, mock_repo_provider):
 
     mock_repo_provider.get_repo_languages.return_value = ["javascript"]
     mocker.patch(
-        f"tasks.{TaskConfigGroup.sync_repo_languages.value}.get_repo_provider_service",
+        "tasks.base.get_repo_provider_service",
         return_value=mock_repo_provider,
     )
 
@@ -129,9 +129,10 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert (
-            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) is None
-        )
+        assert task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == {
+            "successful": True,
+            "synced": False,
+        }
 
     def test_languages_no_intersection_and_synced_beyond_threshold(
         self, dbsession, setup_with_languages
@@ -163,9 +164,10 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert (
-            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) is None
-        )
+        assert task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == {
+            "successful": True,
+            "synced": False,
+        }
 
     def test_languages_intersection_and_synced_beyond_threshold(
         self, dbsession, setup_with_null_languages
@@ -179,9 +181,10 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert (
-            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) is None
-        )
+        assert task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == {
+            "successful": True,
+            "synced": False,
+        }
 
     def test_languages_intersection_and_synced_beyond_threshold_with_languages(
         self, dbsession, setup_with_languages
@@ -195,9 +198,10 @@ class TestSyncRepoLanguages(object):
         dbsession.flush()
 
         task = SyncRepoLanguagesTask()
-        assert (
-            task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) is None
-        )
+        assert task.run_impl(dbsession, repoid=repo.repoid, manual_trigger=False) == {
+            "successful": True,
+            "synced": False,
+        }
 
     def test_languages_intersection_and_synced_with_manual_trigger(
         self, dbsession, setup_with_languages


### PR DESCRIPTION
depends on: https://github.com/codecov/worker/pull/1107
part of: https://github.com/codecov/engineering-team/issues/3389

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.