### PR TITLE
feat: new TA processor implementation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -204,6 +204,8 @@ def mock_configuration(mocker):
                 "hash_key": "88f572f4726e4971827415efa8867978",
                 "secret_access_key": "codecov-default-secret",
                 "verify_ssl": False,
+                "host": "minio",
+                "port": 9000,
             },
             "smtp": {
                 "host": "mailhog",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - postgres
       - redis
       - timescale
+      - minio
     volumes:
       - ./:/app/apps/worker
       - ./docker/test_codecov_config.yml:/config/codecov.yml
@@ -40,6 +41,13 @@ services:
       - POSTGRES_PASSWORD=password
     volumes:
       - ./docker/init_db.sql:/docker-entrypoint-initdb.d/init_db.sql
+
+  minio:
+    image: minio/minio:RELEASE.2019-04-09T01-22-30Z
+    command: server /export
+    environment:
+      - MINIO_ACCESS_KEY=codecov-default-key
+      - MINIO_SECRET_KEY=codecov-default-secret
 
   redis:
     image: redis:6-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,10 @@ services:
       - MINIO_ACCESS_KEY=codecov-default-key
       - MINIO_SECRET_KEY=codecov-default-secret
     volumes:
-      - archive-volume:/export
+      - type: tmpfs
+        target: /export
+        tmpfs:
+          size: 256M
   redis:
     image: redis:6-alpine
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,12 +43,15 @@ services:
       - ./docker/init_db.sql:/docker-entrypoint-initdb.d/init_db.sql
 
   minio:
-    image: minio/minio:RELEASE.2019-04-09T01-22-30Z
+    image: minio/minio:latest
     command: server /export
+    ports:
+      - "${MINIO_PORT:-9000}:9000"
     environment:
       - MINIO_ACCESS_KEY=codecov-default-key
       - MINIO_SECRET_KEY=codecov-default-secret
-
+    volumes:
+      - archive-volume:/export
   redis:
     image: redis:6-alpine
 

--- a/docker/test_codecov_config.yml
+++ b/docker/test_codecov_config.yml
@@ -18,6 +18,8 @@ services:
     access_key_id: codecov-default-key
     secret_access_key: codecov-default-secret
     verify_ssl: false
+    port: 9000
+    host: minio
   smtp:
     host: mailhog
     port: 1025

--- a/services/test_analytics/ta_processing.py
+++ b/services/test_analytics/ta_processing.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import sentry_sdk
+import test_results_parser
+from shared.config import get_config
+from shared.django_apps.core.models import Commit, Repository
+from shared.django_apps.reports.models import ReportSession, UploadError
+from shared.storage.base import BaseStorageService
+
+from services.test_analytics.ta_timeseries import get_flaky_tests_set, insert_testrun
+from services.yaml import UserYaml, read_yaml_field
+
+
+@dataclass
+class TAProcInfo:
+    repository: Repository
+    branch: str | None
+    bucket_name: str
+    user_yaml: UserYaml
+
+
+def handle_file_not_found(upload: ReportSession):
+    upload.state = "processed"
+    upload.save()
+    UploadError.objects.create(
+        report_session=upload,
+        error_code="file_not_in_storage",
+        error_params={},
+    )
+
+
+def handle_parsing_error(upload: ReportSession, exc: Exception):
+    sentry_sdk.capture_exception(exc, tags={"upload_state": upload.state})
+    upload.state = "processed"
+    upload.save()
+    UploadError.objects.create(
+        report_session=upload,
+        error_code="unsupported_file_format",
+        error_params={"error_message": str(exc)},
+    )
+
+
+def get_ta_processing_info(
+    repoid: int,
+    commitid: str,
+    commit_yaml: dict[str, Any],
+) -> TAProcInfo:
+    repository = Repository.objects.get(repoid=repoid)
+
+    commit = Commit.objects.get(repository=repository, commitid=commitid)
+    branch = commit.branch
+    if branch is None:
+        raise ValueError("Branch is None")
+
+    bucket_name = cast(
+        str, get_config("services", "minio", "bucket", default="archive")
+    )
+    user_yaml: UserYaml = UserYaml(commit_yaml)
+    return TAProcInfo(
+        repository,
+        branch,
+        bucket_name,
+        user_yaml,
+    )
+
+
+def should_delete_archive(user_yaml: UserYaml) -> bool:
+    if get_config("services", "minio", "expire_raw_after_n_days"):
+        return True
+    return not read_yaml_field(user_yaml, ("codecov", "archive", "uploads"), _else=True)
+
+
+def delete_archive(
+    storage_service: BaseStorageService, upload: ReportSession, bucket_name: str
+):
+    archive_url = upload.storage_path
+    if archive_url and not archive_url.startswith("http"):
+        storage_service.delete_file(bucket_name, archive_url)
+
+
+def insert_testruns_timeseries(
+    repoid: int,
+    commitid: str,
+    branch: str | None,
+    upload: ReportSession,
+    parsing_infos: list[test_results_parser.ParsingInfo],
+):
+    flaky_test_set = get_flaky_tests_set(repoid)
+
+    for parsing_info in parsing_infos:
+        insert_testrun(
+            timestamp=upload.created_at,
+            repo_id=repoid,
+            commit_sha=commitid,
+            branch=branch,
+            upload_id=upload.id,
+            flags=upload.flag_names,
+            parsing_info=parsing_info,
+            flaky_test_ids=flaky_test_set,
+        )

--- a/services/test_analytics/ta_processing.py
+++ b/services/test_analytics/ta_processing.py
@@ -1,15 +1,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any
 
 import sentry_sdk
 import test_results_parser
 from shared.config import get_config
 from shared.django_apps.core.models import Commit, Repository
 from shared.django_apps.reports.models import ReportSession, UploadError
-from shared.storage.base import BaseStorageService
 
+from services.archive import ArchiveService
 from services.test_analytics.ta_timeseries import get_flaky_tests_set, insert_testrun
 from services.yaml import UserYaml, read_yaml_field
 
@@ -18,7 +18,6 @@ from services.yaml import UserYaml, read_yaml_field
 class TAProcInfo:
     repository: Repository
     branch: str | None
-    bucket_name: str
     user_yaml: UserYaml
 
 
@@ -55,30 +54,32 @@ def get_ta_processing_info(
     if branch is None:
         raise ValueError("Branch is None")
 
-    bucket_name = cast(
-        str, get_config("services", "minio", "bucket", default="archive")
-    )
     user_yaml: UserYaml = UserYaml(commit_yaml)
     return TAProcInfo(
         repository,
         branch,
-        bucket_name,
         user_yaml,
     )
 
 
-def should_delete_archive(user_yaml: UserYaml) -> bool:
+def should_delete_archive_settings(user_yaml: UserYaml) -> bool:
     if get_config("services", "minio", "expire_raw_after_n_days"):
         return True
     return not read_yaml_field(user_yaml, ("codecov", "archive", "uploads"), _else=True)
 
 
-def delete_archive(
-    storage_service: BaseStorageService, upload: ReportSession, bucket_name: str
+def rewrite_or_delete_upload(
+    archive_service: ArchiveService,
+    user_yaml: UserYaml,
+    upload: ReportSession,
+    readable_file: bytes,
 ):
-    archive_url = upload.storage_path
-    if archive_url and not archive_url.startswith("http"):
-        storage_service.delete_file(bucket_name, archive_url)
+    if should_delete_archive_settings(user_yaml):
+        archive_url = upload.storage_path
+        if archive_url and not archive_url.startswith("http"):
+            archive_service.delete_file(archive_url)
+    else:
+        archive_service.write_file(upload.storage_path, bytes(readable_file))
 
 
 def insert_testruns_timeseries(

--- a/services/test_analytics/ta_processor.py
+++ b/services/test_analytics/ta_processor.py
@@ -1,0 +1,90 @@
+import logging
+from typing import Any
+
+import shared.storage
+from shared.django_apps.core.models import Commit
+from shared.django_apps.reports.models import ReportSession
+from shared.storage.exceptions import FileNotInStorageError
+from test_results_parser import parse_raw_upload
+
+from services.processing.types import UploadArguments
+from services.test_analytics.ta_processing import (
+    delete_archive,
+    get_ta_processing_info,
+    handle_file_not_found,
+    handle_parsing_error,
+    insert_testruns_timeseries,
+    should_delete_archive,
+)
+
+log = logging.getLogger(__name__)
+
+
+def ta_processor_impl(
+    repoid: int,
+    commitid: str,
+    commit_yaml: dict[str, Any],
+    argument: UploadArguments,
+    update_state: bool = False,
+) -> bool:
+    log.info(
+        "Processing single TA argument",
+        extra=dict(
+            upload_id=argument.get("upload_id"),
+            repoid=repoid,
+            commitid=commitid,
+        ),
+    )
+
+    upload_id = argument.get("upload_id")
+    if upload_id is None:
+        return False
+
+    upload = ReportSession.objects.get(id=upload_id)
+    if upload.state == "processed":
+        # don't need to process again because the intermediate result should already be in redis
+        return False
+
+    if upload.storage_path is None:
+        if update_state:
+            handle_file_not_found(upload)
+        return False
+
+    ta_proc_info = get_ta_processing_info(repoid, commitid, commit_yaml)
+
+    storage_service = shared.storage.get_appropriate_storage_service(
+        ta_proc_info.repository.repoid
+    )
+
+    try:
+        payload_bytes = storage_service.read_file(
+            ta_proc_info.bucket_name, upload.storage_path
+        )
+    except FileNotInStorageError:
+        if update_state:
+            handle_file_not_found(upload)
+        return False
+
+    try:
+        parsing_infos, readable_file = parse_raw_upload(payload_bytes)
+    except RuntimeError as exc:
+        if update_state:
+            handle_parsing_error(upload, exc)
+        return False
+
+    branch = Commit.objects.get(id=upload.report.commit_id).branch
+
+    insert_testruns_timeseries(repoid, commitid, branch, upload, parsing_infos)
+
+    if update_state:
+        upload.state = "processed"
+        upload.save()
+
+        if should_delete_archive(ta_proc_info.user_yaml):
+            delete_archive(storage_service, upload, ta_proc_info.bucket_name)
+        else:
+            storage_service.write_file(
+                ta_proc_info.bucket_name, upload.storage_path, bytes(readable_file)
+            )
+
+    return True

--- a/services/test_analytics/tests/conftest.py
+++ b/services/test_analytics/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+from shared.storage import get_appropriate_storage_service
+from shared.storage.exceptions import BucketAlreadyExistsError
+
+
+@pytest.fixture
+def storage(mock_configuration):
+    storage_service = get_appropriate_storage_service()
+    try:
+        storage_service.create_root_storage("archive")
+    except BucketAlreadyExistsError:
+        pass
+    return storage_service

--- a/services/test_analytics/tests/conftest.py
+++ b/services/test_analytics/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from shared.config import get_config
 from shared.storage import get_appropriate_storage_service
 from shared.storage.exceptions import BucketAlreadyExistsError
 
@@ -7,7 +8,7 @@ from shared.storage.exceptions import BucketAlreadyExistsError
 def storage(mock_configuration):
     storage_service = get_appropriate_storage_service()
     try:
-        storage_service.create_root_storage("archive")
+        storage_service.create_root_storage(get_config("services", "minio", "bucket"))
     except BucketAlreadyExistsError:
         pass
     return storage_service

--- a/services/test_analytics/tests/samples/sample_test.json
+++ b/services/test_analytics/tests/samples/sample_test.json
@@ -1,0 +1,11 @@
+{
+    "test_results_files": [
+        {
+            "filename": "codecov-demo/temp.junit.xml",
+            "format": "base64+compressed",
+            "data": "eJy1VMluwjAQvfMVI1dCoBbHZiklJEFVS4V66Kkqx8okBqw6i2KHwt/XWSChnCrRXDLjefNm8Uuc2T6UsOOpEnHkIooJAh75cSCijYsyve49oJnnaK60yoR5NWyIWMhdlBzyE5OWpnGqXGQY1kzILOXGoQjUl0gSHhSBItdFQ2OJPJdgMuqXjtIsTFzUJ/1Bj9IeuX+n1KZjmwwxoZSMDWwbK13W/HhZvC1fn5eLCZaxzyQq2/KZ4uBLplQJY4nAmocJNhA/k0zHKc5xn7WPqimKYxYEjc6Iad66DrHKVjplvv4f9jCTWiTy0GQnV2MPxE4E/Lxzz6muGMzFKbbJaZXiqQajIHBdIHjUvqFkCrcA31tugEUA2lJP11nkayM3eKobKIsA00D2lAz9CV9NSHujpx16B/3uievI9mceU/sChryAr6ExZKdrtwpw+VQjXeSVPVVjtubn6HoBp8iVlnDGd9VFtFpGFFYuCqsWgfVLFDg52ANiw2Mxpyk3zz94x6qU4DnWUW2VWfwkmrbyfgBbcXMH",
+            "labels": ""
+        }
+    ],
+    "metadata": {}
+}

--- a/services/test_analytics/tests/snapshots/ta_processing__insert_testruns_timeseries__0.json
+++ b/services/test_analytics/tests/snapshots/ta_processing__insert_testruns_timeseries__0.json
@@ -1,0 +1,38 @@
+[
+  {
+    "timestamp": "2025-01-01T00:00:00+00:00",
+    "test_id": "7a44f8a4b65ee2abd9617fc99a63fc2e",
+    "name": "test_1_name",
+    "classname": "test_1_classname",
+    "testsuite": "test_1_testsuite",
+    "computed_name": "test_1_computed_name",
+    "outcome": "pass",
+    "duration_seconds": 1.0,
+    "failure_message": null,
+    "framework": "Pytest",
+    "filename": "test_1_file",
+    "repo_id": 1,
+    "commit_sha": "123",
+    "branch": "main",
+    "flags": [],
+    "upload_id": 1
+  },
+  {
+    "timestamp": "2025-01-01T00:00:00+00:00",
+    "test_id": "25ce6e22db03ef4f4230eb999c776f99",
+    "name": "test_2_name",
+    "classname": "test_2_classname",
+    "testsuite": "test_2_testsuite",
+    "computed_name": "test_2",
+    "outcome": "failure",
+    "duration_seconds": 1.0,
+    "failure_message": "test_2_failure_message",
+    "framework": "Pytest",
+    "filename": "test_2_file",
+    "repo_id": 1,
+    "commit_sha": "123",
+    "branch": "main",
+    "flags": [],
+    "upload_id": 1
+  }
+]

--- a/services/test_analytics/tests/test_ta_processing.py
+++ b/services/test_analytics/tests/test_ta_processing.py
@@ -1,0 +1,207 @@
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+import test_results_parser
+from shared.config import ConfigHelper
+from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
+from shared.django_apps.reports.models import UploadError
+from shared.django_apps.reports.tests.factories import (
+    RepositoryFlagFactory,
+    UploadFactory,
+    UploadFlagMembershipFactory,
+)
+from shared.django_apps.test_analytics.models import Flake
+from shared.django_apps.timeseries.models import Testrun
+from shared.storage.exceptions import FileNotInStorageError
+from shared.yaml import UserYaml
+
+from services.test_analytics.ta_processing import (
+    TAProcInfo,
+    delete_archive,
+    get_ta_processing_info,
+    handle_file_not_found,
+    handle_parsing_error,
+    insert_testruns_timeseries,
+    should_delete_archive,
+)
+from services.test_analytics.ta_timeseries import calc_test_id
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_get_ta_processing_info():
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch="main")
+
+    result = get_ta_processing_info(repository.repoid, commit.commitid, {})
+
+    assert isinstance(result, TAProcInfo)
+    assert result.repository == repository
+    assert result.branch == "main"
+    assert isinstance(result.user_yaml, UserYaml)
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_get_ta_processing_info_no_branch():
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch=None)
+
+    commit_yaml = {"codecov": {"notify": {"after_n_builds": 1}}}
+
+    with pytest.raises(ValueError, match="Branch is None"):
+        get_ta_processing_info(repository.repoid, commit.commitid, commit_yaml)
+
+
+def test_should_delete_archive_config_enabled():
+    mock_config = ConfigHelper()
+    mock_config.set_params({"services": {"minio": {"expire_raw_after_n_days": 7}}})
+
+    with patch("services.test_analytics.ta_processing.get_config", return_value=7):
+        assert should_delete_archive(UserYaml({})) is True
+
+
+def test_should_delete_archive_yaml_disabled():
+    mock_config = ConfigHelper()
+    mock_config.set_params({"services": {"minio": {}}})
+
+    with patch("services.test_analytics.ta_processing.get_config", return_value=None):
+        user_yaml = UserYaml({"codecov": {"archive": {"uploads": False}}})
+        assert should_delete_archive(user_yaml) is True
+
+
+def test_should_delete_archive_yaml_enabled():
+    mock_config = ConfigHelper()
+    mock_config.set_params({"services": {"minio": {}}})
+
+    with patch("services.test_analytics.ta_processing.get_config", return_value=None):
+        user_yaml = UserYaml({"codecov": {"archive": {"uploads": True}}})
+        assert should_delete_archive(user_yaml) is False
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_delete_archive(storage):
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository)
+    upload = UploadFactory.create(
+        report__commit=commit, storage_path="path/to/archive.xml"
+    )
+
+    storage.write_file("archive", "path/to/archive.xml", b"test content")
+
+    delete_archive(storage, upload, "archive")
+
+    with pytest.raises(FileNotInStorageError):
+        storage.read_file("archive", "path/to/archive.xml")
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_delete_archive_http_path(storage):
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository)
+    upload = UploadFactory.create(
+        report__commit=commit, storage_path="http://example.com/archive.xml"
+    )
+
+    storage.write_file("archive", "path/to/archive.xml", b"test content")
+
+    delete_archive(storage, upload, "archive")
+
+    assert storage.read_file("archive", "path/to/archive.xml") == b"test content"
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_handle_file_not_found():
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository)
+    upload = UploadFactory.create(report__commit=commit, state="started")
+
+    handle_file_not_found(upload)
+
+    upload.refresh_from_db()
+    assert upload.state == "processed"
+
+    error = UploadError.objects.get(report_session=upload)
+    assert error.error_code == "file_not_in_storage"
+    assert error.error_params == {}
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_handle_parsing_error():
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository)
+    upload = UploadFactory.create(report__commit=commit, state="started")
+
+    test_exception = ValueError("Test error")
+    mock_capture_exception = MagicMock()
+
+    with patch("sentry_sdk.capture_exception", mock_capture_exception):
+        handle_parsing_error(upload, test_exception)
+
+    upload.refresh_from_db()
+    assert upload.state == "processed"
+
+    error = UploadError.objects.get(report_session=upload)
+    assert error.error_code == "unsupported_file_format"
+    assert error.error_params == {"error_message": "Test error"}
+
+    mock_capture_exception.assert_called_once_with(
+        test_exception, tags={"upload_state": "started"}
+    )
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_insert_testruns_timeseries():
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository)
+    flag = RepositoryFlagFactory.create(repository=repository, flag_name="unit")
+    upload = UploadFactory.create(report__commit=commit)
+    UploadFlagMembershipFactory.create(report_session=upload, flag=flag, id=upload.id)
+
+    test_id = calc_test_id("test_name", "test_classname", "test_suite")
+    flaky_test_ids = {test_id}
+
+    Flake.objects.create(
+        repoid=repository.repoid,
+        test_id=test_id,
+        end_date=None,
+        start_date=datetime.now(),
+        count=0,
+        fail_count=0,
+        recent_passes_count=0,
+        flags_id=None,
+    )
+
+    testrun: test_results_parser.Testrun = {
+        "name": "test_name",
+        "classname": "test_classname",
+        "testsuite": "test_suite",
+        "computed_name": "computed_name",
+        "duration": 1.0,
+        "outcome": "pass",
+        "failure_message": None,
+        "filename": "test_filename",
+        "build_url": None,
+    }
+
+    parsing_info: test_results_parser.ParsingInfo = {
+        "framework": "Pytest",
+        "testruns": [testrun],
+    }
+
+    parsing_infos = [parsing_info]
+
+    insert_testruns_timeseries(
+        repository.repoid, commit.commitid, commit.branch, upload, parsing_infos
+    )
+
+    testrun_db = Testrun.objects.get(
+        name="test_name",
+        classname="test_classname",
+        testsuite="test_suite",
+    )
+    assert testrun_db.branch == commit.branch
+    assert testrun_db.upload_id == upload.id
+    assert testrun_db.flags == upload.flag_names
+    assert testrun_db.duration_seconds == 1.0
+    assert testrun_db.outcome == "pass"
+    assert bytes(testrun_db.test_id) in flaky_test_ids

