### PR TITLE
fix: step 3 of changing cache task args

### DIFF
--- a/services/test_analytics/tests/test_ta_cache_rollups.py
+++ b/services/test_analytics/tests/test_ta_cache_rollups.py
@@ -78,7 +78,7 @@ def test_cache_test_rollups(storage, snapshot):
 
     CacheTestRollupsTask().run_impl(
         _db_session=None,
-        repoid=1,
+        repo_id=1,
         branch=None,
         impl_type="new",
     )
@@ -170,7 +170,7 @@ def test_cache_test_rollups_use_timeseries_main(storage, snapshot):
 
     CacheTestRollupsTask().run_impl(
         _db_session=None,
-        repoid=1,
+        repo_id=1,
         branch="main",
         impl_type="new",
     )
@@ -262,7 +262,7 @@ def test_cache_test_rollups_use_timeseries_branch(storage, snapshot):
 
     CacheTestRollupsTask().run_impl(
         _db_session=None,
-        repoid=1,
+        repo_id=1,
         branch="feature",
         impl_type="new",
     )

--- a/tasks/cache_test_rollups.py
+++ b/tasks/cache_test_rollups.py
@@ -115,16 +115,11 @@ class CacheTestRollupsTask(BaseCodecovTask, name=cache_test_rollups_task_name):
         self,
         _db_session,
         branch: str,
-        repo_id: int | None = None,
-        repoid: int | None = None,
+        repo_id: int,
         update_date: bool = True,
         impl_type: Literal["old", "new", "both"] = "old",
         **kwargs,
     ):
-        repo_id = repo_id or repoid
-        if repo_id is None:
-            raise ValueError("repo_id or repoid must be provided")
-
         redis_conn = get_redis_connection()
         try:
             with redis_conn.lock(

--- a/tasks/tests/unit/test_cache_test_rollups.py
+++ b/tasks/tests/unit/test_cache_test_rollups.py
@@ -88,7 +88,7 @@ class TestCacheTestRollupsTask:
 
             task = CacheTestRollupsTask()
             result = task.run_impl(
-                _db_session=None, repoid=self.repo.repoid, branch="main"
+                _db_session=None, repo_id=self.repo.repoid, branch="main"
             )
             assert result == {"success": True}
 
@@ -191,7 +191,7 @@ class TestCacheTestRollupsTask:
             task = CacheTestRollupsTask()
             _ = task.run_impl(
                 _db_session=None,
-                repoid=rollup_date.repository_id,
+                repo_id=rollup_date.repository_id,
                 branch=rollup_date.branch,
                 update_date=False,
             )
@@ -213,7 +213,7 @@ class TestCacheTestRollupsTask:
             task = CacheTestRollupsTask()
             _ = task.run_impl(
                 _db_session=None,
-                repoid=rollup_date.repository_id,
+                repo_id=rollup_date.repository_id,
                 branch="main",
                 update_date=True,
             )
@@ -231,7 +231,7 @@ class TestCacheTestRollupsTask:
             task = CacheTestRollupsTask()
             _ = task.run_impl(
                 _db_session=None,
-                repoid=self.repo.repoid,
+                repo_id=self.repo.repoid,
                 branch="main",
                 update_date=True,
             )
@@ -249,7 +249,7 @@ class TestCacheTestRollupsTask:
         with time_machine.travel(dt.datetime.now(dt.UTC), tick=False):
             _ = task.run_impl(
                 _db_session=None,
-                repoid=self.repo.repoid,
+                repo_id=self.repo.repoid,
                 branch="main",
                 update_date=True,
                 impl_type="both",


### PR DESCRIPTION
since all callers are using repo_id by this point we no longer have
to accept repoid as an arg
