### PR TITLE
Add regular `Upload` cleanup

### DIFF
--- a/services/cleanup/regular.py
+++ b/services/cleanup/regular.py
@@ -1,5 +1,9 @@
 import logging
 import random
+from datetime import datetime, timedelta, timezone
+
+from django.db.models.query import QuerySet
+from shared.django_apps.reports.models import ReportSession as Upload
 
 from services.cleanup.cleanup import run_cleanup
 from services.cleanup.utils import CleanupResult, CleanupSummary, cleanup_context
@@ -11,8 +15,7 @@ def run_regular_cleanup() -> CleanupSummary:
     log.info("Starting regular cleanup job")
     complete_summary = CleanupSummary(CleanupResult(0), summary={})
 
-    # Usage of these model was removed, and we should clean up all its data before dropping the table for good.
-    cleanups_to_run = []
+    cleanups_to_run = create_upload_cleanup_jobs()
 
     # as we expect this job to have frequent retries, and cleanup to take a long time,
     # lets shuffle the various cleanups so that each one of those makes a little progress.
@@ -27,9 +30,51 @@ def run_regular_cleanup() -> CleanupSummary:
             complete_summary.add(summary)
 
     # TODO:
-    # - cleanup old `ReportSession`s (aka `Upload`s)
     # - cleanup `Commit`s that are `deleted`
     # - figure out a way how we can first mark, and then fully delete `Branch`es
 
     log.info("Regular cleanup finished")
     return complete_summary
+
+
+UPLOAD_RETENTION_PERIOD = 150
+MONTH_SLOTS = 120
+
+
+def create_upload_cleanup_jobs() -> list[QuerySet]:
+    """
+    This returns a list of `Upload` querysets, each targetting a subset of to-delete data.
+
+    As the `Upload` table is one of our biggest tables, running an (almost)
+    unbounded `DELETE` query would certainly cause problems.
+
+    Fortunately though, the (production) table has an index on `created_at`,
+    so queries targetting a range on that field should be fairly quick, and we
+    can use that to devide up the deletion workload onto more manageable chunks.
+
+    We are targetting 30-day chunks, going back ~10 years.
+    As the main cleanup task above is using a `random.shuffle`, and the cleanup
+    task itself is being restarted/retried on timeouts, this will end up with
+    an even distribution of cleanup tasks running concurrently, deleting different
+    chunks of this table.
+    """
+    latest_timestamp = datetime.now(timezone.utc) - timedelta(
+        days=UPLOAD_RETENTION_PERIOD
+    )
+    timestamps = [latest_timestamp]
+    for _ in range(MONTH_SLOTS):
+        timestamps.append(timestamps[-1] - timedelta(days=30))
+    timestamps.reverse()
+
+    begin_timestamp = None
+    queries: list[QuerySet] = []
+    for timestamp in timestamps:
+        query = Upload.objects
+        if begin_timestamp:
+            query = query.filter(created_at__gte=begin_timestamp)
+        query = query.filter(created_at__lt=timestamp)
+        queries.append(query)
+
+        begin_timestamp = timestamp
+
+    return queries

--- a/services/cleanup/tests/snapshots/regular_cleanup__generates_sliced_upload_cleanups__upload.txt
+++ b/services/cleanup/tests/snapshots/regular_cleanup__generates_sliced_upload_cleanups__upload.txt
@@ -1,0 +1,50 @@
+-- UploadError
+DELETE
+FROM "reports_uploaderror"
+WHERE "reports_uploaderror"."upload_id" IN
+    (SELECT U0."id"
+     FROM "reports_upload" U0
+     WHERE (U0."created_at" >= %s
+            AND U0."created_at" < %s));
+-- [2024-10-25 00:00:00+00:00, 2024-11-24 00:00:00+00:00]
+
+
+-- UploadFlagMembership
+DELETE
+FROM "reports_uploadflagmembership"
+WHERE "reports_uploadflagmembership"."upload_id" IN
+    (SELECT U0."id"
+     FROM "reports_upload" U0
+     WHERE (U0."created_at" >= %s
+            AND U0."created_at" < %s));
+-- [2024-10-25 00:00:00+00:00, 2024-11-24 00:00:00+00:00]
+
+
+-- UploadLevelTotals
+DELETE
+FROM "reports_uploadleveltotals"
+WHERE "reports_uploadleveltotals"."upload_id" IN
+    (SELECT U0."id"
+     FROM "reports_upload" U0
+     WHERE (U0."created_at" >= %s
+            AND U0."created_at" < %s));
+-- [2024-10-25 00:00:00+00:00, 2024-11-24 00:00:00+00:00]
+
+
+-- TestInstance
+DELETE
+FROM "reports_testinstance"
+WHERE "reports_testinstance"."upload_id" IN
+    (SELECT U0."id"
+     FROM "reports_upload" U0
+     WHERE (U0."created_at" >= %s
+            AND U0."created_at" < %s));
+-- [2024-10-25 00:00:00+00:00, 2024-11-24 00:00:00+00:00]
+
+
+-- ReportSession
+DELETE
+FROM "reports_upload"
+WHERE ("reports_upload"."created_at" >= %s
+       AND "reports_upload"."created_at" < %s);
+-- [2024-10-25 00:00:00+00:00, 2024-11-24 00:00:00+00:00]

