### PR TITLE
fix: handle TA db replication lag

### DIFF
--- a/services/test_analytics/ta_processing.py
+++ b/services/test_analytics/ta_processing.py
@@ -47,9 +47,11 @@ def get_ta_processing_info(
     commitid: str,
     commit_yaml: dict[str, Any],
 ) -> TAProcInfo:
-    repository = Repository.objects.get(repoid=repoid)
+    repository = Repository.objects.using("default").get(repoid=repoid)
 
-    commit = Commit.objects.get(repository=repository, commitid=commitid)
+    commit = Commit.objects.using("default").get(
+        repository=repository, commitid=commitid
+    )
     branch = commit.branch
     if branch is None:
         raise ValueError("Branch is None")

--- a/services/test_analytics/ta_processor.py
+++ b/services/test_analytics/ta_processor.py
@@ -39,7 +39,7 @@ def ta_processor_impl(
     if upload_id is None:
         return False
 
-    upload = ReportSession.objects.get(id=upload_id)
+    upload = ReportSession.objects.using("default").get(id=upload_id)
     if upload.state == "processed":
         # don't need to process again because the intermediate result should already be in redis
         return False


### PR DESCRIPTION
since we've observed a bit of replication lag between the primary and the TA read replica i just want to ensure we make these important reads from the primary to avoid any read-after-write inconsistencies