### PR TITLE
feat: add version metadata in ta_cache_rollups

### DIFF
--- a/services/test_analytics/tests/snapshots/ta_cache_rollups__cache_test_rollups__0.json
+++ b/services/test_analytics/tests/snapshots/ta_cache_rollups__cache_test_rollups__0.json
@@ -3,6 +3,10 @@
     "computed_name2",
     "computed_name"
   ],
+  "testsuite": [
+    "testsuite2",
+    "testsuite"
+  ],
   "flags": [
     [
       "test-rollups2"

--- a/services/test_analytics/tests/snapshots/ta_cache_rollups__cache_test_rollups_use_timeseries_branch__0.json
+++ b/services/test_analytics/tests/snapshots/ta_cache_rollups__cache_test_rollups_use_timeseries_branch__0.json
@@ -3,6 +3,10 @@
     "computed_name",
     "computed_name2"
   ],
+  "testsuite": [
+    "testsuite",
+    "testsuite2"
+  ],
   "flags": [
     [
       "test-rollups"

--- a/services/test_analytics/tests/snapshots/ta_cache_rollups__cache_test_rollups_use_timeseries_main__0.json
+++ b/services/test_analytics/tests/snapshots/ta_cache_rollups__cache_test_rollups_use_timeseries_main__0.json
@@ -3,6 +3,10 @@
     "computed_name2",
     "computed_name"
   ],
+  "testsuite": [
+    "testsuite2",
+    "testsuite"
+  ],
   "flags": [
     [
       "test-rollups2"


### PR DESCRIPTION
we want to be able to evolve the schema of the rollups and we can do that by including a version tag in the GCS object metadata.

However, even though in this case we're making the change in worker first, in the future, we should modify the reading code to handle the new schema before modifying the write code, since if we deploy both reader and writer at the same time, its possible a rollup written by a new version of the writer is read by an old version of the reader which doesn't understand the new format

deps on: https://github.com/codecov/shared/pull/590