--- a/services/test_analytics/tests/test_ta_processor.py
+++ b/services/test_analytics/tests/test_ta_processor.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import pytest
 from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
@@ -17,13 +17,7 @@ from services.test_analytics.ta_processor import ta_processor_impl
 
 @pytest.fixture
 def sample_test_json_path():
-    return os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
-        "tasks",
-        "tests",
-        "samples",
-        "sample_test.json",
-    )
+    return Path(__file__).parent / "samples" / "sample_test.json"
 
 
 @pytest.mark.django_db(databases=["default", "timeseries"])

--- a/services/test_analytics/tests/test_ta_processor.py
+++ b/services/test_analytics/tests/test_ta_processor.py
@@ -1,0 +1,224 @@
+import os
+
+import pytest
+from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
+from shared.django_apps.reports.models import UploadError
+from shared.django_apps.reports.tests.factories import (
+    RepositoryFlagFactory,
+    UploadFactory,
+    UploadFlagMembershipFactory,
+)
+from shared.django_apps.timeseries.models import Testrun
+from shared.storage.exceptions import FileNotInStorageError
+
+from services.processing.types import UploadArguments
+from services.test_analytics.ta_processor import ta_processor_impl
+
+
+@pytest.fixture
+def sample_test_json_path():
+    return os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__)))),
+        "tasks",
+        "tests",
+        "samples",
+        "sample_test.json",
+    )
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+@pytest.mark.parametrize("update_state", [True, False])
+def test_ta_processor_impl_no_upload_id(update_state):
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch="main")
+    commit_yaml = {}
+
+    argument: UploadArguments = {}
+
+    result = ta_processor_impl(
+        repository.repoid,
+        commit.commitid,
+        commit_yaml,
+        argument,
+        update_state=update_state,
+    )
+
+    assert result is False
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+@pytest.mark.parametrize("update_state", [True, False])
+def test_ta_processor_impl_already_processed(update_state):
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch="main")
+    upload = UploadFactory.create(report__commit=commit, state="processed")
+    commit_yaml = {}
+
+    argument: UploadArguments = {"upload_id": upload.id}
+
+    result = ta_processor_impl(
+        repository.repoid,
+        commit.commitid,
+        commit_yaml,
+        argument,
+        update_state=update_state,
+    )
+
+    assert result is False
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_ta_processor_impl_no_storage_path(storage):
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch="main")
+    upload = UploadFactory.create(
+        report__commit=commit, state="processing", storage_path=None
+    )
+    commit_yaml = {}
+
+    argument: UploadArguments = {"upload_id": upload.id}
+
+    result = ta_processor_impl(
+        repository.repoid, commit.commitid, commit_yaml, argument, update_state=True
+    )
+
+    assert result is False
+
+    upload.refresh_from_db()
+    assert upload.state == "processed"
+
+    error = UploadError.objects.get(report_session=upload)
+    assert error.error_code == "file_not_in_storage"
+    assert error.error_params == {}
+
+
+@pytest.mark.parametrize("storage_path", [None, "path/to/nonexistent.xml"])
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_ta_processor_impl_file_not_found(storage, storage_path):
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch="main")
+    upload = UploadFactory.create(
+        report__commit=commit,
+        state="processing",
+        storage_path=None,
+    )
+    commit_yaml = {}
+
+    argument: UploadArguments = {"upload_id": upload.id}
+
+    result = ta_processor_impl(
+        repository.repoid, commit.commitid, commit_yaml, argument, update_state=True
+    )
+
+    assert result is False
+
+    upload.refresh_from_db()
+    assert upload.state == "processed"
+
+    error = UploadError.objects.get(report_session=upload)
+    assert error.error_code == "file_not_in_storage"
+    assert error.error_params == {}
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_ta_processor_impl_parsing_error(storage):
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch="main")
+    upload = UploadFactory.create(
+        report__commit=commit, state="processing", storage_path="path/to/invalid.xml"
+    )
+    commit_yaml = {}
+
+    argument: UploadArguments = {"upload_id": upload.id}
+
+    storage.write_file("archive", "path/to/invalid.xml", b"invalid xml content")
+
+    result = ta_processor_impl(
+        repository.repoid, commit.commitid, commit_yaml, argument, update_state=True
+    )
+
+    assert result is False
+
+    upload.refresh_from_db()
+    assert upload.state == "processed"
+
+    error = UploadError.objects.get(report_session=upload)
+    assert error.error_code == "unsupported_file_format"
+    assert error.error_params == {
+        "error_message": "Error deserializing json\n\nCaused by:\n    expected value at line 1 column 1"
+    }
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_ta_processor_impl_success_delete_archive(storage, sample_test_json_path):
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch="main")
+    upload = UploadFactory.create(
+        report__commit=commit,
+        state="processing",
+        storage_path="path/to/valid.json",
+    )
+
+    flag = RepositoryFlagFactory.create(repository=repository, flag_name="unit")
+    UploadFlagMembershipFactory.create(report_session=upload, flag=flag)
+
+    commit_yaml = {"codecov": {"archive": {"uploads": False}}}
+
+    argument: UploadArguments = {"upload_id": upload.id}
+
+    with open(sample_test_json_path, "rb") as f:
+        sample_content = f.read()
+
+    storage.write_file("archive", "path/to/valid.json", sample_content)
+
+    result = ta_processor_impl(
+        repository.repoid, commit.commitid, commit_yaml, argument, update_state=True
+    )
+
+    assert result is True
+
+    testrun_db = Testrun.objects.filter(upload_id=upload.id).first()
+    assert testrun_db is not None
+    assert testrun_db.branch == commit.branch
+    assert testrun_db.upload_id == upload.id
+    assert testrun_db.flags == [flag.flag_name]
+
+    with pytest.raises(FileNotInStorageError):
+        storage.read_file("archive", "path/to/valid.json")
+
+
+@pytest.mark.django_db(databases=["default", "timeseries"])
+def test_ta_processor_impl_success_keep_archive(storage, sample_test_json_path):
+    repository = RepositoryFactory.create()
+    commit = CommitFactory.create(repository=repository, branch="main")
+    upload = UploadFactory.create(
+        report__commit=commit,
+        state="processing",
+        storage_path="path/to/valid.json",
+    )
+
+    flag = RepositoryFlagFactory.create(repository=repository, flag_name="unit")
+    UploadFlagMembershipFactory.create(report_session=upload, flag=flag)
+
+    commit_yaml = {"codecov": {"archive": {"uploads": True}}}
+
+    argument: UploadArguments = {"upload_id": upload.id}
+
+    with open(sample_test_json_path, "rb") as f:
+        sample_content = f.read()
+
+    storage.write_file("archive", "path/to/valid.json", sample_content)
+
+    result = ta_processor_impl(
+        repository.repoid, commit.commitid, commit_yaml, argument, update_state=True
+    )
+
+    assert result is True
+
+    testrun_db = Testrun.objects.filter(upload_id=upload.id).first()
+    assert testrun_db is not None
+    assert testrun_db.branch == commit.branch
+    assert testrun_db.upload_id == upload.id
+    assert testrun_db.flags == [flag.flag_name]
+
+    assert storage.read_file("archive", "path/to/valid.json") is not None