--- a/services/cleanup/tests/snapshots/relations__builds_delete_queries__owner.txt
+++ b/services/cleanup/tests/snapshots/relations__builds_delete_queries__owner.txt
@@ -2,15 +2,18 @@
 DELETE
 FROM "user_measurements"
 WHERE "user_measurements"."owner_id" IN (%s);
+-- [123]
 
 
 -- YamlHistory
 DELETE
 FROM "yaml_history"
 WHERE "yaml_history"."ownerid" IN (%s);
+-- [123]
 DELETE
 FROM "yaml_history"
 WHERE "yaml_history"."author" IN (%s);
+-- [123]
 
 
 -- CommitNotification
@@ -20,36 +23,42 @@ WHERE "commit_notifications"."gh_app_id" IN
     (SELECT U0."id"
      FROM "codecov_auth_githubappinstallation" U0
      WHERE U0."owner_id" IN (%s));
+-- [123]
 
 
 -- OwnerInstallationNameToUseForTask
 DELETE
 FROM "codecov_auth_ownerinstallationnametousefortask"
 WHERE "codecov_auth_ownerinstallationnametousefortask"."owner_id" IN (%s);
+-- [123]
 
 
 -- OrganizationLevelToken
 DELETE
 FROM "codecov_auth_organizationleveltoken"
 WHERE "codecov_auth_organizationleveltoken"."ownerid" IN (%s);
+-- [123]
 
 
 -- OwnerProfile
 DELETE
 FROM "codecov_auth_ownerprofile"
 WHERE "codecov_auth_ownerprofile"."owner_id" IN (%s);
+-- [123]
 
 
 -- Session
 DELETE
 FROM "sessions"
 WHERE "sessions"."ownerid" IN (%s);
+-- [123]
 
 
 -- UserToken
 DELETE
 FROM "codecov_auth_usertoken"
 WHERE "codecov_auth_usertoken"."ownerid" IN (%s);
+-- [123]
 
 
 -- TestInstance
@@ -59,6 +68,7 @@ WHERE "reports_testinstance"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- DailyTestRollup
@@ -68,6 +78,7 @@ WHERE "reports_dailytestrollups"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- CacheConfig
@@ -77,6 +88,7 @@ WHERE "bundle_analysis_cacheconfig"."repo_id" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- RepositoryToken
@@ -86,6 +98,7 @@ WHERE "codecov_auth_repositorytoken"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- Branch
@@ -95,6 +108,7 @@ WHERE "branches"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- FlagComparison
@@ -107,6 +121,7 @@ WHERE "compare_flagcomparison"."repositoryflag_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 
 
 -- ComponentComparison
@@ -122,6 +137,7 @@ WHERE "compare_componentcomparison"."commit_comparison_id" IN
               (SELECT U0."repoid"
                FROM "repos" U0
                WHERE U0."ownerid" IN (%s))));
+-- [123]
 DELETE
 FROM "compare_componentcomparison"
 WHERE "compare_componentcomparison"."commit_comparison_id" IN
@@ -134,6 +150,7 @@ WHERE "compare_componentcomparison"."commit_comparison_id" IN
               (SELECT U0."repoid"
                FROM "repos" U0
                WHERE U0."ownerid" IN (%s))));
+-- [123]
 
 
 -- CommitError
@@ -146,6 +163,7 @@ WHERE "core_commiterror"."commit_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 
 
 -- LabelAnalysisProcessingError
@@ -161,6 +179,7 @@ WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" I
               (SELECT U0."repoid"
                FROM "repos" U0
                WHERE U0."ownerid" IN (%s))));
+-- [123]
 DELETE
 FROM "labelanalysis_labelanalysisprocessingerror"
 WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" IN
