### PR TITLE
Batch creation of `CommitNotification`

### DIFF
--- a/services/notification/__init__.py
+++ b/services/notification/__init__.py
@@ -21,9 +21,7 @@ from database.models.core import GITHUB_APP_INSTALLATION_DEFAULT_NAME, Owner, Re
 from services.comparison import ComparisonProxy
 from services.decoration import Decoration
 from services.license import is_properly_licensed
-from services.notification.commit_notifications import (
-    create_or_update_commit_notification_from_notification_result,
-)
+from services.notification.commit_notifications import store_notification_results
 from services.notification.notifiers import (
     StatusType,
     get_all_notifier_classes_mapping,
@@ -307,6 +305,8 @@ class NotificationService(object):
             for notifier in all_other_notifiers
         )
 
+        store_notification_results(comparison, results)
+
         return [
             IndividualResult(
                 notifier=notifier.name, title=notifier.title, result=result
@@ -351,13 +351,6 @@ class NotificationService(object):
         except Exception:
             log.exception("Individual notifier failed", extra=log_extra)
             return notifier, res
-        finally:
-            if res is None or res.notification_attempted:
-                # only running if there is no result (indicating some exception)
-                # or there was an actual attempt
-                create_or_update_commit_notification_from_notification_result(
-                    comparison, notifier, res
-                )
 
 
 def split_notifiers(

--- a/services/notification/commit_notifications.py
+++ b/services/notification/commit_notifications.py
@@ -1,5 +1,6 @@
 import logging
 
+import sentry_sdk
 from sqlalchemy.orm.session import Session
 
 from database.enums import NotificationState
@@ -11,6 +12,22 @@ from services.notification.notifiers.base import (
 )
 
 log = logging.getLogger(__name__)
+
+
+@sentry_sdk.trace
+def store_notification_results(
+    comparison: ComparisonProxy,
+    results: list[tuple[AbstractBaseNotifier, NotificationResult | None]],
+):
+    # TODO: we should change this to a batch "INSERT ON CONFLICT UPDATE" eventually,
+    # as this currently results in quite some inefficient query patterns.
+    for notifier, result in results:
+        if result is None or result.notification_attempted:
+            # only running if there is no result (indicating some exception)
+            # or there was an actual attempt
+            create_or_update_commit_notification_from_notification_result(
+                comparison, notifier, result
+            )
 
 
 def create_or_update_commit_notification_from_notification_result(


### PR DESCRIPTION
Instead of doing the manual "update or create" immediately after each notification, move all of the updates to the end of the task.

Actually doing a proper "update or create" is still WIP however.