--- a/services/test_analytics/tests/test_ta_processor.py
+++ b/services/test_analytics/tests/test_ta_processor.py
@@ -8,7 +8,7 @@ from shared.django_apps.reports.tests.factories import (
     UploadFactory,
     UploadFlagMembershipFactory,
 )
-from shared.django_apps.timeseries.models import Testrun
+from shared.django_apps.ta_timeseries.models import Testrun
 from shared.storage.exceptions import FileNotInStorageError
 
 from services.processing.types import UploadArguments
@@ -20,7 +20,7 @@ def sample_test_json_path():
     return Path(__file__).parent / "samples" / "sample_test.json"
 
 
-@pytest.mark.django_db(databases=["default", "timeseries"])
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
 @pytest.mark.parametrize("update_state", [True, False])
 def test_ta_processor_impl_no_upload_id(update_state):
     repository = RepositoryFactory.create()
@@ -40,7 +40,7 @@ def test_ta_processor_impl_no_upload_id(update_state):
     assert result is False
 
 
-@pytest.mark.django_db(databases=["default", "timeseries"])
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
 @pytest.mark.parametrize("update_state", [True, False])
 def test_ta_processor_impl_already_processed(update_state):
     repository = RepositoryFactory.create()
@@ -87,7 +87,7 @@ def test_ta_processor_impl_no_storage_path(storage):
 
 
 @pytest.mark.parametrize("storage_path", [None, "path/to/nonexistent.xml"])