@@ -173,6 +192,7 @@ WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" I
               (SELECT U0."repoid"
                FROM "repos" U0
                WHERE U0."ownerid" IN (%s))));
+-- [123]
 
 
 -- ReportResults
@@ -188,6 +208,7 @@ WHERE "reports_reportresults"."report_id" IN
               (SELECT U0."repoid"
                FROM "repos" U0
                WHERE U0."ownerid" IN (%s))));
+-- [123]
 
 
 -- ReportLevelTotals
@@ -203,6 +224,7 @@ WHERE "reports_reportleveltotals"."report_id" IN
               (SELECT U0."repoid"
                FROM "repos" U0
                WHERE U0."ownerid" IN (%s))));
+-- [123]
 
 
 -- UploadError
@@ -221,6 +243,7 @@ WHERE "reports_uploaderror"."upload_id" IN
                    (SELECT U0."repoid"
                     FROM "repos" U0
                     WHERE U0."ownerid" IN (%s)))));
+-- [123]
 
 
 -- UploadFlagMembership
@@ -233,6 +256,7 @@ WHERE "reports_uploadflagmembership"."flag_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 
 
 -- UploadLevelTotals
@@ -251,6 +275,7 @@ WHERE "reports_uploadleveltotals"."upload_id" IN
                    (SELECT U0."repoid"
                     FROM "repos" U0
                     WHERE U0."ownerid" IN (%s)))));
+-- [123]
 
 
 -- TestResultReportTotals
@@ -266,6 +291,7 @@ WHERE "reports_testresultreporttotals"."report_id" IN
               (SELECT U0."repoid"
                FROM "repos" U0
                WHERE U0."ownerid" IN (%s))));
+-- [123]
 
 
 -- StaticAnalysisSuiteFilepath
@@ -278,6 +304,7 @@ WHERE "staticanalysis_staticanalysissuitefilepath"."file_snapshot_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 
 
 -- Pull
@@ -287,6 +314,7 @@ WHERE "pulls"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- TestFlagBridge
@@ -299,6 +327,7 @@ WHERE "reports_test_results_flag_bridge"."test_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 
 
 -- Flake
@@ -308,6 +337,7 @@ WHERE "reports_flake"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- LastCacheRollupDate
@@ -317,12 +347,14 @@ WHERE "reports_lastrollupdate"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- GithubAppInstallation
 DELETE
 FROM "codecov_auth_githubappinstallation"
 WHERE "codecov_auth_githubappinstallation"."owner_id" IN (%s);
+-- [123]
 
 
 -- CommitComparison
@@ -335,6 +367,7 @@ WHERE "compare_commitcomparison"."base_commit_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 DELETE
 FROM "compare_commitcomparison"
 WHERE "compare_commitcomparison"."compare_commit_id" IN
@@ -344,6 +377,7 @@ WHERE "compare_commitcomparison"."compare_commit_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 
 
 -- LabelAnalysisRequest
@@ -356,6 +390,7 @@ WHERE "labelanalysis_labelanalysisrequest"."base_commit_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 DELETE
 FROM "labelanalysis_labelanalysisrequest"
 WHERE "labelanalysis_labelanalysisrequest"."head_commit_id" IN
@@ -365,6 +400,7 @@ WHERE "labelanalysis_labelanalysisrequest"."head_commit_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 
 
 -- ReportSession
@@ -380,6 +416,7 @@ WHERE "reports_upload"."report_id" IN
               (SELECT U0."repoid"
                FROM "repos" U0
                WHERE U0."ownerid" IN (%s))));
+-- [123]
 
 
 -- StaticAnalysisSuite
@@ -392,6 +429,7 @@ WHERE "staticanalysis_staticanalysissuite"."commit_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 
 
 -- StaticAnalysisSingleFileSnapshot
@@ -401,6 +439,7 @@ WHERE "staticanalysis_staticanalysissinglefilesnapshot"."repository_id" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- RepositoryFlag
@@ -410,6 +449,7 @@ WHERE "reports_repositoryflag"."repository_id" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- Test
@@ -419,6 +459,7 @@ WHERE "reports_test"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- ReducedError
@@ -428,6 +469,7 @@ WHERE "reports_reducederror"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- CommitReport
@@ -440,6 +482,7 @@ WHERE "reports_commitreport"."commit_id" IN
          (SELECT U0."repoid"
           FROM "repos" U0
           WHERE U0."ownerid" IN (%s)));
