### PR TITLE
Allow unrolling subqueries in cleanup task

### DIFF
--- a/tasks/tests/unit/test_delete_owner.py
+++ b/tasks/tests/unit/test_delete_owner.py
@@ -10,6 +10,20 @@ from shared.django_apps.core.tests.factories import (
     CommitFactory,
     RepositoryFactory,
 )
+from shared.django_apps.reports.models import (
+    CommitReport,
+    DailyTestRollup,
+    Test,
+    TestInstance,
+)
+from shared.django_apps.reports.models import ReportSession as Upload
+from shared.django_apps.reports.tests.factories import (
+    CommitReportFactory,
+    DailyTestRollupFactory,
+    TestFactory,
+    TestInstanceFactory,
+    UploadFactory,
+)
 
 from services.cleanup.utils import CleanupResult, CleanupSummary
 from tasks.delete_owner import DeleteOwnerTask
@@ -53,10 +67,23 @@ def test_delete_owner_deletes_owner_with_commit_compares(mock_storage):
     compare_commit = CommitFactory(repository=repo, author=user)
     CommitComparisonFactory(base_commit=base_commit, compare_commit=compare_commit)
 
+    report = CommitReportFactory(commit=base_commit)
+    upload = UploadFactory(report=report)
+    test = TestFactory(repository=repo)
+    TestInstanceFactory(test=test, upload=upload)
+    DailyTestRollupFactory(test=test, repoid=repo.repoid)
+
+    # This test factory implicitly creates:
+    # - Test with a Repository and an Owner,
+    # - An Upload with a CommitReport, a Commit that has a different Owner and
+    #   one more Repository with yet another different Owner.
+    # And then also a Branch and a Pull via DB triggers because of the Commit.
+    remaining = TestInstanceFactory()
+
     res = DeleteOwnerTask().run_impl({}, user.ownerid)
 
     assert res == CleanupSummary(
-        CleanupResult(7),
+        CleanupResult(12),
         {
             Branch: CleanupResult(1),
             Commit: CleanupResult(2),
@@ -64,15 +91,26 @@ def test_delete_owner_deletes_owner_with_commit_compares(mock_storage):
             Owner: CleanupResult(1),
             Pull: CleanupResult(1),
             Repository: CleanupResult(1),
+            CommitReport: CleanupResult(1),
+            Upload: CleanupResult(1),
+            Test: CleanupResult(1),
+            TestInstance: CleanupResult(1),
+            DailyTestRollup: CleanupResult(1),
         },
     )
 
-    assert Branch.objects.count() == 0
-    assert Commit.objects.count() == 0
+    assert list(TestInstance.objects.all()) == [remaining]
+    # See the comment above why we have all of these objects
+    assert Branch.objects.count() == 1
+    assert Commit.objects.count() == 1
     assert CommitComparison.objects.count() == 0
-    assert Owner.objects.count() == 0
-    assert Pull.objects.count() == 0
-    assert Repository.objects.count() == 0
+    assert Owner.objects.count() == 3
+    assert Pull.objects.count() == 1
+    assert Repository.objects.count() == 2
+    assert CommitReport.objects.count() == 1
+    assert Upload.objects.count() == 1
+    assert Test.objects.count() == 1
+    assert DailyTestRollup.objects.count() == 0
 
 
 @pytest.mark.django_db(databases=["timeseries", "default"], transaction=True)


### PR DESCRIPTION
For some reason, our postgres is unable to properly optimize a delete query on certain tables, which are using a subquery in the where clause.

It turns out that unrolling that subquery within Python works just fine however. So lets do just that.

As we are building all of the delete queries dynamically based on django relations (or some manually defined ones as well), we have to use some queryset magic as well to reverse those automatically created subqueries.

So another method was added which can parse the `IN (...)` subquery out of a queryset, in order to execute that separately, and issue N+1 delete queries on the target table.