### PR TITLE
fix: manual toggle for cross pollination message

### DIFF
--- a/rollouts/__init__.py
+++ b/rollouts/__init__.py
@@ -12,3 +12,5 @@ NEW_TA_TASKS = Feature("new_ta_tasks")
 PARALLEL_COMPONENT_COMPARISON = Feature("parallel_component_comparison")
 
 TA_TIMESERIES = Feature("ta_timeseries")
+
+DISABLE_CROSS_POLLINATION_MESSAGE = Feature("disable_cross_pollination_message")

--- a/services/notification/notifiers/mixins/message/__init__.py
+++ b/services/notification/notifiers/mixins/message/__init__.py
@@ -8,6 +8,7 @@ from shared.reports.resources import ReportTotals
 
 from database.models.core import Owner
 from helpers.environment import is_enterprise
+from rollouts import DISABLE_CROSS_POLLINATION_MESSAGE
 from services.comparison import ComparisonProxy, FilteredComparison
 from services.notification.notifiers.mixins.message.helpers import (
     should_message_be_compact,
@@ -217,7 +218,9 @@ class MessageMixin(object):
         ).intersection(self.repository.languages or {}):
             extra_message.append(ba_message)
 
-        if extra_message:
+        if extra_message and not DISABLE_CROSS_POLLINATION_MESSAGE.check_value(
+            self.repository.ownerid
+        ):
             for i in [
                 "<details><summary> :rocket: New features to boost your workflow: </summary>",
                 "",


### PR DESCRIPTION
temporarily adding a feature flag so support can manually disable this for customers until we make it configurable