+-- [123]
 
 
 -- Commit
@@ -449,15 +492,18 @@ WHERE "commits"."repoid" IN
     (SELECT U0."repoid"
      FROM "repos" U0
      WHERE U0."ownerid" IN (%s));
+-- [123]
 
 
 -- Repository
 DELETE
 FROM "repos"
 WHERE "repos"."ownerid" IN (%s);
+-- [123]
 
 
 -- Owner
 DELETE
 FROM "owners"
 WHERE "owners"."ownerid" = %s;
+-- [123]

--- a/services/cleanup/tests/snapshots/relations__builds_delete_queries__repository.txt
+++ b/services/cleanup/tests/snapshots/relations__builds_delete_queries__repository.txt
@@ -2,36 +2,42 @@
 DELETE
 FROM "reports_testinstance"
 WHERE "reports_testinstance"."repoid" IN (%s);
+-- [123]
 
 
 -- DailyTestRollup
 DELETE
 FROM "reports_dailytestrollups"
 WHERE "reports_dailytestrollups"."repoid" IN (%s);
+-- [123]
 
 
 -- UserMeasurement
 DELETE
 FROM "user_measurements"
 WHERE "user_measurements"."repo_id" IN (%s);
+-- [123]
 
 
 -- CacheConfig
 DELETE
 FROM "bundle_analysis_cacheconfig"
 WHERE "bundle_analysis_cacheconfig"."repo_id" IN (%s);
+-- [123]
 
 
 -- RepositoryToken
 DELETE
 FROM "codecov_auth_repositorytoken"
 WHERE "codecov_auth_repositorytoken"."repoid" IN (%s);
+-- [123]
 
 
 -- Branch
 DELETE
 FROM "branches"
 WHERE "branches"."repoid" IN (%s);
+-- [123]
 
 
 -- FlagComparison
@@ -41,6 +47,7 @@ WHERE "compare_flagcomparison"."repositoryflag_id" IN
     (SELECT U0."id"
      FROM "reports_repositoryflag" U0
      WHERE U0."repository_id" IN (%s));
+-- [123]
 
 
 -- ComponentComparison
@@ -53,6 +60,7 @@ WHERE "compare_componentcomparison"."commit_comparison_id" IN
          (SELECT U0."id"
           FROM "commits" U0
           WHERE U0."repoid" IN (%s)));
+-- [123]
 DELETE
 FROM "compare_componentcomparison"
 WHERE "compare_componentcomparison"."commit_comparison_id" IN
@@ -62,6 +70,7 @@ WHERE "compare_componentcomparison"."commit_comparison_id" IN
          (SELECT U0."id"
           FROM "commits" U0
           WHERE U0."repoid" IN (%s)));
+-- [123]
 
 
 -- CommitNotification
@@ -71,6 +80,7 @@ WHERE "commit_notifications"."commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
      WHERE U0."repoid" IN (%s));
+-- [123]
 
 
 -- CommitError
@@ -80,6 +90,7 @@ WHERE "core_commiterror"."commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
      WHERE U0."repoid" IN (%s));
+-- [123]
 
 
 -- LabelAnalysisProcessingError
@@ -92,6 +103,7 @@ WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" I
          (SELECT U0."id"
           FROM "commits" U0
           WHERE U0."repoid" IN (%s)));
+-- [123]
 DELETE
 FROM "labelanalysis_labelanalysisprocessingerror"
 WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" IN
@@ -101,6 +113,7 @@ WHERE "labelanalysis_labelanalysisprocessingerror"."label_analysis_request_id" I
          (SELECT U0."id"
           FROM "commits" U0
           WHERE U0."repoid" IN (%s)));
+-- [123]
 
 
 -- ReportResults
@@ -113,6 +126,7 @@ WHERE "reports_reportresults"."report_id" IN
          (SELECT U0."id"
           FROM "commits" U0
           WHERE U0."repoid" IN (%s)));
+-- [123]
 
 
 -- ReportLevelTotals
@@ -125,6 +139,7 @@ WHERE "reports_reportleveltotals"."report_id" IN
          (SELECT U0."id"
           FROM "commits" U0
           WHERE U0."repoid" IN (%s)));
+-- [123]
 
 
 -- UploadError
@@ -140,6 +155,7 @@ WHERE "reports_uploaderror"."upload_id" IN
               (SELECT U0."id"
                FROM "commits" U0
                WHERE U0."repoid" IN (%s))));
+-- [123]
 
 
 -- UploadFlagMembership
