### PR TITLE
Enable timeseries tests, differently

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ shell:
 
 test_env.up:
 	env | grep GITHUB > .testenv; true
-	TIMESERIES_ENABLED=${TIMESERIES_ENABLED} docker-compose up -d
+	docker-compose up -d
 
 test_env.prepare:
 	docker-compose exec worker make test_env.container_prepare
@@ -234,7 +234,7 @@ test_env.run_integration:
 	docker-compose exec worker make test.integration
 
 test_env:
-	TIMESERIES_ENABLED=true make test_env.up
+	make test_env.up
 	make test_env.prepare
 	make test_env.check_db
 	make test_env.run_unit

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,14 +33,14 @@ services:
           size: 2048M
 
   timescale:
-    image: timescale/timescaledb:latest-pg14
+    image: timescale/timescaledb-ha:pg14-latest
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_PASSWORD=password
     volumes:
       - type: tmpfs
-        target: /var/lib/postgresql/data
+        target: /home/postgres/pgdata/data
         tmpfs:
           size: 2048M
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,11 +38,6 @@ services:
       - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
       - POSTGRES_PASSWORD=password
-    volumes:
-      - type: tmpfs
-        target: /home/postgres/pgdata/data
-        tmpfs:
-          size: 2048M
 
   redis:
     image: redis:6-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - ./:/app/apps/worker
       - ./docker/test_codecov_config.yml:/config/codecov.yml
     environment:
-      - SETUP__TIMESERIES__ENABLED=${TIMESERIES_ENABLED-true}
       # Improves pytest-cov performance in python 3.12
       # https://github.com/nedbat/coveragepy/issues/1665#issuecomment-1937075835
       - COVERAGE_CORE=sysmon
@@ -20,8 +19,9 @@ services:
     command:
       - sleep
       - infinity
+
   postgres:
-    image: postgres:14.7-alpine
+    image: postgres:14-alpine
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
@@ -31,8 +31,9 @@ services:
         target: /var/lib/postgresql/data
         tmpfs:
           size: 2048M
+
   timescale:
-    image: timescale/timescaledb-ha:pg14-latest
+    image: timescale/timescaledb:latest-pg14
     environment:
       - POSTGRES_USER=postgres
       - POSTGRES_HOST_AUTH_METHOD=trust
@@ -42,8 +43,9 @@ services:
         target: /var/lib/postgresql/data
         tmpfs:
           size: 2048M
+
   redis:
     image: redis:6-alpine
+
   mailhog:
     image: mailhog/mailhog:latest
-

--- a/docker/test_codecov_config.yml
+++ b/docker/test_codecov_config.yml
@@ -3,6 +3,8 @@ setup:
   debug: no
   loglvl: INFO
   encryption_secret: "zp^P9*i8aR3"
+  timeseries:
+    enabled: true
 
 services:
   database_url: postgres://postgres:password@postgres:5432/postgres


### PR DESCRIPTION
Rather than messing with ENV in docker, this uses the test-global `config.yml` to enable timeseries tests, and switches to a lighter-weight timescale docker image.