### PR TITLE
Update `shared` again, removing `change_sessionid`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -278,9 +278,6 @@ def mock_archive_storage(mocker):
     )
     storage_server = MemoryStorageService({})
     mocker.patch(
-        "shared.api_archive.archive.StorageService", return_value=storage_server
-    )
-    mocker.patch(
         "shared.storage.get_appropriate_storage_service", return_value=storage_server
     )
     return storage_server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,4 +85,4 @@ dev-dependencies = [
 [tool.uv.sources]
 timestring = { git = "https://github.com/codecov/timestring", rev = "d37ceacc5954dff3b5bd2f887936a98a668dda42" }
 test-results-parser = { git = "https://github.com/codecov/test-results-parser", rev = "190bbc8a911099749928e13d5fe57f6027ca1e74" }
-shared = { git = "https://github.com/codecov/shared", rev = "47fa7fd405cd4a37ab6df9f200d6b600795f2786" }
+shared = { git = "https://github.com/codecov/shared", rev = "fd58134d9f15bce28917f68bda9e740dd9fe32ff" }

--- a/services/cleanup/utils.py
+++ b/services/cleanup/utils.py
@@ -5,13 +5,13 @@ from contextlib import contextmanager
 import shared.storage
 from django.db import transaction
 from django.db.models import Model
-from shared.api_archive.storage import StorageService
 from shared.config import get_config
+from shared.storage.base import BaseStorageService
 
 
 class CleanupContext:
     threadpool: ThreadPoolExecutor
-    storage: StorageService
+    storage: BaseStorageService
     default_bucket: str
     bundleanalysis_bucket: str
 

--- a/services/report/report_builder.py
+++ b/services/report/report_builder.py
@@ -3,8 +3,8 @@ import logging
 from enum import Enum
 from typing import Any, List, Sequence
 
-from shared.reports.resources import LineSession, Report, ReportFile, ReportLine
-from shared.reports.types import CoverageDatapoint
+from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.types import CoverageDatapoint, LineSession
 from shared.yaml.user_yaml import UserYaml
 
 from helpers.labels import SpecialLabelsEnum

--- a/services/report/tests/unit/test_process.py
+++ b/services/report/tests/unit/test_process.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 
 import pytest
 from lxml import etree
-from shared.reports.resources import LineSession, Report, ReportFile, ReportLine
-from shared.reports.types import ReportTotals
+from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.types import LineSession, ReportTotals
 from shared.utils.sessions import Session
 from shared.yaml import UserYaml
 

--- a/services/report/tests/unit/test_report_builder.py
+++ b/services/report/tests/unit/test_report_builder.py
@@ -1,6 +1,6 @@
 import pytest
-from shared.reports.resources import LineSession, ReportFile, ReportLine
-from shared.reports.types import CoverageDatapoint
+from shared.reports.resources import ReportFile, ReportLine
+from shared.reports.types import CoverageDatapoint, LineSession
 
 from services.report.report_builder import (
     CoverageType,

--- a/services/report/tests/unit/test_sessions.py
+++ b/services/report/tests/unit/test_sessions.py
@@ -2,14 +2,13 @@ import pytest
 from mock import MagicMock
 from shared.reports.editable import EditableReport, EditableReportFile
 from shared.reports.resources import (
-    LineSession,
     Report,
     ReportFile,
     ReportLine,
     Session,
     SessionType,
 )
-from shared.reports.types import CoverageDatapoint
+from shared.reports.types import CoverageDatapoint, LineSession
 from shared.yaml import UserYaml
 
 from helpers.labels import SpecialLabelsEnum

--- a/tasks/tests/unit/test_delete_owner.py
+++ b/tasks/tests/unit/test_delete_owner.py
@@ -17,7 +17,7 @@ from tasks.delete_owner import DeleteOwnerTask
 here = Path(__file__)
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases=["timeseries", "default"], transaction=True)
 def test_delete_owner_deletes_owner_with_ownerid(mock_storage):
     user = OwnerFactory()
     repo = RepositoryFactory(author=user)
@@ -44,7 +44,7 @@ def test_delete_owner_deletes_owner_with_ownerid(mock_storage):
     assert Repository.objects.count() == 0
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases=["timeseries", "default"], transaction=True)
 def test_delete_owner_deletes_owner_with_commit_compares(mock_storage):
     user = OwnerFactory()
     repo = RepositoryFactory(author=user)
@@ -75,7 +75,7 @@ def test_delete_owner_deletes_owner_with_commit_compares(mock_storage):
     assert Repository.objects.count() == 0
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db(databases=["timeseries", "default"], transaction=True)
 def test_delete_owner_from_orgs_removes_ownerid_from_organizations_of_related_owners(
     mock_storage,
 ):

--- a/tasks/tests/unit/test_flush_repo.py
+++ b/tasks/tests/unit/test_flush_repo.py
@@ -25,7 +25,7 @@ from services.cleanup.utils import CleanupResult, CleanupSummary
 from tasks.flush_repo import FlushRepoTask
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases=["timeseries", "default"])
 def test_flush_repo_nothing(mock_storage):
     repo = RepositoryFactory()
 