@@ -149,6 +165,7 @@ WHERE "reports_uploadflagmembership"."flag_id" IN
     (SELECT U0."id"
      FROM "reports_repositoryflag" U0
      WHERE U0."repository_id" IN (%s));
+-- [123]
 
 
 -- UploadLevelTotals
@@ -164,6 +181,7 @@ WHERE "reports_uploadleveltotals"."upload_id" IN
               (SELECT U0."id"
                FROM "commits" U0
                WHERE U0."repoid" IN (%s))));
+-- [123]
 
 
 -- TestResultReportTotals
@@ -176,6 +194,7 @@ WHERE "reports_testresultreporttotals"."report_id" IN
          (SELECT U0."id"
           FROM "commits" U0
           WHERE U0."repoid" IN (%s)));
+-- [123]
 
 
 -- StaticAnalysisSuiteFilepath
@@ -185,12 +204,14 @@ WHERE "staticanalysis_staticanalysissuitefilepath"."file_snapshot_id" IN
     (SELECT U0."id"
      FROM "staticanalysis_staticanalysissinglefilesnapshot" U0
      WHERE U0."repository_id" IN (%s));
+-- [123]
 
 
 -- Pull
 DELETE
 FROM "pulls"
 WHERE "pulls"."repoid" IN (%s);
+-- [123]
 
 
 -- TestFlagBridge
@@ -200,18 +221,21 @@ WHERE "reports_test_results_flag_bridge"."test_id" IN
     (SELECT U0."id"
      FROM "reports_test" U0
      WHERE U0."repoid" IN (%s));
+-- [123]
 
 
 -- Flake
 DELETE
 FROM "reports_flake"
 WHERE "reports_flake"."repoid" IN (%s);
+-- [123]
 
 
 -- LastCacheRollupDate
 DELETE
 FROM "reports_lastrollupdate"
 WHERE "reports_lastrollupdate"."repoid" IN (%s);
+-- [123]
 
 
 -- CommitComparison
@@ -221,12 +245,14 @@ WHERE "compare_commitcomparison"."base_commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
      WHERE U0."repoid" IN (%s));
+-- [123]
 DELETE
 FROM "compare_commitcomparison"
 WHERE "compare_commitcomparison"."compare_commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
      WHERE U0."repoid" IN (%s));
+-- [123]
 
 
 -- LabelAnalysisRequest
@@ -236,12 +262,14 @@ WHERE "labelanalysis_labelanalysisrequest"."base_commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
      WHERE U0."repoid" IN (%s));
+-- [123]
 DELETE
 FROM "labelanalysis_labelanalysisrequest"
 WHERE "labelanalysis_labelanalysisrequest"."head_commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
      WHERE U0."repoid" IN (%s));
+-- [123]
 
 
 -- ReportSession
@@ -254,6 +282,7 @@ WHERE "reports_upload"."report_id" IN
          (SELECT U0."id"
           FROM "commits" U0
           WHERE U0."repoid" IN (%s)));
+-- [123]
 
 
 -- StaticAnalysisSuite
@@ -263,30 +292,35 @@ WHERE "staticanalysis_staticanalysissuite"."commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
      WHERE U0."repoid" IN (%s));
+-- [123]
 
 
 -- StaticAnalysisSingleFileSnapshot
 DELETE
 FROM "staticanalysis_staticanalysissinglefilesnapshot"
 WHERE "staticanalysis_staticanalysissinglefilesnapshot"."repository_id" IN (%s);
+-- [123]
 
 
 -- RepositoryFlag
 DELETE
 FROM "reports_repositoryflag"
 WHERE "reports_repositoryflag"."repository_id" IN (%s);
+-- [123]
 
 
 -- Test
 DELETE
 FROM "reports_test"
 WHERE "reports_test"."repoid" IN (%s);
+-- [123]
 
 
 -- ReducedError
 DELETE
 FROM "reports_reducederror"
 WHERE "reports_reducederror"."repoid" IN (%s);
+-- [123]
 
 
 -- CommitReport
@@ -296,15 +330,18 @@ WHERE "reports_commitreport"."commit_id" IN
     (SELECT U0."id"
      FROM "commits" U0
      WHERE U0."repoid" IN (%s));
+-- [123]
 
 
 -- Commit
 DELETE
 FROM "commits"
 WHERE "commits"."repoid" IN (%s);
+-- [123]
 
 
 -- Repository
 DELETE
 FROM "repos"
 WHERE "repos"."repoid" = %s;
+-- [123]

--- a/services/cleanup/tests/test_regular_cleanup.py
+++ b/services/cleanup/tests/test_regular_cleanup.py
@@ -1,11 +1,78 @@
-import pytest
+from datetime import datetime, timezone
 
-from services.cleanup.regular import run_regular_cleanup
+import pytest
+from freezegun import freeze_time
+from shared.bundle_analysis import StoragePaths
+from shared.django_apps.core.tests.factories import CommitFactory, RepositoryFactory
+from shared.django_apps.reports.models import ReportSession as Upload
+from shared.django_apps.reports.tests.factories import (
+    CommitReportFactory,
+    UploadFactory,
+)
+
+from services.archive import ArchiveService
+from services.cleanup.regular import create_upload_cleanup_jobs, run_regular_cleanup
+from services.cleanup.tests.test_relations import dump_delete_queries
 from services.cleanup.utils import CleanupResult, CleanupSummary
 
 
 @pytest.mark.django_db
-def test_runs_regular_cleanup():
+@freeze_time("2025-04-23T00:00:00Z")
+def test_runs_regular_cleanup(mock_storage):
+    repo = RepositoryFactory()
+    archive_service = ArchiveService(repo)
+
+    for i, timestamp in enumerate(
+        [
+            datetime(2024, 8, 1, tzinfo=timezone.utc),
+            datetime(2025, 1, 1, tzinfo=timezone.utc),
+        ]
+    ):
+        commit = CommitFactory(repository=repo)
+
+        commit_report = CommitReportFactory(commit=commit)
+        with freeze_time(timestamp):
+            upload = UploadFactory(report=commit_report, storage_path=f"upload{i}")
+
+        archive_service.write_chunks(commit.commitid, f"chunks_data{i}")
+        archive_service.write_file(upload.storage_path, f"upload_data{i}")
+
+        ba_report = CommitReportFactory(commit=commit, report_type="bundle_analysis")
+        with freeze_time(timestamp):
+            ba_upload = UploadFactory(report=ba_report, storage_path=f"ba_upload{i}")
+
+        ba_report_path = StoragePaths.bundle_report.path(
+            repo_key=archive_service.storage_hash, report_key=ba_report.external_id
+        )
+        archive_service.storage.write_file(
+            "bundle-analysis", ba_report_path, f"ba_report_data{i}"
+        )
+        archive_service.storage.write_file(
+            "bundle-analysis", ba_upload.storage_path, f"ba_upload_data{i}"
+        )
+
+    archive = mock_storage.storage["archive"]
+    ba_archive = mock_storage.storage["bundle-analysis"]
+    assert len(archive) == 4
+    assert len(ba_archive) == 4
+
     summary = run_regular_cleanup()
 
-    assert summary == CleanupSummary(CleanupResult(0, 0), {})
+    assert summary == CleanupSummary(
+        CleanupResult(2, 2),
+        {
+            Upload: CleanupResult(2, 2),
+        },
+    )
+    assert len(archive) == 3
+    assert len(ba_archive) == 3
+
+
+@pytest.mark.django_db
+@freeze_time("2025-04-23T00:00:00Z")
+def test_generates_sliced_upload_cleanups(snapshot):
+    # we expect the last slice to delete uploads older than `2024-11-24`,
+    # or 120 days older than the frozen timestamp given above.
+    latest = create_upload_cleanup_jobs()[-1]
+
+    assert dump_delete_queries(latest) == snapshot("upload.txt")

--- a/services/cleanup/tests/test_relations.py
+++ b/services/cleanup/tests/test_relations.py
@@ -26,9 +26,16 @@ def dump_delete_queries(queryset: QuerySet) -> str:
 
         for query in relation.querysets:
             compiler = query.query.chain(DeleteQuery).get_compiler(query.db)
-            sql, _params = compiler.as_sql()
+            sql, params = compiler.as_sql()
             sql = sqlparse.format(sql, reindent=True, keyword_case="upper")
             queries += sql + ";\n"
+            if params:
+                queries += "-- ["
+                for i, param in enumerate(params):
+                    if i:
+                        queries += ", "
+                    queries += str(param)
+                queries += "]\n"
 
     return queries
 


### PR DESCRIPTION
This adds logic clean up `Upload`s older than 120 days currently.

The logic to do this is carefully crafted to spread out the deletion into smaller chunks, as the production `Upload` table is one of the largest we have, and bulk-deletion of all uploads will probably cause other DB issues.