### PR TITLE
Move debugging test

### DIFF
--- a/services/report/tests/unit/test_process.py
+++ b/services/report/tests/unit/test_process.py
@@ -1,5 +1,4 @@
 from json import loads
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -21,41 +20,8 @@ from services.report.parser.types import LegacyParsedRawReport, ParsedUploadedRe
 from services.report.report_builder import ReportBuilder
 from test_utils.base import BaseTestCase
 
-here = Path(__file__)
-folder = here.parent
-
-
-@pytest.mark.skip(reason="this is supposed to be invoked manually")
-def test_manual():
-    # The intention of this test is to easily reproduce production problems with real reports.
-    # So download the relevant report, fill in its filename below, comment out the `skip` annotation,
-    # and run this test directly.
-    filename = "..."
-    with open(filename, "rb") as d:
-        contents = d.read()
-
-    parsed_report = LegacyReportParser().parse_raw_report_from_bytes(contents)
-    master = process.process_raw_upload(None, parsed_report, Session())
-
-    assert not master.is_empty()
-
 
 class TestProcessRawUpload(BaseTestCase):
-    def readjson(self, filename):
-        with open(folder / filename, "r") as d:
-            contents = loads(d.read())
-            return contents
-
-    def get_v3_report(self):
-        filename = "report.v3.json"
-        with open(folder / filename, "r") as d:
-            contents = loads(d.read())
-            return Report(**contents)
-
-    @property
-    def data(self):
-        return {"yaml": {}}
-
     @pytest.mark.parametrize("keys", ["nm", "n", "m", "nme", "ne", "M"])
     def test_process_raw_upload(self, keys):
         report = []

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,0 +1,51 @@
+import orjson
+import pytest
+from shared.reports.resources import Report
+from shared.utils.sessions import Session
+
+from services.report import raw_upload_processor as process
+from services.report.parser.legacy import LegacyReportParser
+
+# The intention of these tests is to easily reproduce production problems with real reports.
+#
+# In order to run them, comment out the `skip` annotation.
+#
+# For both tests, download the raw upload, or the `report_json`/`chunks` from storage,
+# and paste in the filename before running the test directly.
+#
+# As these tests do not depend on any external service, you can run them directly with:
+# > pytest -vvs "tests/test_debug.py::test_process_upload"
+#
+# Then either hook up an interactive debugger, or do "print-debugging" to your liking.
+
+
+@pytest.mark.skip(reason="this is supposed to be invoked manually")
+def test_process_upload():
+    upload_file = "..."
+    with open(upload_file, "rb") as d:
+        contents = d.read()
+
+    parsed_upload = LegacyReportParser().parse_raw_report_from_bytes(contents)
+    report = process.process_raw_upload(None, parsed_upload, Session())
+
+    file = report.get("interesting_file")
+
+
+@pytest.mark.skip(reason="this is supposed to be invoked manually")
+def test_inspect_report():
+    report_json_file = "..."
+    chunks_file = "..."
+    with open(report_json_file, "rb") as d:
+        report_json = d.read()
+    with open(chunks_file, "rb") as d:
+        chunks = d.read()
+
+    report_json = orjson.loads(report_json)
+    report = Report.from_chunks(
+        chunks=chunks,
+        files=report_json["files"],
+        sessions=report_json["sessions"],
+        totals=report_json.get("totals"),
+    )
+
+    file = report.get("interesting_file")


### PR DESCRIPTION
This now defines two skipped-by-default tests that are supposed to be manually invoked with some downloaded production artifacts to more easily be able to reproduce customer issues.

There is a test to run the raw upload processing, as well as a test that just loads a stored report into memory so it can be inspected further.