### PR TITLE
Prefix redis cache keys with `cache:`

### DIFF
--- a/services/bundle_analysis/notify/messages/commit_status.py
+++ b/services/bundle_analysis/notify/messages/commit_status.py
@@ -72,7 +72,7 @@ class CommitStatusMessageStrategy(MessageStrategyInterface):
         )
 
     def _cache_key(self, context: CommitStatusNotificationContext) -> str:
-        return make_hash_sha256(
+        return "cache:" + make_hash_sha256(
             dict(
                 type="status_check_notification",
                 repoid=context.repository.repoid,

--- a/services/notification/notifiers/status/base.py
+++ b/services/notification/notifiers/status/base.py
@@ -271,7 +271,7 @@ class StatusNotifier(AbstractBaseNotifier):
         )
         head_commit = comparison.head.commit if comparison.head else None
 
-        cache_key = make_hash_sha256(
+        cache_key = "cache:" + make_hash_sha256(
             dict(
                 type="status_check_notification",
                 repoid=head_commit.repoid,


### PR DESCRIPTION
The Sentry redis integration can automatically tag spans for use in the Sentry "Caches insights page" based on a prefix.

Although that insights page is pretty useless IMO, we might as well use it.