### PR TITLE
fix: Pass in uv-lock for self-hosted cache image stuff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
       cache_file: "uv.lock"
 
-
   codecovstartup:
     name: Codecov Startup
     needs: build
@@ -91,3 +90,4 @@ jobs:
     with:
       push_rolling: true
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
+      cache_file: "uv.lock"

--- a/.github/workflows/self-hosted-release.yml
+++ b/.github/workflows/self-hosted-release.yml
@@ -27,3 +27,4 @@ jobs:
     with:
       push_release: true
       repo: ${{ vars.CODECOV_IMAGE_V2 || 'codecov/self-hosted-worker' }}
+      cache_file: "uv.lock"


### PR DESCRIPTION
Unblocks self-hosted release because we weren't passing in the uv.lock param to use that cached image, so it was referencing the requirements.txt image when that one is no longer being built

<!--

  Sentry/Codecov employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.