### PR TITLE
types: make TA notification payload generic

### DIFF
--- a/services/test_results.py
+++ b/services/test_results.py
@@ -124,10 +124,10 @@ T = TypeVar("T", str, bytes)
 
 @dataclass
 class TestResultsNotificationFailure(Generic[T]):
-    test_id: T
     failure_message: str
     display_name: str
     envs: list[str]
+    test_id: T
     duration_seconds: float
     build_url: str | None = None
 

--- a/services/test_results.py
+++ b/services/test_results.py
@@ -1,7 +1,7 @@
 import logging
 from dataclasses import dataclass
 from hashlib import sha256
-from typing import Sequence
+from typing import Generic, Sequence, TypeVar
 
 from shared.django_apps.codecov_auth.models import Plan
 from shared.plan.constants import TierName
@@ -119,12 +119,15 @@ def generate_test_id(repoid, testsuite, name, flags_hash):
     ).hexdigest()
 
 
+T = TypeVar("T", str, bytes)
+
+
 @dataclass
-class TestResultsNotificationFailure:
+class TestResultsNotificationFailure(Generic[T]):
+    test_id: T
     failure_message: str
     display_name: str
     envs: list[str]
-    test_id: str
     duration_seconds: float
     build_url: str | None = None
 
@@ -136,17 +139,17 @@ class FlakeInfo:
 
 
 @dataclass
-class TACommentInDepthInfo:
-    failures: list[TestResultsNotificationFailure]
-    flaky_tests: dict[str, FlakeInfo]
+class TACommentInDepthInfo(Generic[T]):
+    failures: list[TestResultsNotificationFailure[T]]
+    flaky_tests: dict[T, FlakeInfo]
 
 
 @dataclass
-class TestResultsNotificationPayload:
+class TestResultsNotificationPayload(Generic[T]):
     failed: int
     passed: int
     skipped: int
-    info: TACommentInDepthInfo | None = None
+    info: TACommentInDepthInfo[T] | None = None
 
 
 @dataclass
@@ -199,7 +202,7 @@ def display_duration(f: float) -> str:
 
 
 def generate_failure_info(
-    fail: TestResultsNotificationFailure,
+    fail: TestResultsNotificationFailure[T],
 ):
     if fail.failure_message is not None:
         failure_message = fail.failure_message
@@ -220,7 +223,7 @@ def generate_view_test_analytics_line(commit: Commit) -> str:
 
 
 def messagify_failure(
-    failure: TestResultsNotificationFailure,
+    failure: TestResultsNotificationFailure[T],
 ) -> str:
     test_name = wrap_in_code(failure.display_name.replace("\x1f", " "))
     formatted_duration = display_duration(failure.duration_seconds)
@@ -233,7 +236,7 @@ def messagify_failure(
 
 
 def messagify_flake(
-    flaky_failure: TestResultsNotificationFailure,
+    flaky_failure: TestResultsNotificationFailure[T],
     flake_info: FlakeInfo,
 ) -> str:
     test_name = wrap_in_code(flaky_failure.display_name.replace("\x1f", " "))
@@ -276,8 +279,8 @@ def specific_error_message(error: ErrorPayload) -> str:
 
 
 @dataclass
-class TestResultsNotifier(BaseNotifier):
-    payload: TestResultsNotificationPayload | None = None
+class TestResultsNotifier(BaseNotifier, Generic[T]):
+    payload: TestResultsNotificationPayload[T] | None = None
     error: ErrorPayload | None = None
 
     def build_message(self) -> str:


### PR DESCRIPTION
making this change because the test_ids used in timescale will be bytes instead of strs