### PR TITLE
emit junit results in a monorepo-friendly way

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,4 +83,4 @@ dev-dependencies = [
 [tool.uv.sources]
 timestring = { git = "https://github.com/codecov/timestring", rev = "d37ceacc5954dff3b5bd2f887936a98a668dda42" }
 test-results-parser = { git = "https://github.com/codecov/test-results-parser", rev = "190bbc8a911099749928e13d5fe57f6027ca1e74" }
-shared = { git = "https://github.com/codecov/shared", rev = "a93b0f1299841e56d8ceb591813974e97bec75b9" }
+shared = { git = "https://github.com/codecov/shared", rev = "af74ab881368fa0e8ea3777404443ac4c525835a" }

--- a/uv.lock
+++ b/uv.lock
@@ -1702,7 +1702,7 @@ wheels = [
 [[package]]
 name = "shared"
 version = "0.1.0"
-source = { git = "https://github.com/codecov/shared?rev=a93b0f1299841e56d8ceb591813974e97bec75b9#a93b0f1299841e56d8ceb591813974e97bec75b9" }
+source = { git = "https://github.com/codecov/shared?rev=af74ab881368fa0e8ea3777404443ac4c525835a#af74ab881368fa0e8ea3777404443ac4c525835a" }
 dependencies = [
     { name = "amplitude-analytics" },
     { name = "boto3" },
@@ -2041,7 +2041,7 @@ requires-dist = [
     { name = "regex", specifier = ">=2023.12.25" },
     { name = "requests", specifier = ">=2.32.0" },
     { name = "sentry-sdk", specifier = ">=2.13.0" },
-    { name = "shared", git = "https://github.com/codecov/shared?rev=a93b0f1299841e56d8ceb591813974e97bec75b9" },
+    { name = "shared", git = "https://github.com/codecov/shared?rev=af74ab881368fa0e8ea3777404443ac4c525835a" },
     { name = "sqlalchemy", specifier = "==1.3.*" },
     { name = "sqlparse", specifier = "==0.5.0" },
     { name = "statsd", specifier = ">=3.3.0" },


### PR DESCRIPTION
see resulting test file paths here: https://app.codecov.io/gh/codecov/worker/tests/matt%2Fmonorepo-friendly-junit

sort by "Last run" to get the results of the most recent attempt

this is a bit of a hack, but better solutions are all way, way easier after cutover and involve more invasive changes to how things work.

the worker/shared/api PRs pass `--rootdir=${PYTEST_ROOTDIR} -c pytest.ini` to pytest invocations. `--rootdir=${PYTEST_ROOTDIR}` allows us to override the rootdir, and `-c pytest.ini` makes sure pytest can still find its config when we do.

by default, the rootdir is `.`, which is the directory `pytest.ini` lives in. it's as if neither argument were passed at all. the original worker/api/shared repos use the default, so they are unchanged.

[the gha-workflows PR](https://github.com/codecov/gha-workflows/pull/47) adds an optional input to the test workflows which allow `PYTEST_ROOTDIR` to be overridden. umbrella passes in `/app`, and the result is that test file paths inside `junit.xml` will have the prefix umbrella wants (e.g. `apps/worker` for worker).

so, the original repositories generate junit files with test file paths relative to the repo root, just like always. and umbrella will generate junit files with test file paths relative to _umbrella's_ root, which is what umbrella wants.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.