### PR TITLE
feat: implement flake processing using timeseries models

### DIFF
--- a/services/processing/flake_processing.py
+++ b/services/processing/flake_processing.py
@@ -39,7 +39,7 @@ def process_flake_in_transaction(
         report__report_type=CommitReport.ReportType.TEST_RESULTS.value,
         report__commit__repository__repoid=repo_id,
         report__commit__commitid=commit_id,
-        state__in=["processed", "v2_finished"],
+        state__in=["processed"],
     )
 
     curr_flakes = fetch_curr_flakes(repo_id)

--- a/services/test_analytics/ta_process_flakes.py
+++ b/services/test_analytics/ta_process_flakes.py
@@ -1,0 +1,121 @@
+import logging
+from datetime import datetime
+
+from django.db import transaction
+from django.db.models import Q, QuerySet
+from redis.exceptions import LockError
+from shared.django_apps.reports.models import CommitReport, ReportSession
+from shared.django_apps.ta_timeseries.models import Testrun
+from shared.django_apps.test_analytics.models import Flake
+
+from services.redis import get_redis_connection
+
+log = logging.getLogger(__name__)
+
+FAIL_FILTER = Q(outcome="failure") | Q(outcome="flaky_failure") | Q(outcome="error")
+
+LOCK_NAME = "ta_flake_lock:{}"
+KEY_NAME = "ta_flake_key:{}"
+
+
+def get_relevant_uploads(repo_id: int, commit_id: str) -> QuerySet[ReportSession]:
+    return ReportSession.objects.filter(
+        report__report_type=CommitReport.ReportType.TEST_RESULTS.value,
+        report__commit__repository__repoid=repo_id,
+        report__commit__commitid=commit_id,
+        state__in=["processed"],
+    )
+
+
+def fetch_current_flakes(repo_id: int) -> dict[bytes, Flake]:
+    return {
+        bytes(flake.test_id): flake for flake in Flake.objects.filter(repoid=repo_id)
+    }
+
+
+def get_testruns(
+    upload: ReportSession, curr_flakes: dict[bytes, Flake]
+) -> QuerySet[Testrun]:
+    upload_filter = Q(upload_id=upload.id)
+    flaky_pass_filter = Q(outcome="pass") & Q(test_id__in=curr_flakes.keys())
+    return Testrun.objects.filter(upload_filter & (FAIL_FILTER | flaky_pass_filter))
+
+
+def handle_pass(curr_flakes: dict[bytes, Flake], test_id: bytes):
+    # possible that we expire it and stop caring about it
+    if test_id not in curr_flakes:
+        return
+
+    curr_flakes[test_id].recent_passes_count += 1
+    curr_flakes[test_id].count += 1
+    if curr_flakes[test_id].recent_passes_count == 30:
+        curr_flakes[test_id].end_date = datetime.now()
+        curr_flakes[test_id].save()
+        del curr_flakes[test_id]
+
+
+def handle_failure(
+    curr_flakes: dict[bytes, Flake], test_id: bytes, testrun: Testrun, repo_id: int
+):
+    existing_flake = curr_flakes.get(test_id)
+    if existing_flake:
+        existing_flake.fail_count += 1
+        existing_flake.count += 1
+        existing_flake.recent_passes_count = 0
+    else:
+        if testrun.outcome != "flaky_failure":
+            testrun.outcome = "flaky_failure"
+        new_flake = Flake(
+            repoid=repo_id,
+            test_id=test_id,
+            count=1,
+            fail_count=1,
+            recent_passes_count=0,
+            start_date=datetime.now(),
+        )
+        curr_flakes[test_id] = new_flake
+
+
+def process_flakes_for_commit(repo_id: int, commit_id: str):
+    uploads = get_relevant_uploads(repo_id, commit_id)
+
+    curr_flakes = fetch_current_flakes(repo_id)
+
+    for upload in uploads:
+        testruns = get_testruns(upload, curr_flakes)
+
+        for testrun in testruns:
+            test_id = bytes(testrun.test_id)
+            match testrun.outcome:
+                case "pass":
+                    handle_pass(curr_flakes, test_id)
+                case "failure" | "flaky_failure" | "error":
+                    handle_failure(curr_flakes, test_id, testrun, repo_id)
+                case _:
+                    continue
+
+        Testrun.objects.bulk_update(testruns, ["outcome"])
+
+    Flake.objects.bulk_create(
+        curr_flakes.values(),
+        update_conflicts=True,
+        unique_fields=["id"],
+        update_fields=["end_date", "count", "recent_passes_count", "fail_count"],
+    )
+
+    transaction.commit()
+
+
+def process_flakes_for_repo(repo_id: int):
+    redis_client = get_redis_connection()
+    lock_name = LOCK_NAME.format(repo_id)
+    key_name = KEY_NAME.format(repo_id)
+    try:
+        with redis_client.lock(lock_name, timeout=300, blocking_timeout=3):
+            while commit_ids := redis_client.lpop(key_name, 10):
+                for commit_id in commit_ids:
+                    process_flakes_for_commit(repo_id, commit_id.decode())
+            return True
+    except LockError:
+        log.warning("Failed to acquire lock for repo %s", repo_id)
+        return False

