### PR TITLE
fix: process flakes summary usage

### DIFF
--- a/services/processing/flake_processing.py
+++ b/services/processing/flake_processing.py
@@ -10,15 +10,12 @@ from shared.django_apps.reports.models import (
     TestInstance,
 )
 
-from services.test_analytics.ta_metrics import process_flakes_summary
-
 log = logging.getLogger(__name__)
 
 
 FLAKE_EXPIRY_COUNT = 30
 
 
-@process_flakes_summary.labels("old").time()
 def process_flake_for_repo_commit(
     repo_id: int,
     commit_id: str,

--- a/tasks/process_flakes.py
+++ b/tasks/process_flakes.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 
 from app import celery_app
 from services.processing.flake_processing import process_flake_for_repo_commit
+from services.test_analytics.ta_metrics import process_flakes_summary
 from services.test_analytics.ta_process_flakes import process_flakes_for_repo
 from tasks.base import BaseCodecovTask
 
@@ -89,7 +90,8 @@ class ProcessFlakesTask(BaseCodecovTask, name=process_flakes_task_name):
                         break
 
                     for commit_sha in commit_shas:
-                        process_func(repo_id, commit_sha.decode())
+                        with process_flakes_summary.labels("old").time():
+                            process_func(repo_id, commit_sha.decode())
 
         except LockError:
             log.warning("Unable to acquire process flakeslock for key %s.", lock_name)


### PR DESCRIPTION
metrics aren't being gathered despite following the docs, so instead of using the decorator i will try using the context manager to see if the problem is with the way im emitting metrics, since every other metric being emitted using the context manager is working fine
