### PR TITLE
make all tests assume the same default bucket name

### DIFF
--- a/django_scaffold/settings.py
+++ b/django_scaffold/settings.py
@@ -11,7 +11,7 @@ ALLOWED_HOSTS = []
 IS_DEV = os.getenv("RUN_ENV") == "DEV"
 IS_ENTERPRISE = os.getenv("RUN_ENV") == "ENTERPRISE"
 
-GCS_BUCKET_NAME = get_config("services", "minio", "bucket", default="codecov")
+GCS_BUCKET_NAME = get_config("services", "minio", "bucket", default="archive")
 
 # Application definition
 INSTALLED_APPS = [

--- a/docker/test_codecov_config.yml
+++ b/docker/test_codecov_config.yml
@@ -12,6 +12,7 @@ services:
   redis_url: redis://redis:6379
   minio:
     hash_key: testixik8qdauiab1yiffydimvi72ekq # never change this
+    bucket: archive
     access_key_id: codecov-default-key
     secret_access_key: codecov-default-secret
     verify_ssl: false

--- a/tasks/tests/unit/test_cache_test_rollups.py
+++ b/tasks/tests/unit/test_cache_test_rollups.py
@@ -17,7 +17,7 @@ from tasks.cache_test_rollups import CacheTestRollupsTask
 
 class TestCacheTestRollupsTask:
     def read_table(self, mock_storage, storage_path: str):
-        decompressed_table: bytes = mock_storage.read_file("codecov", storage_path)
+        decompressed_table: bytes = mock_storage.read_file("archive", storage_path)
         return pl.read_ipc(decompressed_table)
 
     def test_cache_test_rollups(self, mock_storage, transactional_db):

--- a/tasks/tests/unit/test_cache_test_rollups_redis.py
+++ b/tasks/tests/unit/test_cache_test_rollups_redis.py
@@ -9,7 +9,7 @@ from tasks.cache_test_rollups_redis import CacheTestRollupsRedisTask
 
 class TestCacheTestRollupsTask:
     def read_table(self, mock_storage, storage_path: str):
-        decompressed_table: bytes = mock_storage.read_file("codecov", storage_path)
+        decompressed_table: bytes = mock_storage.read_file("archive", storage_path)
         return pl.read_ipc(decompressed_table)
 
     def test_cache_test_rollups(self, mock_storage, transactional_db):
@@ -19,11 +19,11 @@ class TestCacheTestRollupsTask:
         storage_service = shared.storage.get_appropriate_storage_service(repo.repoid)
         storage_key = f"test_results/rollups/{repo.repoid}/main/1"
         try:
-            storage_service.create_root_storage("codecov")
+            storage_service.create_root_storage("archive")
         except BucketAlreadyExistsError:
             pass
 
-        storage_service.write_file("codecov", storage_key, b"hello world")
+        storage_service.write_file("archive", storage_key, b"hello world")
 
         task = CacheTestRollupsRedisTask()
         result = task.run_impl(_db_session=None, repoid=repo.repoid, branch="main")
@@ -31,4 +31,4 @@ class TestCacheTestRollupsTask:
 
         redis_key = f"ta_roll:{repo.repoid}:main:1"
 
-        assert redis.get(redis_key) == storage_service.read_file("codecov", storage_key)
+        assert redis.get(redis_key) == storage_service.read_file("archive", storage_key)


### PR DESCRIPTION
in `main.py` worker uses `archive` as the default bucket name but in `django_scaffold/settings.py` it uses `codecov` as the default bucket name. most tests assume it's `archive` but some assume it's `codecov`. if you actually set one in `codecov.yml`, some tests will fail based on which value you pick

this diff aligns everyone on the same default value and sets it in the test config.yml

this is still a bit of a mess. this is supposed to be the same bucket as in codecov-api, but the two repos disagree on its default name. and tests here are still not resilient to changing the underlying config. but this change gets everything a little more stable for `umbrella`.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.