### PR TITLE
fix: ta finisher calls process flakes properly

### DIFF
--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -35,7 +35,7 @@ from services.test_results import (
 from tasks.base import BaseCodecovTask
 from tasks.cache_test_rollups import cache_test_rollups_task_name
 from tasks.notify import notify_task_name
-from tasks.process_flakes import process_flakes_task_name
+from tasks.process_flakes import NEW_KEY, process_flakes_task_name
 
 log = logging.getLogger(__name__)
 
@@ -129,7 +129,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
 
         if should_do_flaky_detection(repo, commit_yaml):
             if commit.merged is True or commit.branch == repo.branch:
-                redis_client.set(f"flake_uploads:{repoid}", 0)
+                redis_client.lpush(NEW_KEY.format(repo.repoid), commit.commitid)
                 self.app.tasks[process_flakes_task_name].apply_async(
                     kwargs=dict(
                         repo_id=repoid,


### PR DESCRIPTION
we previously were using the method of setting a key in redis to have a value to let the process flakes task know that there was more work to do, however this made it so the process flakes task would skip processing certain commits

this is a follow-up change to previous changes we made to the process flakes task: https://github.com/codecov/worker/pull/1101

this change makes it so the test results finisher is using the new method of queueing up commitids in redis before queueing up the process flakes task

there will be another change where we make it so process flakes no longer checks the old redis key and that will complete this change