### PR TITLE
fix: replace error from parser lib with failure

### DIFF
--- a/services/test_analytics/tests/test_ta_timeseries.py
+++ b/services/test_analytics/tests/test_ta_timeseries.py
@@ -84,7 +84,9 @@ def test_pr_comment_agg():
 
     agg = get_pr_comment_agg(1, "commit_sha")
     assert agg == {
-        "pass": 1,
+        "passed": 1,
+        "failed": 0,
+        "skipped": 0,
     }
 
 


### PR DESCRIPTION
our aggregation functions in the db assume the only states for the outcomes are: "pass" | "skip" | "failure" | "flaky_fail"

ideally we should change the aggregation functions to not care about the values of the outcome column (do something like the pivot operator from BQ)