### PR TITLE
Remove usage of additional `Report.get` arguments

### DIFF
--- a/helpers/reports.py
+++ b/helpers/reports.py
@@ -1,15 +1,12 @@
-from collections import namedtuple
-
 from shared.config import get_config
 from shared.yaml import UserYaml
 
 from services.yaml.reader import read_yaml_field
 
-null = namedtuple("_", ["totals"])(None)
-
 
 def get_totals_from_file_in_reports(report, path):
-    return report.get(path, null).totals
+    file = report.get(path)
+    return file.totals if file else None
 
 
 def delete_archive_setting(commit_yaml: UserYaml | dict) -> bool:


### PR DESCRIPTION
I’m about to remove the additional arguments to `Report.get`, so lets first remove any remaining usage.