### PR TITLE
feat: Allow PRs from sentry-autofix[bot] without seat

### DIFF
--- a/services/decoration.py
+++ b/services/decoration.py
@@ -19,8 +19,9 @@ log = logging.getLogger(__name__)
 BOT_USER_EMAILS = [
     "dependabot[bot]@users.noreply.github.com",
     "29139614+renovate[bot]@users.noreply.github.com",
+    "157164994+sentry-autofix[bot]@users.noreply.github.com",
 ]
-BOT_USER_IDS = ["29139614"]  # renovate[bot] github
+BOT_USER_IDS = ["29139614", "157164994"]  # renovate[bot] github, sentry-autofix[bot]
 USER_BASIC_LIMIT_UPLOAD = 250
 
 

--- a/services/tests/test_decoration.py
+++ b/services/tests/test_decoration.py
@@ -612,7 +612,9 @@ class TestDecorationServiceTestCase(object):
         [
             (True, "email", "dependabot[bot]@users.noreply.github.com"),
             (True, "email", "29139614+renovate[bot]@users.noreply.github.com"),
+            (True, "email", "157164994+sentry-autofix[bot]@users.noreply.github.com"),
             (True, "service_id", "29139614"),
+            (True, "service_id", "157164994"),
             (False, None, None),
         ],
     )


### PR DESCRIPTION
Allows Codecov to run on PRs from sentry-autofix[bot] without needing a seat. Was reported by a user on Discord:


