### PR TITLE
fix: TA should read comment config value

### DIFF
--- a/helpers/notifier.py
+++ b/helpers/notifier.py
@@ -22,6 +22,7 @@ class NotifierResult(Enum):
     COMMENT_POSTED = "comment_posted"
     TORNGIT_ERROR = "torngit_error"
     NO_PULL = "no_pull"
+    NO_COMMENT = "no_comment"
 
 
 @dataclass

--- a/tasks/ta_finisher.py
+++ b/tasks/ta_finisher.py
@@ -316,7 +316,13 @@ class TAFinisherTask(BaseCodecovTask, name=ta_finisher_task_name):
                 "queue_notify": True,
             }
 
-        if pull:
+        if not pull:
+            success = False
+            notifier_result = NotifierResult.NO_PULL
+        elif not commit_yaml.read_yaml_field("comment", _else=True):
+            success = False
+            notifier_result = NotifierResult.NO_COMMENT
+        else:
             seat_activation_result = self.seat_activation(
                 db_session, pull, commit, commit_yaml, repo_service
             )
@@ -340,9 +346,6 @@ class TAFinisherTask(BaseCodecovTask, name=ta_finisher_task_name):
                 True if notifier_result is NotifierResult.COMMENT_POSTED else False
             )
             TestResultsFlow.log(TestResultsFlow.TEST_RESULTS_NOTIFY)
-        else:
-            success = False
-            notifier_result = NotifierResult.NO_PULL
 
         self.extra_dict["success"] = success
         self.extra_dict["notifier_result"] = notifier_result.value

--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -243,7 +243,15 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
             repo_service, commit, commit_yaml
         )
 
-        if pull is not None:
+        if not pull:
+            success = False
+            attempted = False
+            notifier_result = NotifierResult.NO_PULL
+        elif not commit_yaml.read_yaml_field("comment", _else=True):
+            success = False
+            attempted = False
+            notifier_result = NotifierResult.NO_COMMENT
+        else:
             activate_seat_info = determine_seat_activation(pull)
 
             should_show_upgrade_message = True
@@ -325,10 +333,6 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
                     ),
                 )
             attempted = True
-        else:
-            success = False
-            attempted = False
-            notifier_result = NotifierResult.NO_PULL
 
         self.extra_dict["success"] = success
         self.extra_dict["notifier_result"] = notifier_result.value


### PR DESCRIPTION
prevously it wasn't checking these settings, but it lead to users getting the TA / upgrade comment only, so we should check it