### PR TITLE
Bundle Analysis: dedupe caching processing

### DIFF
--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -211,17 +211,11 @@ class BundleAnalysisReportService(BaseReportService):
                 repo_id=commit.repoid,
             ).values_list("bundle_name", flat=True)
 
-            # For each bundle:
-            # if caching is on then update bundle.is_cached property to true
-            # if caching is off then delete that bundle from the report
-            update_fields = {}
+            # Delete the bundle from the report if it's not to be cached
             for bundle in bundle_report.bundle_reports():
-                if bundle.name in bundles_to_be_cached:
-                    update_fields[bundle.name] = True
-                else:
+                if bundle.name not in bundles_to_be_cached:
                     bundle_report.delete_bundle_by_name(bundle.name)
-            if update_fields:
-                bundle_report.update_is_cached(update_fields)
+
             return bundle_report
         # fallback to create a fresh bundle analysis report if there is no previous report to carry over
         return BundleAnalysisReport()

--- a/services/bundle_analysis/report.py
+++ b/services/bundle_analysis/report.py
@@ -211,11 +211,17 @@ class BundleAnalysisReportService(BaseReportService):
                 repo_id=commit.repoid,
             ).values_list("bundle_name", flat=True)
 
-            # Delete the bundle from the report if it's not to be cached
+            # For each bundle:
+            # if caching is on then update bundle.is_cached property to true
+            # if caching is off then delete that bundle from the report
+            update_fields = {}
             for bundle in bundle_report.bundle_reports():
-                if bundle.name not in bundles_to_be_cached:
+                if bundle.name in bundles_to_be_cached:
+                    update_fields[bundle.name] = True
+                else:
                     bundle_report.delete_bundle_by_name(bundle.name)
-
+            if update_fields:
+                bundle_report.update_is_cached(update_fields)
             return bundle_report
         # fallback to create a fresh bundle analysis report if there is no previous report to carry over
         return BundleAnalysisReport()

--- a/tasks/bundle_analysis_processor.py
+++ b/tasks/bundle_analysis_processor.py
@@ -196,6 +196,17 @@ class BundleAnalysisProcessorTask(
 
             processing_results.append(result.as_dict())
         except (CeleryError, SoftTimeLimitExceeded, SQLAlchemyError):
+            log.exception(
+                "Unable to process bundle analysis upload",
+                extra=dict(
+                    repoid=repoid,
+                    commit=commitid,
+                    commit_yaml=commit_yaml,
+                    params=params,
+                    upload_id=upload.id_,
+                    parent_task=self.request.parent_id,
+                ),
+            )
             raise
         except Exception:
             log.exception(


### PR DESCRIPTION
Another attempt at ensuring we don't do BA processor task a bunch of times for each upload that comes in for a commit regardless of the report type. We only need to do cache the bundles one time, all subsequent calls are redundant. In the previous attempt it was directly querying the Upload model for all upload types which is slow, this rework ensures it doesn't directly query Upload and it only makes query if the repo has BA enabled.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. In 2022 this entity acquired Codecov and as result Sentry is going to need some rights from me in order to utilize my contributions in this PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.