### PR TITLE
Fix `report_lock` TTL

### DIFF
--- a/tasks/upload_finisher.py
+++ b/tasks/upload_finisher.py
@@ -375,9 +375,14 @@ upload_finisher_task = celery_app.tasks[RegisteredUploadTask.name]
 def get_report_lock(repoid: int, commitid: str, hard_time_limit: int) -> Lock:
     lock_name = UPLOAD_PROCESSING_LOCK_NAME(repoid, commitid)
     redis_connection = get_redis_connection()
+
+    timeout = 60 * 5
+    if hard_time_limit:
+        timeout = max(timeout, hard_time_limit)
+
     return redis_connection.lock(
         lock_name,
-        timeout=max(60 * 5, hard_time_limit),
+        timeout=timeout,
         blocking_timeout=5,
     )
 


### PR DESCRIPTION
It might be possible that `hard_time_limit` is `0`, in which case we would define a `0` TTL for the redis lock.

The problem here is that we have observed some data races related to this lock apparently not working as intended. The redis key / lock TTL-ing might be one cause of this.