@@ -40,7 +40,7 @@ def test_flush_repo_nothing(mock_storage):
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases=["timeseries", "default"])
 def test_flush_repo_few_of_each_only_db_objects(mock_storage):
     repo = RepositoryFactory()
     flag = RepositoryFlagFactory(repository=repo)
@@ -84,7 +84,7 @@ def test_flush_repo_few_of_each_only_db_objects(mock_storage):
     )
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(databases=["timeseries", "default"])
 def test_flush_repo_little_bit_of_everything(mocker, mock_storage):
     repo = RepositoryFactory()
     archive_service = ArchiveService(repo)

--- a/tasks/tests/unit/test_label_analysis.py
+++ b/tasks/tests/unit/test_label_analysis.py
@@ -2,8 +2,8 @@ import json
 
 import pytest
 from mock import patch
-from shared.reports.resources import LineSession, Report, ReportFile, ReportLine
-from shared.reports.types import CoverageDatapoint
+from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.types import CoverageDatapoint, LineSession
 
 from database.models.labelanalysis import LabelAnalysisRequest
 from database.tests.factories import RepositoryFactory

--- a/tasks/tests/unit/test_label_analysis_encoded_labels.py
+++ b/tasks/tests/unit/test_label_analysis_encoded_labels.py
@@ -2,8 +2,8 @@ import json
 
 import pytest
 from mock import MagicMock, patch
-from shared.reports.resources import LineSession, Report, ReportFile, ReportLine
-from shared.reports.types import CoverageDatapoint
+from shared.reports.resources import Report, ReportFile, ReportLine
+from shared.reports.types import CoverageDatapoint, LineSession
 
 from database.models.labelanalysis import LabelAnalysisRequest
 from database.tests.factories import RepositoryFactory

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = "==3.13.*"
 
 [[package]]
@@ -1336,8 +1337,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/39/1b/d0b013bf7d1af7cf0a6a4fce13f5fe5813ab225313755367b36e714a63f8/pycryptodome-3.21.0-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:18caa8cfbc676eaaf28613637a89980ad2fd96e00c564135bf90bc3f0b34dd93", size = 2254397 },
     { url = "https://files.pythonhosted.org/packages/14/71/4cbd3870d3e926c34706f705d6793159ac49d9a213e3ababcdade5864663/pycryptodome-3.21.0-cp36-abi3-win32.whl", hash = "sha256:280b67d20e33bb63171d55b1067f61fbd932e0b1ad976b3a184303a3dad22764", size = 1775641 },
     { url = "https://files.pythonhosted.org/packages/43/1d/81d59d228381576b92ecede5cd7239762c14001a828bdba30d64896e9778/pycryptodome-3.21.0-cp36-abi3-win_amd64.whl", hash = "sha256:b7aa25fc0baa5b1d95b7633af4f5f1838467f1815442b22487426f94e0d66c53", size = 1812863 },
-    { url = "https://files.pythonhosted.org/packages/25/b3/09ff7072e6d96c9939c24cf51d3c389d7c345bf675420355c22402f71b68/pycryptodome-3.21.0-pp27-pypy_73-manylinux2010_x86_64.whl", hash = "sha256:2cb635b67011bc147c257e61ce864879ffe6d03342dc74b6045059dfbdedafca", size = 1691593 },
-    { url = "https://files.pythonhosted.org/packages/a8/91/38e43628148f68ba9b68dedbc323cf409e537fd11264031961fd7c744034/pycryptodome-3.21.0-pp27-pypy_73-win32.whl", hash = "sha256:4c26a2f0dc15f81ea3afa3b0c87b87e501f235d332b7f27e2225ecb80c0b1cdd", size = 1765997 },
 ]
 
 [[package]]
@@ -1731,7 +1730,7 @@ wheels = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = { git = "https://github.com/codecov/shared?rev=47fa7fd405cd4a37ab6df9f200d6b600795f2786#47fa7fd405cd4a37ab6df9f200d6b600795f2786" }
+source = { git = "https://github.com/codecov/shared?rev=fd58134d9f15bce28917f68bda9e740dd9fe32ff#fd58134d9f15bce28917f68bda9e740dd9fe32ff" }
 dependencies = [
     { name = "amplitude-analytics" },
     { name = "boto3" },
@@ -2074,7 +2073,7 @@ requires-dist = [
     { name = "regex", specifier = ">=2023.12.25" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "sentry-sdk", specifier = ">=2.13.0" },
-    { name = "shared", git = "https://github.com/codecov/shared?rev=47fa7fd405cd4a37ab6df9f200d6b600795f2786" },
+    { name = "shared", git = "https://github.com/codecov/shared?rev=fd58134d9f15bce28917f68bda9e740dd9fe32ff" },
     { name = "sqlalchemy", specifier = "==1.3.*" },
     { name = "sqlparse", specifier = "==0.5.0" },
     { name = "statsd", specifier = ">=3.3.0" },


### PR DESCRIPTION
This function has been moved to `shared`, so can now be removed from `worker`.