-@pytest.mark.django_db(databases=["default", "timeseries"])
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
 def test_ta_processor_impl_file_not_found(storage, storage_path):
     repository = RepositoryFactory.create()
     commit = CommitFactory.create(repository=repository, branch="main")
@@ -114,7 +114,7 @@ def test_ta_processor_impl_file_not_found(storage, storage_path):
     assert error.error_params == {}
 
 
-@pytest.mark.django_db(databases=["default", "timeseries"])
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
 def test_ta_processor_impl_parsing_error(storage):
     repository = RepositoryFactory.create()
     commit = CommitFactory.create(repository=repository, branch="main")
@@ -143,7 +143,7 @@ def test_ta_processor_impl_parsing_error(storage):
     }
 
 
-@pytest.mark.django_db(databases=["default", "timeseries"])
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
 def test_ta_processor_impl_success_delete_archive(storage, sample_test_json_path):
     repository = RepositoryFactory.create()
     commit = CommitFactory.create(repository=repository, branch="main")
@@ -181,7 +181,7 @@ def test_ta_processor_impl_success_delete_archive(storage, sample_test_json_path
         storage.read_file("archive", "path/to/valid.json")
 
 
-@pytest.mark.django_db(databases=["default", "timeseries"])
+@pytest.mark.django_db(databases=["default", "ta_timeseries"])
 def test_ta_processor_impl_success_keep_archive(storage, sample_test_json_path):
     repository = RepositoryFactory.create()
     commit = CommitFactory.create(repository=repository, branch="main")


### PR DESCRIPTION
deps on: #1078

we make use of the TA timeseries functions to process testruns
persisting them to Timescale instead of postgres

in test_results_processor we toggle which implementation to use
based on should_use_timeseries
