### PR TITLE
fix(ta): pass impl_type in finisher

### DIFF
--- a/tasks/test_results_finisher.py
+++ b/tasks/test_results_finisher.py
@@ -58,9 +58,6 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         impl_type: Literal["old", "new", "both"] = "old",
         **kwargs,
     ):
-        if impl_type == "both":
-            impl_type = "old"
-
         repoid = int(repoid)
 
         self.extra_dict: dict[str, Any] = {
@@ -115,7 +112,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         commitid: str,
         commit_yaml: UserYaml,
         chain_result: bool,
-        impl_type: Literal["old", "new"],
+        impl_type: Literal["old", "both", "new"],
         **kwargs,
     ) -> FinisherResult:
         log.info("Running test results finishers", extra=self.extra_dict)
@@ -127,7 +124,9 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         assert commit, "commit not found"
         repo = commit.repository
 
-        return self.old_impl(db_session, repo, commit, chain_result, commit_yaml)
+        return self.old_impl(
+            db_session, repo, commit, chain_result, commit_yaml, impl_type
+        )
 
     def old_impl(
         self,
@@ -136,6 +135,7 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
         commit: Commit,
         chain_result: bool,
         commit_yaml: UserYaml,
+        impl_type: Literal["old", "both", "new"],
     ) -> FinisherResult:
         repoid = repo.repoid
         commitid = commit.commitid
@@ -148,12 +148,17 @@ class TestResultsFinisherTask(BaseCodecovTask, name=test_results_finisher_task_n
                     kwargs=dict(
                         repo_id=repoid,
                         commit_id=commit.commitid,
+                        impl_type=impl_type,
                     )
                 )
 
         if commit.branch is not None:
             self.app.tasks[cache_test_rollups_task_name].apply_async(
-                kwargs=dict(repoid=repoid, branch=commit.branch),
+                kwargs=dict(
+                    repoid=repoid,
+                    branch=commit.branch,
+                    impl_type=impl_type,
+                ),
             )
 
         commit_report = commit.commit_report(ReportType.TEST_RESULTS)

--- a/tasks/tests/unit/test_test_results_finisher.py
+++ b/tasks/tests/unit/test_test_results_finisher.py
@@ -366,6 +366,7 @@ class TestUploadTestFinisherTask(object):
             repoid=repoid,
             commitid=commit.commitid,
             commit_yaml={"codecov": {"max_report_age": False}},
+            impl_type="both",
         )
 
         expected_result = {
@@ -380,6 +381,7 @@ class TestUploadTestFinisherTask(object):
             kwargs={
                 "repoid": repoid,
                 "branch": "main",
+                "impl_type": "both",
             },
         )
 
@@ -512,6 +514,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
             kwargs={
                 "repoid": repoid,
                 "branch": "main",
+                "impl_type": "old",
             },
         )
 
@@ -610,6 +613,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
             kwargs={
                 "repoid": repoid,
                 "branch": "main",
+                "impl_type": "old",
             },
         )
 
@@ -680,6 +684,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
             kwargs={
                 "repoid": repoid,
                 "branch": "main",
+                "impl_type": "old",
             },
         )
 
@@ -723,6 +728,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
             kwargs={
                 "repoid": repoid,
                 "branch": "main",
+                "impl_type": "old",
             },
         )
 
@@ -845,6 +851,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
             kwargs={
                 "repoid": repoid,
                 "branch": "main",
+                "impl_type": "old",
             },
         )
 
@@ -922,6 +929,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
             kwargs={
                 "repoid": repoid,
                 "branch": "main",
+                "impl_type": "old",
             },
         )
 
@@ -1007,6 +1015,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
             kwargs={
                 "repo_id": repoid,
                 "commit_id": commit.commitid,
+                "impl_type": "old",
             },
         )
         test_results_mock_app.tasks[
@@ -1015,6 +1024,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
             kwargs={
                 "repoid": repoid,
                 "branch": "main",
+                "impl_type": "old",
             },
         )
 
@@ -1188,6 +1198,7 @@ To view more test analytics, go to the [Test Analytics Dashboard](https://app.co
                 kwargs={
                     "repo_id": repoid,
                     "commit_id": commit.commitid,
+                    "impl_type": "old",
                 },
             )
         else:


### PR DESCRIPTION
we are currently not passing the impl_type to the rollups and flakes tasks in the finisher, even though the impl_type might be both, which means the tasks aren't running the logic they should be according to the feature flag