--- a/services/test_analytics/tests/snapshots/ta_process_flakes__testrun_filters__0.json
+++ b/services/test_analytics/tests/snapshots/ta_process_flakes__testrun_filters__0.json
@@ -1,0 +1,22 @@
+{
+  "test1": {
+    "count": 6,
+    "fail_count": 2,
+    "recent_passes_count": 1
+  },
+  "test3": {
+    "count": 1,
+    "fail_count": 1,
+    "recent_passes_count": 0
+  },
+  "test4": {
+    "count": 1,
+    "fail_count": 1,
+    "recent_passes_count": 0
+  },
+  "test5": {
+    "count": 1,
+    "fail_count": 1,
+    "recent_passes_count": 0
+  }
+}

--- a/services/test_analytics/tests/test_ta_process_flakes.py
+++ b/services/test_analytics/tests/test_ta_process_flakes.py
@@ -1,0 +1,312 @@
+from typing import TypedDict
+
+import pytest
+from django.utils import timezone
+from shared.django_apps.reports.models import CommitReport, ReportSession
+from shared.django_apps.reports.tests.factories import CommitReportFactory
+from shared.django_apps.ta_timeseries.models import Testrun
+from shared.django_apps.test_analytics.models import Flake
+
+from services.redis import get_redis_connection
+from services.test_analytics.ta_process_flakes import KEY_NAME, process_flakes_for_repo
+
+
+class TestrunData(TypedDict):
+    test_id: str
+    outcome: str
+
+
+class UploadData(TypedDict):
+    state: str
+    testruns: list[TestrunData]
+
+
+class FlakeDataRequired(TypedDict):
+    test_id: str
+
+
+class FlakeDataOptional(FlakeDataRequired, total=False):
+    count: int
+    fail_count: int
+    recent_passes_count: int
+    start_date: timezone.datetime
+    end_date: timezone.datetime | None
+
+
+class SetupResult(TypedDict):
+    repoid: int
+    commitid: str
+
+
+pytestmark = pytest.mark.django_db(
+    databases=["default", "ta_timeseries"], transaction=True
+)
+
+
+@pytest.fixture
+def setup_test_data(db):
+    def _create_test_data(
+        uploads: list[UploadData],
+        existing_flakes: list[FlakeDataOptional],
+    ) -> SetupResult:
+        report = CommitReportFactory(
+            report_type=CommitReport.ReportType.TEST_RESULTS.value,
+        )
+        report.save()
+        repo_id = report.commit.repository.repoid
+        commit_id = report.commit.commitid
+
+        redis = get_redis_connection()
+        redis.lpush(KEY_NAME.format(repo_id), commit_id)
+
+        sessions = []
+        testruns = []
+        for upload in uploads:
+            session = ReportSession.objects.create(
+                report=report,
+                state=upload["state"],
+            )
+            sessions.append(session)
+
+            for testrun_data in upload.get("testruns", []):
+                testrun = Testrun.objects.create(
+                    timestamp=timezone.now(),
+                    test_id=testrun_data["test_id"].encode(),
+                    outcome=testrun_data["outcome"],
+                    repo_id=repo_id,
+                    commit_sha=commit_id,
+                    upload_id=session.id,
+                )
+                testruns.append(testrun)
+
+        created_flakes = []
+        for flake_data in existing_flakes:
+            flake = Flake.objects.create(
+                repoid=repo_id,
+                test_id=flake_data["test_id"].encode(),
+                recent_passes_count=flake_data.get("recent_passes_count", 0),
+                count=flake_data.get("count", 0),
+                fail_count=flake_data.get("fail_count", 0),
+                start_date=flake_data.get("start_date", timezone.now()),
+                end_date=flake_data.get("end_date", None),
+            )
+            created_flakes.append(flake)
+
+        return {
+            "repoid": repo_id,
+            "commitid": commit_id,
+        }
+
+    return _create_test_data
+
+
+def test_process_flakes_valid_states_only(setup_test_data):
+    result = setup_test_data(
+        uploads=[
+            {
+                "state": "processed",
+                "testruns": [{"test_id": "test1", "outcome": "failure"}],
+            },
+            {
+                "state": "finished",
+                "testruns": [{"test_id": "test3", "outcome": "failure"}],
+            },
+            {
+                "state": "started",
+                "testruns": [{"test_id": "test4", "outcome": "failure"}],
+            },
+        ],
+        existing_flakes=[],
+    )
+
+    process_flakes_for_repo(result["repoid"])
+
+    assert Flake.objects.count() == 1
+
+
+def test_testrun_filters(setup_test_data, snapshot):
+    result = setup_test_data(
+        uploads=[
+            {
+                "state": "processed",
+                "testruns": [
+                    {"test_id": "test1", "outcome": "pass"},
+                    {"test_id": "test2", "outcome": "pass"},
+                    {"test_id": "test3", "outcome": "failure"},
+                    {"test_id": "test4", "outcome": "flaky_failure"},
+                    {"test_id": "test5", "outcome": "error"},
+                    {"test_id": "test6", "outcome": "skip"},
+                ],
+            }
+        ],
+        existing_flakes=[
+            {"test_id": "test1", "count": 5, "fail_count": 2},
+        ],
+    )
+
+    process_flakes_for_repo(result["repoid"])
+
+    flakes = {
+        bytes(flake.test_id).decode(): {
+            "count": flake.count,
+            "fail_count": flake.fail_count,
+            "recent_passes_count": flake.recent_passes_count,
+        }
+        for flake in Flake.objects.all()
+    }
+
+    assert snapshot("json") == flakes
+
+
+def test_update_existing_flakes(setup_test_data):
+    result = setup_test_data(
+        uploads=[
+            {
+                "state": "processed",
+                "testruns": [
+                    {"test_id": "test1", "outcome": "pass"},
+                    {"test_id": "test1", "outcome": "failure"},
+                ],
+            }
+        ],
+        existing_flakes=[
+            {
+                "test_id": "test1",
+                "count": 5,
+                "fail_count": 2,
+                "recent_passes_count": 0,
+            },
+        ],
+    )
+
+    process_flakes_for_repo(result["repoid"])
+
+    flake = Flake.objects.get(test_id=b"test1")
+    assert flake.count == 7
+    assert flake.fail_count == 3
+    assert flake.recent_passes_count == 0
+
+
+def test_create_new_flakes(setup_test_data):
+    result = setup_test_data(
+        uploads=[
+            {
+                "state": "processed",
+                "testruns": [
+                    {"test_id": "test1", "outcome": "failure"},
+                    {"test_id": "test2", "outcome": "flaky_failure"},
+                    {"test_id": "test3", "outcome": "error"},
+                ],
+            }
+        ],
+        existing_flakes=[],
+    )
+
+    process_flakes_for_repo(result["repoid"])
+
+    assert Flake.objects.count() == 3
+    for test_id in [b"test1", b"test2", b"test3"]:
+        flake = Flake.objects.get(test_id=test_id)
+        assert flake.count == 1
+        assert flake.fail_count == 1
+        assert flake.recent_passes_count == 0
+        assert flake.start_date is not None
+        assert flake.end_date is None
+
+
+def test_flake_expiry_and_recreation(setup_test_data):
+    result = setup_test_data(
+        uploads=[
+            {
+                "state": "processed",
+                "testruns": [
+                    {"test_id": "test1", "outcome": "pass"},
+                    {"test_id": "test1", "outcome": "failure"},
+                ],
+            }
+        ],
+        existing_flakes=[
+            {
+                "test_id": "test1",
+                "count": 29,
+                "fail_count": 1,
+                "recent_passes_count": 29,
+            },
+        ],
+    )
+
+    process_flakes_for_repo(result["repoid"])
+
+    flakes = Flake.objects.filter(test_id=b"test1").order_by("start_date")
+    assert len(flakes) == 2
+
+    expired_flake = flakes[0]
+    assert expired_flake.end_date is not None
+    assert expired_flake.recent_passes_count == 30
+
+    new_flake = flakes[1]
+    assert new_flake.end_date is None
+    assert new_flake.count == 1
+    assert new_flake.fail_count == 1
+    assert new_flake.recent_passes_count == 0
+
+
+def test_flake_expiry_and_more_passes(setup_test_data):
+    result = setup_test_data(
+        uploads=[
+            {
+                "state": "processed",
+                "testruns": [
+                    {"test_id": "test1", "outcome": "pass"},
+                    {"test_id": "test1", "outcome": "pass"},
+                    {"test_id": "test1", "outcome": "pass"},
+                ],
+            }
+        ],
+        existing_flakes=[
+            {
+                "test_id": "test1",
+                "count": 29,
+                "fail_count": 1,
+                "recent_passes_count": 29,
+            },
+        ],
+    )
+
+    process_flakes_for_repo(result["repoid"])
+
+    flakes = Flake.objects.filter(test_id=b"test1").order_by("start_date")
+    assert len(flakes) == 1
+
+    expired_flake = flakes[0]
+    assert expired_flake.end_date is not None
+    assert expired_flake.recent_passes_count == 30
+
+
+def test_testrun_outcome_updates(setup_test_data):
+    result = setup_test_data(
+        uploads=[
+            {
+                "state": "processed",
+                "testruns": [
+                    {"test_id": "test1", "outcome": "failure"},
+                    {"test_id": "test2", "outcome": "error"},
+                    {"test_id": "test3", "outcome": "flaky_failure"},
+                ],
+            }
+        ],
+        existing_flakes=[],
+    )
+
+    process_flakes_for_repo(result["repoid"])
+
+    testruns = {
+        bytes(testrun.test_id).decode(): testrun.outcome
+        for testrun in Testrun.objects.all()
+    }
+
+    assert testruns == {
+        "test1": "flaky_failure",  # Updated from failure
+        "test2": "flaky_failure",  # Updated from error
+        "test3": "flaky_failure",  # Already flaky_failure, unchanged
+    }


### PR DESCRIPTION
- remove code related to old upload states
- create implementation of flake processing that consumes data from timescale
- process flakes uses impl_type

idea is that we'll start with impl_type both for a while which will persist flakes to the current db table and the new one, then at some point we will detect flaky tests in the finisher by checking the new flakes table