### PR TITLE
Remove `get_changes_using_rust` usage

### DIFF
--- a/services/comparison/__init__.py
+++ b/services/comparison/__init__.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import sentry_sdk
 from asgiref.sync import async_to_sync
-from shared.reports.changes import get_changes_using_rust, run_comparison_using_rust
+from shared.reports.changes import run_comparison_using_rust
 from shared.reports.types import Change, ReportTotals
 from shared.torngit.base import TorngitBaseAdapter
 from shared.torngit.exceptions import TorngitClientGeneralError
@@ -169,31 +169,6 @@ class ComparisonProxy(object):
                 self.comparison.head.report,
                 diff,
             )
-            if (
-                self._changes
-                and self.comparison.project_coverage_base.report is not None
-                and self.comparison.head.report is not None
-                and self.comparison.project_coverage_base.report.rust_report is not None
-                and self.comparison.head.report.rust_report is not None
-            ):
-                rust_changes = get_changes_using_rust(
-                    self.comparison.project_coverage_base.report,
-                    self.comparison.head.report,
-                    diff,
-                )
-                original_paths = set([c.path for c in self._changes])
-                new_paths = set([c.path for c in rust_changes])
-                if original_paths != new_paths:
-                    only_on_new = sorted(new_paths - original_paths)
-                    only_on_original = sorted(original_paths - new_paths)
-                    log.info(
-                        "There are differences between python changes and rust changes",
-                        extra=dict(
-                            only_on_new=only_on_new[:100],
-                            only_on_original=only_on_original[:100],
-                            repoid=self.head.commit.repoid,
-                        ),
-                    )
 
         return self._changes
 

--- a/services/notification/tests/unit/test_comparison.py
+++ b/services/notification/tests/unit/test_comparison.py
@@ -1,5 +1,3 @@
-from shared.reports.types import Change
-
 from services.comparison import ComparisonProxy, FilteredComparison
 
 
@@ -14,18 +12,3 @@ class TestFilteredComparison(object):
         assert isinstance(filtered_comparison, FilteredComparison)
         res = filtered_comparison.get_existing_statuses()
         assert res == mocked_get_existing_statuses.return_value
-
-    def test_get_changes_rust_vs_python(self, mocker):
-        mocker.patch.object(ComparisonProxy, "get_diff")
-        mocker.patch(
-            "services.comparison.get_changes",
-            return_value=[Change(path="apple"), Change(path="pear")],
-        )
-        mocker.patch(
-            "services.comparison.get_changes_using_rust",
-            return_value=[Change(path="banana"), Change(path="pear")],
-        )
-        comparison = ComparisonProxy(mocker.MagicMock())
-        res = comparison.get_changes()
-        expected_result = [Change(path="apple"), Change(path="pear")]
-        assert expected_result == res


### PR DESCRIPTION
As the `rust_report` is hard-enabled because `get_impacted_files` depends on it, we are also unconditionally running both implementations of `get_changes`.

But those two implementations differ in some details, and we are spamming logs with a ton of differences that noone ever looks ate to eventually move the implementation one way or the other.

So lets just remove this comparison code for a tiny speedup.